### PR TITLE
Verify that user is properly authenticated before sending mail if AUTH is required

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -202,6 +202,11 @@ func (session *session) handleMAIL(cmd command) {
 		return
 	}
 
+	if session.server.Authenticator != nil && session.peer.Username == "" {
+		session.reply(530, "Authentication Required.")
+		return
+	}
+
 	if !session.tls && session.server.ForceTLS {
 		session.reply(502, "Please turn on TLS by issuing a STARTTLS command.")
 		return

--- a/smtpd_test.go
+++ b/smtpd_test.go
@@ -1188,12 +1188,8 @@ func TestErrors(t *testing.T) {
 		t.Fatalf("AUTH didn't fail: %v", err)
 	}
 
-	if err := c.Mail("sender@example.org"); err != nil {
-		t.Fatalf("MAIL failed: %v", err)
-	}
-
 	if err := c.Mail("sender@example.org"); err == nil {
-		t.Fatal("Duplicate MAIL didn't fail")
+		t.Fatalf("MAIL didn't fail")
 	}
 
 	if err := cmd(c.Text, 502, "STARTTLS"); err != nil {
@@ -1226,6 +1222,14 @@ func TestErrors(t *testing.T) {
 
 	if err := cmd(c.Text, 235, "Zm9vAGJhcgBxdXV4"); err != nil {
 		t.Fatalf("AUTH didn't work: %v", err)
+	}
+
+	if err := c.Mail("sender@example.org"); err != nil {
+		t.Fatalf("MAIL failed: %v", err)
+	}
+
+	if err := c.Mail("sender@example.org"); err == nil {
+		t.Fatalf("Duplicate MAIL didn't fail")
 	}
 
 	if err := c.Quit(); err != nil {

--- a/smtpd_test.go
+++ b/smtpd_test.go
@@ -318,6 +318,33 @@ func TestAuthNotSupported(t *testing.T) {
 
 }
 
+func TestAuthBypass(t *testing.T) {
+
+	addr, closer := runsslserver(t, &smtpd.Server{
+		Authenticator:	func(peer smtpd.Peer, username, password string) error {
+			return smtpd.Error{Code: 550, Message: "Denied"}
+		},
+		ForceTLS:	true,
+		ProtocolLogger:	log.New(os.Stdout, "log: ", log.Lshortfile),
+	})
+
+	defer closer()
+
+	c, err := smtp.Dial(addr)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+
+	if err := c.StartTLS(&tls.Config{InsecureSkipVerify: true}); err != nil {
+		t.Fatalf("STARTTLS failed: %v", err)
+	}
+
+	if err := c.Mail("sender@example.org"); err == nil {
+		t.Fatal("Unexpected MAIL success")
+	}
+
+}
+
 func TestConnectionCheck(t *testing.T) {
 
 	addr, closer := runserver(t, &smtpd.Server{


### PR DESCRIPTION
Right now if an Authenticator is setup is does check if auth was okay but does not ensure that an authentication attempt was made at all. So AUTH can be bypassed unless someone provides his own Handler implementation for mails and checks that a user is properly authenticated.

The attached patch closes this AUTH bypass and ensures that if an Authenticator was setup that only authenticated peers can send mails.