### PR TITLE
Handle address validation better.

### DIFF
--- a/address.go
+++ b/address.go
@@ -3,17 +3,9 @@ package smtpd
 import (
 	"fmt"
 	"net/mail"
-	"strings"
 )
 
 func parseAddress(src string) (string, error) {
-
-	// Mailbox specifications as per RFC5321 must have a local part and a
-	// domain part separated by '@'
-	if strings.Count(src, "@") != 1 {
-		return "", fmt.Errorf("malformed e-mail address: %s", src)
-	}
-
 	// While a RFC5321 mailbox specification is not the same as an RFC5322
 	// email address specification, it is better to accept that format and
 	// parse it down to the actual address, as there are a lot of badly

--- a/address.go
+++ b/address.go
@@ -2,18 +2,29 @@ package smtpd
 
 import (
 	"fmt"
+	"net/mail"
 	"strings"
 )
 
 func parseAddress(src string) (string, error) {
 
-	if len(src) == 0 || src[0] != '<' || src[len(src)-1] != '>' {
-		return "", fmt.Errorf("Ill-formatted e-mail address: %s", src)
+	// Mailbox specifications as per RFC5321 must have a local part and a
+	// domain part separated by '@'
+	if strings.Count(src, "@") != 1 {
+		return "", fmt.Errorf("malformed e-mail address: %s", src)
 	}
 
-	if strings.Count(src, "@") > 1 {
-		return "", fmt.Errorf("Ill-formatted e-mail address: %s", src)
+	// While a RFC5321 mailbox specification is not the same as an RFC5322
+	// email address specification, it is better to accept that format and
+	// parse it down to the actual address, as there are a lot of badly
+	// behaving MTAs and MUAs that do it wrongly. It therefore makes sense
+	// to rely on Go's built-in address parser. This does have the benefit
+	// of allowing "email@example.com" as input as thats commonly used,
+	// though not RFC compliant.
+	addr, err := mail.ParseAddress(src)
+	if err != nil {
+		return "", fmt.Errorf("malformed e-mail address: %s", src)
 	}
 
-	return src[1 : len(src)-1], nil
+	return addr.Address, nil
 }

--- a/protocol.go
+++ b/protocol.go
@@ -212,11 +212,17 @@ func (session *session) handleMAIL(cmd command) {
 		return
 	}
 
-	addr, err := parseAddress(cmd.params[1])
+	var err error
+	addr := "" // null sender
 
-	if err != nil {
-		session.reply(502, "Ill-formatted e-mail address")
-		return
+	// We must accept a null sender as per rfc5321 section-6.1.
+	if cmd.params[1] != "<>" {
+		addr, err = parseAddress(cmd.params[1])
+
+		if err != nil {
+			session.reply(502, "Malformed e-mail address")
+			return
+		}
 	}
 
 	if session.server.SenderChecker != nil {
@@ -256,7 +262,7 @@ func (session *session) handleRCPT(cmd command) {
 	addr, err := parseAddress(cmd.params[1])
 
 	if err != nil {
-		session.reply(502, "Ill-formatted e-mail address")
+		session.reply(502, "Malformed e-mail address")
 		return
 	}
 


### PR DESCRIPTION
Go has a built-in address validator for RFC5322 email addresses, which works fine for RFC5321 as it's a little bit more permissive than 5321.

Note that while the RFC requires "<local-part@domain>" the angle brackets are often not supplied by some SMTP clients (breaking the RFC) so it's actually ok to be a little permissive there, and the Go std library func does allow that.

Additionally, we are required to accept a sender of "<>" [as per the RFC](https://tools.ietf.org/html/rfc5321#section-6.1).

Lastly, I changed the language for the error message "Ill-formatted" to "malformed" as the latter is more natural English and is generally the word used by other MTAs.