### PR TITLE
feat: allow insecure auth (fixes #19).

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -24,7 +24,10 @@ func (s *session) handleAUTH(ctx context.Context, cmd *command) context.Context 
 		return s.reply(ctx, 502, "Please introduce yourself first.")
 	}
 
-	if !s.tls {
+	if !s.tls && !s.server.AllowInsecureAuth {
+		if s.server.TLSConfig == nil {
+			return s.reply(ctx, 502, "Cannot AUTH in plain text mode and STARTTLS is not available.")
+		}
 		return s.reply(ctx, 502, "Cannot AUTH in plain text mode. Use STARTTLS.")
 	}
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"net/smtp"
+	"strings"
 	"testing"
 
 	"github.com/chrj/smtpd/v2"
@@ -262,5 +263,94 @@ func TestAUTHRejected(t *testing.T) {
 	if err := cmd(c.Text, 550, "AUTH PLAIN Zm9vAGJhcgBxdXV4"); err != nil {
 		t.Fatalf("authenticator error not mapped to 550: %v", err)
 	}
+	_ = c.Quit()
+}
+
+func TestAUTHInsecureAllowed(t *testing.T) {
+	t.Parallel()
+
+	state := &captureAuthState{}
+
+	// No TLSConfig at all: AllowInsecureAuth is the only reason AUTH is
+	// reachable on this listener.
+	addr, closer := runserver(t, &smtpd.Server{
+		Logger:            testLogger(t),
+		AllowInsecureAuth: true,
+	}, captureAuth(state))
+	defer closer()
+
+	c, err := smtp.Dial(addr)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	if err := c.Hello("localhost"); err != nil {
+		t.Fatalf("HELO failed: %v", err)
+	}
+
+	if supported, _ := c.Extension("AUTH"); !supported {
+		t.Fatal("AUTH not advertised on a plain connection with AllowInsecureAuth")
+	}
+	if _, mechs := c.Extension("AUTH"); !strings.Contains(mechs, "PLAIN") {
+		t.Fatalf("PLAIN not offered on a plain connection, got mechanisms %q", mechs)
+	}
+
+	if err := c.Auth(smtp.PlainAuth("", "foo", "bar", "127.0.0.1")); err != nil {
+		t.Fatalf("AUTH over a plain connection failed: %v", err)
+	}
+	if state.gotUser != "foo" {
+		t.Errorf("Authenticate got username %q, want %q", state.gotUser, "foo")
+	}
+	if state.gotPass != "bar" {
+		t.Errorf("Authenticate got password %q, want %q", state.gotPass, "bar")
+	}
+
+	// The authenticated identity must survive onto the peer, same as it does
+	// over TLS.
+	if err := c.Mail("sender@example.org"); err != nil {
+		t.Fatalf("MAIL FROM failed: %v", err)
+	}
+	if state.peerUser != "foo" {
+		t.Errorf("peer.Username was %q, want %q", state.peerUser, "foo")
+	}
+
+	_ = c.Quit()
+}
+
+func TestAUTHInsecureDeniedByDefault(t *testing.T) {
+	t.Parallel()
+
+	// Same listener as above but with AllowInsecureAuth left at its zero
+	// value, which must keep AUTH both unadvertised and unusable.
+	addr, closer := runserver(t, &smtpd.Server{Logger: testLogger(t)}, acceptAuth())
+	defer closer()
+
+	c, err := smtp.Dial(addr)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	if err := c.Hello("localhost"); err != nil {
+		t.Fatalf("HELO failed: %v", err)
+	}
+
+	if supported, _ := c.Extension("AUTH"); supported {
+		t.Fatal("AUTH advertised on a plain connection by default")
+	}
+
+	// With no TLSConfig, telling the client to use STARTTLS would be a dead
+	// end, so the refusal says so instead.
+	id, err := c.Text.Cmd("AUTH PLAIN Zm9vAGJhcgBxdXV4")
+	if err != nil {
+		t.Fatalf("sending AUTH failed: %v", err)
+	}
+	c.Text.StartResponse(id)
+	_, msg, err := c.Text.ReadResponse(502)
+	c.Text.EndResponse(id)
+	if err != nil {
+		t.Fatalf("AUTH without TLS didn't 502: %v", err)
+	}
+	if msg != "Cannot AUTH in plain text mode and STARTTLS is not available." {
+		t.Errorf("got refusal %q, want the STARTTLS-unavailable message", msg)
+	}
+
 	_ = c.Quit()
 }

--- a/session.go
+++ b/session.go
@@ -187,7 +187,7 @@ func (s *session) extensions() []string {
 		extensions = append(extensions, "STARTTLS")
 	}
 
-	if s.server.hasAuthenticator() && s.tls {
+	if s.server.hasAuthenticator() && (s.tls || s.server.AllowInsecureAuth) {
 		extensions = append(extensions, "AUTH PLAIN LOGIN")
 	}
 

--- a/smtpd.go
+++ b/smtpd.go
@@ -131,6 +131,17 @@ type Server struct {
 	// TLS
 	TLSConfig *tls.Config
 
+	// AllowInsecureAuth permits AUTH on connections that have not negotiated
+	// TLS. It is false by default: AUTH is neither advertised nor accepted in
+	// plain text, because PLAIN and LOGIN both transmit the password in the
+	// clear. RFC 4954 discourages offering them without a security layer.
+	//
+	// Set this only when the transport is trusted by other means - a listener
+	// bound to loopback, a unix socket, or a private network segment. Pair it
+	// with a CheckConnection middleware that rejects non-local peers so the
+	// exposure is bounded explicitly rather than by assumption.
+	AllowInsecureAuth bool
+
 	// Logging
 	Logger *slog.Logger // nil = silent
 


### PR DESCRIPTION
Add a flag to allow authentication without TLS, fixes issue #19 