### PR TITLE
Finer grained authentication control.

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -202,7 +202,7 @@ func (session *session) handleMAIL(cmd command) {
 		return
 	}
 
-	if session.server.Authenticator != nil && session.peer.Username == "" {
+	if session.server.Authenticator != nil && !session.server.AuthOptional && session.peer.Username == "" {
 		session.reply(530, "Authentication Required.")
 		return
 	}

--- a/smtpd.go
+++ b/smtpd.go
@@ -44,6 +44,9 @@ type Server struct {
 	// Enable PLAIN/LOGIN authentication, only available after STARTTLS.
 	// Can be left empty for no authentication support.
 	Authenticator func(peer Peer, username, password string) error
+	// When true, MAIL/RCPT are allowed without AUTH even if Authenticator is set.
+	// Default false keeps authentication required when Authenticator is configured.
+	AuthOptional bool
 
 	EnableXCLIENT       bool // Enable XCLIENT support (default: false)
 	EnableProxyProtocol bool // Enable proxy protocol support (default: false)
@@ -55,10 +58,10 @@ type Server struct {
 
 	// mu guards doneChan and makes closing it and listener atomic from
 	// perspective of Serve()
-	mu sync.Mutex
-	doneChan chan struct{}
-	listener *net.Listener
-	waitgrp sync.WaitGroup
+	mu         sync.Mutex
+	doneChan   chan struct{}
+	listener   *net.Listener
+	waitgrp    sync.WaitGroup
 	inShutdown atomicBool // true when server is in shutdown
 }
 
@@ -228,7 +231,7 @@ func (srv *Server) Shutdown(wait bool) error {
 	// First close the listener
 	srv.mu.Lock()
 	if srv.listener != nil {
-		lnerr = (*srv.listener).Close();
+		lnerr = (*srv.listener).Close()
 	}
 	srv.closeDoneChanLocked()
 	srv.mu.Unlock()
@@ -254,7 +257,7 @@ func (srv *Server) Wait() error {
 
 // Address returns the listening address of the server
 func (srv *Server) Address() net.Addr {
-	return (*srv.listener).Addr();
+	return (*srv.listener).Addr()
 }
 
 func (srv *Server) configureDefaults() {
@@ -432,7 +435,6 @@ func (session *session) close() {
 	time.Sleep(200 * time.Millisecond)
 	session.conn.Close()
 }
-
 
 // From net/http/server.go
 

--- a/smtpd_test.go
+++ b/smtpd_test.go
@@ -394,11 +394,11 @@ func TestAuthNotSupported(t *testing.T) {
 func TestAuthBypass(t *testing.T) {
 
 	addr, closer := runsslserver(t, &smtpd.Server{
-		Authenticator:	func(peer smtpd.Peer, username, password string) error {
+		Authenticator: func(peer smtpd.Peer, username, password string) error {
 			return smtpd.Error{Code: 550, Message: "Denied"}
 		},
-		ForceTLS:	true,
-		ProtocolLogger:	log.New(os.Stdout, "log: ", log.Lshortfile),
+		ForceTLS:       true,
+		ProtocolLogger: log.New(os.Stdout, "log: ", log.Lshortfile),
 	})
 
 	defer closer()
@@ -414,6 +414,65 @@ func TestAuthBypass(t *testing.T) {
 
 	if err := c.Mail("sender@example.org"); err == nil {
 		t.Fatal("Unexpected MAIL success")
+	}
+
+}
+
+func TestAuthRequiredByDefault(t *testing.T) {
+
+	addr, closer := runsslserver(t, &smtpd.Server{
+		Authenticator: func(peer smtpd.Peer, username, password string) error {
+			return smtpd.Error{Code: 550, Message: "Denied"}
+		},
+		ForceTLS:       true,
+		ProtocolLogger: log.New(os.Stdout, "log: ", log.Lshortfile),
+	})
+
+	defer closer()
+
+	c, err := smtp.Dial(addr)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+
+	if err := c.StartTLS(&tls.Config{InsecureSkipVerify: true}); err != nil {
+		t.Fatalf("STARTTLS failed: %v", err)
+	}
+
+	if err := c.Mail("sender@example.org"); err == nil {
+		t.Fatal("Unexpected MAIL success")
+	}
+
+}
+
+func TestAuthOptional(t *testing.T) {
+
+	addr, closer := runsslserver(t, &smtpd.Server{
+		Authenticator: func(peer smtpd.Peer, username, password string) error {
+			return smtpd.Error{Code: 550, Message: "Denied"}
+		},
+		AuthOptional:   true,
+		ForceTLS:       true,
+		ProtocolLogger: log.New(os.Stdout, "log: ", log.Lshortfile),
+	})
+
+	defer closer()
+
+	c, err := smtp.Dial(addr)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+
+	if err := c.StartTLS(&tls.Config{InsecureSkipVerify: true}); err != nil {
+		t.Fatalf("STARTTLS failed: %v", err)
+	}
+
+	if err := c.Mail("sender@example.org"); err != nil {
+		t.Fatalf("Unexpected MAIL failure: %v", err)
+	}
+
+	if err := c.Quit(); err != nil {
+		t.Fatalf("Quit failed: %v", err)
 	}
 
 }


### PR DESCRIPTION
# Motivation

Some deployments want to support `AUTH` for clients that use it, while still accepting mail from clients that do not authenticate.

Previously, setting `Authenticator` always enforced authentication before `MAIL FROM`.

# Changes
* Added a new `Server` field: `AuthOptional bool`
* Updated `MAIL FROM` auth enforcement logic:
* Require authentication only when `Authenticator` is set and `AuthOptional` is false.

Added tests covering both modes:
* Auth required by default (backward compatibility)
* Auth optional when `AuthOptional` is `true`

# Backward Compatibility
Fully backward compatible.
Existing servers that set `Authenticator` and do not set `AuthOptional` keep current behavior (authentication required).
`AuthOptional` defaults to `false`, so no change is needed for existing users.

# Testing
Added:
* `TestAuthRequiredByDefault`
* `TestAuthOptional`
