### PR TITLE
docs: point README version table to latest v2 tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Versions
 | Version | Status | Branch | Tag | Docs |
 |---------|--------|--------|-----|------|
 | v1 | stable | [`v1`](https://github.com/chrj/smtpd/tree/v1) | [`v1.0.0`](https://github.com/chrj/smtpd/releases/tag/v1.0.0) | [godoc](https://pkg.go.dev/github.com/chrj/smtpd) |
-| v2 | stable | [`main`](https://github.com/chrj/smtpd/tree/main) | [`v2.0.0`](https://github.com/chrj/smtpd/releases/tag/v2.0.0) | [godoc](https://pkg.go.dev/github.com/chrj/smtpd/v2) |
+| v2 | stable | [`main`](https://github.com/chrj/smtpd/tree/main) | [`v2.1.2`](https://github.com/chrj/smtpd/releases/tag/v2.1.2) | [godoc](https://pkg.go.dev/github.com/chrj/smtpd/v2) |
 
 v1 is the original battle-tested API.
 


### PR DESCRIPTION
## Summary
- Update the version table's v2 tag link from `v2.0.0` to `v2.1.2` (latest release), matching the latest git tags.

## Test plan
- N/A (documentation-only change)