### PR TITLE
feat: smtptest sub-package for SMTP client tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `github.com/chrj/smtpd/v2/smtptest`: test servers that run on the loopback
   interface, for end-to-end tests of an SMTP client. `NewServer`,
   `NewSTARTTLSServer` and `NewTLSServer` cover the three transports, and
-  `Recorder` keeps the messages that the client sent.
+  `Recorder` keeps the messages that the client sent. `Server.Dial` returns a
+  `*smtp.Client` that already completed the handshake of the transport.
 
 ## [2.0.0] - 2026-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `github.com/chrj/smtpd/v2/smtptest`: test servers that run on the loopback
+  interface, for end-to-end tests of an SMTP client. `NewServer`,
+  `NewSTARTTLSServer` and `NewTLSServer` cover the three transports, and
+  `Recorder` keeps the messages that the client sent.
+
 ## [2.0.0] - 2026-07-05
 
 Ground-up rewrite of the v1 API. The SMTP wire behavior is unchanged; the Go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `NewSTARTTLSServer` and `NewTLSServer` cover the three transports, and
   `Recorder` keeps the messages that the client sent. `Server.Dial` returns a
   `*smtp.Client` that already completed the handshake of the transport.
+  `Send` and `Cmd` drive a client, and they also work against a server that
+  the package did not start.
 
 ## [2.0.0] - 2026-07-05
 

--- a/README.md
+++ b/README.md
@@ -346,6 +346,38 @@ Each call opens one connection. Use `Dial` for the parts of a test that only
 need a working client. A client library under test connects to `Addr`
 itself.
 
+If the server stopped, `Dial` panics with the reason from `Serve`. A test
+with a bad configuration reads that reason instead of a dial error.
+
+### Send and Cmd
+
+`Send` runs one transaction on a client: MAIL FROM, RCPT TO, DATA and QUIT.
+It returns the first error, so a test can read the reply code of a
+rejection:
+
+```go
+err := smtptest.Send(srv.Dial(), "sender@example.org",
+    []string{"recipient@example.net"}, "Subject: hello\r\n\r\nbody\r\n")
+
+var reply *textproto.Error
+if !errors.As(err, &reply) || reply.Code != 550 {
+    t.Errorf("RCPT TO error: got %v, want 550", err)
+}
+```
+
+`Cmd` sends one raw command and compares the reply code. Use it for a
+command that `net/smtp` does not send, such as XCLIENT or PROXY, or for bad
+syntax:
+
+```go
+if err := smtptest.Cmd(c.Text, 550, "XCLIENT NAME=ignored"); err != nil {
+    t.Errorf("XCLIENT: %v", err)
+}
+```
+
+Both take a `*smtp.Client`, and not a `*smtptest.Server`. A test of your own
+SMTP server can use them against a server that this package did not start.
+
 ### Certificates
 
 Both TLS servers present a self-signed certificate for `localhost`,
@@ -355,6 +387,8 @@ Both TLS servers present a self-signed certificate for `localhost`,
 * `Certificate()` returns the parsed `*x509.Certificate`.
 * `CertPEM()` returns the certificate in PEM form, for a client that reads a
   trust anchor from a file.
+* `KeyPEM()` returns the private key in PEM form. With `CertPEM` it makes the
+  pair that a server under test loads from two files.
 
 To present your own certificate, set `TLS` before a `Start` method. The
 `Start` methods keep that certificate and add the default one only when the

--- a/README.md
+++ b/README.md
@@ -323,6 +323,29 @@ if got := rec.Messages()[0].Sender; got != "sender@example.org" {
 }
 ```
 
+The server gives its address in three forms. `Addr` is the "host:port" pair
+for `net.Dial`. `Host` and `Port` are the two parts, for a client that takes
+them apart, and `Host` is also the name that `smtp.PlainAuth` expects.
+
+### Dial
+
+`Dial` opens a connection and returns a `*smtp.Client` that completed the
+handshake of the transport. It sends STARTTLS to a STARTTLS server, and it
+does the TLS handshake before the greeting for an implicit TLS server:
+
+```go
+c := srv.Dial()
+defer func() { _ = c.Quit() }()
+
+if err := c.Auth(smtp.PlainAuth("", "joe", "secret", srv.Host)); err != nil {
+    t.Fatalf("AUTH: %v", err)
+}
+```
+
+Each call opens one connection. Use `Dial` for the parts of a test that only
+need a working client. A client library under test connects to `Addr`
+itself.
+
 ### Certificates
 
 Both TLS servers present a self-signed certificate for `localhost`,
@@ -356,6 +379,24 @@ srv.Config.Use(smtpd.Middleware{Handler: rec.Handler})
 srv.Start()
 defer srv.Close()
 ```
+
+### A listener of your own
+
+The server accepts on a TCP listener of the loopback interface, because most
+SMTP clients take an address and not a connection. A test that needs another
+transport, such as an in-memory pipe, replaces `Listener` before a `Start`
+method:
+
+```go
+srv := smtptest.NewUnstartedServer(rec.Handler)
+srv.Listener = myListener
+srv.Start()
+defer srv.Close()
+```
+
+Such a listener gives no TCP address. `Host` and `Port` stay empty and zero,
+`Peer.Addr` no longer identifies the client, and `Dial` cannot open the
+connection for you.
 
 Migration guide - v1 → v2
 --------------------------

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Features
 * Context-aware `Shutdown(ctx)` that drains in-flight sessions
 * Ready-made middleware in `github.com/chrj/smtpd/v2/middleware`: SPF, RBL,
   greylisting, per-IP rate limiting, `RequireAuth`, `RequireTLS`
+* Test servers in `github.com/chrj/smtpd/v2/smtptest`, for end-to-end tests of
+  an SMTP client
 
 Quick start
 -----------
@@ -286,6 +288,73 @@ return a derived context:
 CheckHelo: func(ctx context.Context, peer smtpd.Peer, name string) (context.Context, error) {
     return context.WithValue(ctx, traceIDKey{}, uuid.NewString()), nil
 }
+```
+
+Testing
+-------
+
+The sub-package `github.com/chrj/smtpd/v2/smtptest` runs a real server on the
+loopback interface, so a test can drive an SMTP client end to end. It follows
+`net/http/httptest`. A setup fault that a test cannot correct causes a panic,
+and the caller must call `Close`.
+
+```go
+import "github.com/chrj/smtpd/v2/smtptest"
+```
+
+| Function | Transport |
+|----------|-----------|
+| `NewServer` | Plain SMTP. |
+| `NewSTARTTLSServer` | Plain SMTP, with STARTTLS in the reply to EHLO. |
+| `NewTLSServer` | TLS before the greeting, as SMTPS on port 465. |
+| `NewUnstartedServer` | None yet. Change `Config` or `TLS`, then call a `Start` method. |
+
+A `Recorder` is an `smtpd.Handler` that keeps the messages that it receives:
+
+```go
+rec := &smtptest.Recorder{}
+srv := smtptest.NewSTARTTLSServer(rec.Handler)
+defer srv.Close()
+
+sendWithTheClientUnderTest(srv.Addr, srv.ClientTLSConfig())
+
+if got := rec.Messages()[0].Sender; got != "sender@example.org" {
+    t.Errorf("Sender: got %q, want %q", got, "sender@example.org")
+}
+```
+
+### Certificates
+
+Both TLS servers present a self-signed certificate for `localhost`,
+`127.0.0.1` and `::1`. Three methods pass it to the client under test:
+
+* `ClientTLSConfig()` returns a `*tls.Config` that trusts the server.
+* `Certificate()` returns the parsed `*x509.Certificate`.
+* `CertPEM()` returns the certificate in PEM form, for a client that reads a
+  trust anchor from a file.
+
+To present your own certificate, set `TLS` before a `Start` method. The
+`Start` methods keep that certificate and add the default one only when the
+configuration holds none.
+
+```go
+srv := smtptest.NewUnstartedServer(rec.Handler)
+srv.TLS = &tls.Config{Certificates: []tls.Certificate{expiredCert}}
+srv.StartSTARTTLS()
+defer srv.Close()
+```
+
+### Recording in front of a real handler
+
+`Recorder.Handler` reads the body into memory and then puts an equal stream
+back on `env.Data`. A stage that runs after it reads the same bytes, so the
+`Recorder` also works in front of the delivery handler under test:
+
+```go
+srv := smtptest.NewUnstartedServer(deliveryHandlerUnderTest)
+srv.Config.Use(smtpd.Middleware{Handler: rec.Handler})
+srv.Start()
+defer srv.Close()
 ```
 
 Migration guide - v1 → v2

--- a/smtptest/cert.go
+++ b/smtptest/cert.go
@@ -1,0 +1,69 @@
+package smtptest
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"net"
+	"sync"
+	"time"
+)
+
+// localhostCert returns the certificate that a TLS server presents when the
+// test supplies none. It is valid for "localhost", 127.0.0.1 and ::1, and it
+// signs itself, so a client trusts the server when it holds this one
+// certificate.
+//
+// The certificate is generated once for each test binary. Every server in
+// the binary shares it, so the test pays the cost of the key generation one
+// time.
+var localhostCert = sync.OnceValue(newLocalhostCert)
+
+// newLocalhostCert creates a self-signed certificate for the loopback
+// interface. It is valid from one hour in the past until 24 hours in the
+// future.
+func newLocalhostCert() tls.Certificate {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		panic(fmt.Sprintf("smtptest: generate the key of the test certificate: %v", err))
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		panic(fmt.Sprintf("smtptest: generate the serial number of the test certificate: %v", err))
+	}
+
+	template := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{Organization: []string{"smtptest"}, CommonName: "localhost"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		panic(fmt.Sprintf("smtptest: create the test certificate: %v", err))
+	}
+
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		panic(fmt.Sprintf("smtptest: parse the test certificate: %v", err))
+	}
+
+	return tls.Certificate{
+		Certificate: [][]byte{der},
+		PrivateKey:  key,
+		Leaf:        leaf,
+	}
+}

--- a/smtptest/client.go
+++ b/smtptest/client.go
@@ -1,0 +1,60 @@
+package smtptest
+
+import (
+	"fmt"
+	"io"
+	"net/smtp"
+	"net/textproto"
+)
+
+// Send runs one transaction on c: MAIL FROM, RCPT TO, DATA and QUIT. It
+// returns the first error, so a test can read the reply code of the server
+// with errors.As and a *textproto.Error.
+//
+// Send does not close c. A test that stops at a rejected reply can read more
+// from the client.
+func Send(c *smtp.Client, from string, to []string, body string) error {
+	if err := c.Mail(from); err != nil {
+		return fmt.Errorf("MAIL FROM <%s>: %w", from, err)
+	}
+
+	for _, recipient := range to {
+		if err := c.Rcpt(recipient); err != nil {
+			return fmt.Errorf("RCPT TO <%s>: %w", recipient, err)
+		}
+	}
+
+	w, err := c.Data()
+	if err != nil {
+		return fmt.Errorf("DATA: %w", err)
+	}
+
+	if _, err := io.WriteString(w, body); err != nil {
+		return fmt.Errorf("write the body: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("close the body: %w", err)
+	}
+
+	return c.Quit()
+}
+
+// Cmd sends one raw command and reads the reply. It returns an error when the
+// reply code is not wantCode.
+//
+// Use it for a command that net/smtp does not send, such as XCLIENT, or for
+// bad syntax. The Text field of a client gives the connection:
+//
+//	err := smtptest.Cmd(c.Text, 502, "XCLIENT NAME=ignored")
+func Cmd(c *textproto.Conn, wantCode int, format string, args ...any) error {
+	id, err := c.Cmd(format, args...)
+	if err != nil {
+		return fmt.Errorf("send %q: %w", fmt.Sprintf(format, args...), err)
+	}
+
+	c.StartResponse(id)
+	defer c.EndResponse(id)
+
+	_, _, err = c.ReadResponse(wantCode)
+	return err
+}

--- a/smtptest/client_test.go
+++ b/smtptest/client_test.go
@@ -1,0 +1,66 @@
+package smtptest_test
+
+import (
+	"context"
+	"errors"
+	"net/textproto"
+	"testing"
+
+	"github.com/chrj/smtpd/v2"
+	"github.com/chrj/smtpd/v2/smtptest"
+)
+
+// TestSendRejected makes sure that Send gives back the reply of the server,
+// so a test can read the code of a rejection.
+func TestSendRejected(t *testing.T) {
+	srv := smtptest.NewUnstartedServer(nil)
+	srv.Config.Use(smtpd.Middleware{
+		CheckRecipient: func(ctx context.Context, _ smtpd.Peer, _ string) (context.Context, error) {
+			return ctx, smtpd.Error{Code: 550, Message: "No such user"}
+		},
+	})
+	srv.Start()
+	defer srv.Close()
+
+	c := srv.Dial()
+	defer func() { _ = c.Close() }()
+
+	err := smtptest.Send(c, testSender, []string{testRecipient}, testBody)
+	if err == nil {
+		t.Fatal("Send accepted a message that the server rejected")
+	}
+
+	var reply *textproto.Error
+	if !errors.As(err, &reply) {
+		t.Fatalf("Send error: got %v, want a *textproto.Error", err)
+	}
+	if reply.Code != 550 {
+		t.Errorf("reply code: got %d, want 550", reply.Code)
+	}
+}
+
+func TestCmd(t *testing.T) {
+	srv := smtptest.NewServer(nil)
+	defer srv.Close()
+
+	c := srv.Dial()
+	defer func() { _ = c.Close() }()
+
+	// EnableXCLIENT is false by default, so the server answers 550.
+	if err := smtptest.Cmd(c.Text, 550, "XCLIENT NAME=ignored"); err != nil {
+		t.Errorf("Cmd with the expected code: %v", err)
+	}
+
+	err := smtptest.Cmd(c.Text, 250, "XCLIENT NAME=ignored")
+	if err == nil {
+		t.Fatal("Cmd accepted a reply code that it did not expect")
+	}
+
+	var reply *textproto.Error
+	if !errors.As(err, &reply) {
+		t.Fatalf("Cmd error: got %v, want a *textproto.Error", err)
+	}
+	if reply.Code != 550 {
+		t.Errorf("reply code: got %d, want 550", reply.Code)
+	}
+}

--- a/smtptest/example_test.go
+++ b/smtptest/example_test.go
@@ -3,25 +3,19 @@ package smtptest_test
 import (
 	"fmt"
 	"log"
-	"net/smtp"
 
 	"github.com/chrj/smtpd/v2/smtptest"
 )
 
 // ExampleServer sends a message to a test server over STARTTLS and reads back
-// what arrived. Replace the net/smtp calls with the client under test.
+// what arrived. Dial gives a net/smtp client that already sent STARTTLS. A
+// client of your own connects to srv.Addr and trusts srv.ClientTLSConfig().
 func ExampleServer() {
 	rec := &smtptest.Recorder{}
 	srv := smtptest.NewSTARTTLSServer(rec.Handler)
 	defer srv.Close()
 
-	c, err := smtp.Dial(srv.Addr)
-	if err != nil {
-		log.Fatalf("dial %s: %v", srv.Addr, err)
-	}
-	if err := c.StartTLS(srv.ClientTLSConfig()); err != nil {
-		log.Fatalf("STARTTLS: %v", err)
-	}
+	c := srv.Dial()
 
 	if err := c.Mail("sender@example.org"); err != nil {
 		log.Fatalf("MAIL FROM: %v", err)

--- a/smtptest/example_test.go
+++ b/smtptest/example_test.go
@@ -1,0 +1,56 @@
+package smtptest_test
+
+import (
+	"fmt"
+	"log"
+	"net/smtp"
+
+	"github.com/chrj/smtpd/v2/smtptest"
+)
+
+// ExampleServer sends a message to a test server over STARTTLS and reads back
+// what arrived. Replace the net/smtp calls with the client under test.
+func ExampleServer() {
+	rec := &smtptest.Recorder{}
+	srv := smtptest.NewSTARTTLSServer(rec.Handler)
+	defer srv.Close()
+
+	c, err := smtp.Dial(srv.Addr)
+	if err != nil {
+		log.Fatalf("dial %s: %v", srv.Addr, err)
+	}
+	if err := c.StartTLS(srv.ClientTLSConfig()); err != nil {
+		log.Fatalf("STARTTLS: %v", err)
+	}
+
+	if err := c.Mail("sender@example.org"); err != nil {
+		log.Fatalf("MAIL FROM: %v", err)
+	}
+	if err := c.Rcpt("recipient@example.net"); err != nil {
+		log.Fatalf("RCPT TO: %v", err)
+	}
+
+	w, err := c.Data()
+	if err != nil {
+		log.Fatalf("DATA: %v", err)
+	}
+	if _, err := fmt.Fprint(w, "Subject: hello\r\n\r\nThis is the email body\r\n"); err != nil {
+		log.Fatalf("write the body: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		log.Fatalf("close the body: %v", err)
+	}
+	if err := c.Quit(); err != nil {
+		log.Fatalf("QUIT: %v", err)
+	}
+
+	message := rec.Messages()[0]
+	fmt.Println(message.Sender)
+	fmt.Println(message.Recipients)
+	fmt.Println(message.Peer.TLS != nil)
+
+	// Output:
+	// sender@example.org
+	// [recipient@example.net]
+	// true
+}

--- a/smtptest/recorder.go
+++ b/smtptest/recorder.go
@@ -1,0 +1,81 @@
+package smtptest
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"slices"
+	"sync"
+
+	"github.com/chrj/smtpd/v2"
+)
+
+// Message is one message that a Recorder captured.
+type Message struct {
+	Sender     string
+	Recipients []string
+	Data       []byte
+
+	// Peer is the state of the client at the moment of delivery. It carries
+	// the HELO name, the user name after AUTH, and the TLS state.
+	Peer smtpd.Peer
+}
+
+// Recorder is an smtpd.Handler that keeps the messages that it receives, so
+// a test can read back what the client sent. The zero value is ready to use,
+// and it is safe for concurrent sessions.
+//
+// Pass Recorder.Handler to one of the New functions of this package:
+//
+//	rec := &smtptest.Recorder{}
+//	srv := smtptest.NewSTARTTLSServer(rec.Handler)
+//	defer srv.Close()
+type Recorder struct {
+	mu       sync.Mutex
+	messages []Message
+}
+
+// Handler records the envelope and accepts the message. It reads the body
+// into memory and then replaces env.Data with an equal stream. A middleware
+// stage or a delivery handler that runs after it reads the same bytes.
+func (r *Recorder) Handler(ctx context.Context, peer smtpd.Peer, env *smtpd.Envelope) (context.Context, error) {
+	data, err := io.ReadAll(env.Data)
+	if err != nil {
+		return ctx, fmt.Errorf("smtptest: read the message from %v: %w", peer.Addr, err)
+	}
+
+	if err := env.Data.Close(); err != nil {
+		return ctx, fmt.Errorf("smtptest: close the message from %v: %w", peer.Addr, err)
+	}
+
+	env.Data = io.NopCloser(bytes.NewReader(data))
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.messages = append(r.messages, Message{
+		Sender:     env.Sender,
+		Recipients: slices.Clone(env.Recipients),
+		Data:       data,
+		Peer:       peer,
+	})
+
+	return ctx, nil
+}
+
+// Messages returns a copy of the messages in the order of delivery.
+func (r *Recorder) Messages() []Message {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return slices.Clone(r.messages)
+}
+
+// Reset removes every message that the Recorder holds.
+func (r *Recorder) Reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.messages = nil
+}

--- a/smtptest/recorder_test.go
+++ b/smtptest/recorder_test.go
@@ -1,0 +1,133 @@
+package smtptest_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/chrj/smtpd/v2"
+	"github.com/chrj/smtpd/v2/smtptest"
+)
+
+// errReader fails on the first read. It stands for a client that broke the
+// connection in the middle of DATA.
+type errReader struct{ err error }
+
+func (r errReader) Read([]byte) (int, error) { return 0, r.err }
+func (r errReader) Close() error             { return nil }
+
+func TestRecorderHandler(t *testing.T) {
+	rec := &smtptest.Recorder{}
+
+	recipients := []string{"one@example.net", "two@example.net"}
+	env := &smtpd.Envelope{
+		Sender:     "sender@example.org",
+		Recipients: recipients,
+		Data:       io.NopCloser(strings.NewReader("the body")),
+	}
+	peer := smtpd.Peer{HeloName: "client.example.org", Username: "joe"}
+
+	if _, err := rec.Handler(context.Background(), peer, env); err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+
+	messages := rec.Messages()
+	if len(messages) != 1 {
+		t.Fatalf("recorded %d messages, want 1", len(messages))
+	}
+
+	got := messages[0]
+	if got.Sender != "sender@example.org" {
+		t.Errorf("Sender: got %q, want %q", got.Sender, "sender@example.org")
+	}
+	if string(got.Data) != "the body" {
+		t.Errorf("Data: got %q, want %q", string(got.Data), "the body")
+	}
+	if got.Peer.Username != "joe" {
+		t.Errorf("Username: got %q, want %q", got.Peer.Username, "joe")
+	}
+
+	// The handler that runs after the Recorder reads the same bytes.
+	rest, err := io.ReadAll(env.Data)
+	if err != nil {
+		t.Fatalf("read the restored body: %v", err)
+	}
+	if string(rest) != "the body" {
+		t.Errorf("restored body: got %q, want %q", string(rest), "the body")
+	}
+
+	// A later change of the envelope does not reach the record.
+	recipients[0] = "changed@example.net"
+	if got.Recipients[0] != "one@example.net" {
+		t.Errorf("Recipients[0]: got %q, want %q", got.Recipients[0], "one@example.net")
+	}
+}
+
+func TestRecorderHandlerReadError(t *testing.T) {
+	rec := &smtptest.Recorder{}
+	want := errors.New("connection reset")
+
+	env := &smtpd.Envelope{
+		Sender: "sender@example.org",
+		Data:   errReader{err: want},
+	}
+
+	_, err := rec.Handler(context.Background(), smtpd.Peer{}, env)
+	if !errors.Is(err, want) {
+		t.Errorf("Handler error: got %v, want %v", err, want)
+	}
+	if got := rec.Messages(); len(got) != 0 {
+		t.Errorf("recorded %d messages after a read error, want 0", len(got))
+	}
+}
+
+func TestRecorderReset(t *testing.T) {
+	rec := &smtptest.Recorder{}
+	env := &smtpd.Envelope{Data: io.NopCloser(strings.NewReader(""))}
+
+	if _, err := rec.Handler(context.Background(), smtpd.Peer{}, env); err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+	if got := len(rec.Messages()); got != 1 {
+		t.Fatalf("recorded %d messages, want 1", got)
+	}
+
+	rec.Reset()
+
+	if got := len(rec.Messages()); got != 0 {
+		t.Errorf("recorded %d messages after Reset, want 0", got)
+	}
+}
+
+// TestRecorderAsMiddleware makes sure that a delivery handler after the
+// Recorder reads the full message body.
+func TestRecorderAsMiddleware(t *testing.T) {
+	rec := &smtptest.Recorder{}
+	delivered := make(chan string, 1)
+
+	srv := smtptest.NewUnstartedServer(
+		func(ctx context.Context, _ smtpd.Peer, env *smtpd.Envelope) (context.Context, error) {
+			data, err := io.ReadAll(env.Data)
+			if err != nil {
+				return ctx, err
+			}
+			delivered <- string(data)
+			return ctx, env.Data.Close()
+		},
+	)
+	srv.Config.Use(smtpd.Middleware{Handler: rec.Handler})
+	srv.Start()
+	defer srv.Close()
+
+	deliver(t, dialPlain(t, srv.Addr))
+
+	want := "Subject: test\n\nThis is the email body\n"
+	if got := <-delivered; got != want {
+		t.Errorf("body at the delivery handler: got %q, want %q", got, want)
+	}
+	if got := rec.Messages(); len(got) != 1 || string(got[0].Data) != want {
+		t.Errorf("recorded messages: got %d, want 1 with the same body", len(got))
+	}
+}

--- a/smtptest/recorder_test.go
+++ b/smtptest/recorder_test.go
@@ -121,7 +121,7 @@ func TestRecorderAsMiddleware(t *testing.T) {
 	srv.Start()
 	defer srv.Close()
 
-	deliver(t, dialPlain(t, srv.Addr))
+	deliver(t, srv.Dial())
 
 	want := "Subject: test\n\nThis is the email body\n"
 	if got := <-delivered; got != want {

--- a/smtptest/smtptest.go
+++ b/smtptest/smtptest.go
@@ -8,7 +8,8 @@
 // such as a loopback interface that refuses a listener, causes a panic.
 //
 // Use a Recorder as the handler to read back the messages that the client
-// sent.
+// sent. For a test that needs a client and not a client library, Dial
+// returns a net/smtp client that already completed the handshake.
 package smtptest
 
 import (
@@ -19,6 +20,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/smtp"
+	"strconv"
 	"time"
 
 	"github.com/chrj/smtpd/v2"
@@ -35,7 +38,14 @@ type Server struct {
 	// Start method returns.
 	Addr string
 
-	// Listener is the loopback listener that the server accepts on.
+	// Host and Port are the two parts of Addr. Host is also the name that
+	// smtp.PlainAuth expects. They stay empty and zero when the test replaced
+	// Listener with a listener that is not TCP.
+	Host string
+	Port int
+
+	// Listener is the loopback listener that the server accepts on. Replace
+	// it before a Start method to serve on a listener of your own.
 	Listener net.Listener
 
 	// TLS is the TLS configuration of the server. Set it before a Start
@@ -50,10 +60,26 @@ type Server struct {
 	// Config.TLSConfig, so do not set that field yourself: set Server.TLS.
 	Config *smtpd.Server
 
+	// transport records the choice of the Start method, so that Dial can
+	// complete the same handshake as the server expects.
+	transport transport
+
 	// serveErr carries the result of Serve back to Close. It is nil until a
 	// Start method runs, and Close sets it back to nil.
 	serveErr chan error
 }
+
+// transport is the way a client reaches the server.
+type transport int
+
+const (
+	// plain is SMTP without TLS.
+	plain transport = iota
+	// starttls is SMTP that a client upgrades with the STARTTLS command.
+	starttls
+	// implicitTLS is SMTP behind a TLS handshake, as SMTPS on port 465.
+	implicitTLS
+)
 
 // NewServer starts a server that accepts plain connections and gives the
 // messages to h. The caller must call Close when the test is complete.
@@ -96,6 +122,7 @@ func NewUnstartedServer(h smtpd.Handler) *Server {
 // Start serves plain SMTP on the listener. The server does not offer
 // STARTTLS.
 func (s *Server) Start() {
+	s.transport = plain
 	s.serve(s.Listener)
 }
 
@@ -103,6 +130,7 @@ func (s *Server) Start() {
 // the reply to EHLO.
 func (s *Server) StartSTARTTLS() {
 	s.Config.TLSConfig = s.tlsConfig()
+	s.transport = starttls
 	s.serve(s.Listener)
 }
 
@@ -113,7 +141,52 @@ func (s *Server) StartSTARTTLS() {
 // already secure.
 func (s *Server) StartTLS() {
 	s.Config.TLSConfig = s.tlsConfig()
+	s.transport = implicitTLS
 	s.serve(tls.NewListener(s.Listener, s.Config.TLSConfig))
+}
+
+// Dial opens a connection to the server and returns a client that is ready
+// for MAIL FROM. It completes the handshake that the transport of the server
+// needs: it sends STARTTLS to a STARTTLS server, and it does the TLS
+// handshake before the greeting for an implicit TLS server.
+//
+// Each call opens one connection. The caller must call Quit or Close on the
+// client.
+//
+// Dial needs a TCP listener. A test that replaced Listener must open the
+// connection itself.
+func (s *Server) Dial() *smtp.Client {
+	if s.Addr == "" {
+		panic("smtptest: the server is not started")
+	}
+
+	if s.transport == implicitTLS {
+		conn, err := tls.Dial("tcp", s.Addr, s.ClientTLSConfig())
+		if err != nil {
+			panic(fmt.Sprintf("smtptest: TLS dial %s: %v", s.Addr, err))
+		}
+
+		c, err := smtp.NewClient(conn, s.Host)
+		if err != nil {
+			_ = conn.Close()
+			panic(fmt.Sprintf("smtptest: read the greeting of %s: %v", s.Addr, err))
+		}
+		return c
+	}
+
+	c, err := smtp.Dial(s.Addr)
+	if err != nil {
+		panic(fmt.Sprintf("smtptest: dial %s: %v", s.Addr, err))
+	}
+
+	if s.transport == starttls {
+		if err := c.StartTLS(s.ClientTLSConfig()); err != nil {
+			_ = c.Close()
+			panic(fmt.Sprintf("smtptest: STARTTLS on %s: %v", s.Addr, err))
+		}
+	}
+
+	return c
 }
 
 // Close stops the server and waits for the sessions that are still open. The
@@ -225,6 +298,7 @@ func (s *Server) serve(l net.Listener) {
 	}
 
 	s.Addr = s.Listener.Addr().String()
+	s.Host, s.Port = splitAddr(s.Addr)
 
 	// The goroutine keeps its own reference, because Close clears the field.
 	serveErr := make(chan error, 1)
@@ -233,6 +307,23 @@ func (s *Server) serve(l net.Listener) {
 	go func() {
 		serveErr <- s.Config.Serve(l)
 	}()
+}
+
+// splitAddr divides a "host:port" address. It returns an empty host and a
+// zero port for an address that is not TCP, which a listener of the test can
+// give.
+func splitAddr(addr string) (host string, port int) {
+	host, text, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", 0
+	}
+
+	port, err = strconv.Atoi(text)
+	if err != nil {
+		return "", 0
+	}
+
+	return host, port
 }
 
 // newLocalListener opens a listener on a port of the loopback interface that

--- a/smtptest/smtptest.go
+++ b/smtptest/smtptest.go
@@ -160,6 +160,15 @@ func (s *Server) Dial() *smtp.Client {
 		panic("smtptest: the server is not started")
 	}
 
+	// Serve reports a fault of the accept loop on this channel. Without this
+	// check, a server that stopped gives a dial error and hides the reason.
+	select {
+	case err := <-s.serveErr:
+		s.serveErr <- err // Close still needs the value.
+		panic(fmt.Sprintf("smtptest: the server on %s stopped: %v", s.Addr, err))
+	default:
+	}
+
 	if s.transport == implicitTLS {
 		conn, err := tls.Dial("tcp", s.Addr, s.ClientTLSConfig())
 		if err != nil {
@@ -205,7 +214,10 @@ func (s *Server) Close() {
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
 
-	if err := s.Config.Shutdown(ctx); err != nil {
+	// A server that stopped on its own already closed the listener. The
+	// reason for that stop comes from serveErr below, which is the better
+	// message.
+	if err := s.Config.Shutdown(ctx); err != nil && !errors.Is(err, net.ErrClosed) {
 		panic(fmt.Sprintf("smtptest: stop the server on %s: %v", s.Addr, err))
 	}
 
@@ -247,6 +259,28 @@ func (s *Server) CertPEM() []byte {
 		return nil
 	}
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+}
+
+// KeyPEM returns the private key of the server in PEM form. Use it with
+// CertPEM for a server under test that reads a certificate and a key from
+// two files. It returns nil when the server serves no TLS, or when the TLS
+// configuration gives its certificate through GetCertificate.
+func (s *Server) KeyPEM() []byte {
+	if s.TLS == nil || len(s.TLS.Certificates) == 0 {
+		return nil
+	}
+
+	key := s.TLS.Certificates[0].PrivateKey
+	if key == nil {
+		return nil
+	}
+
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		panic(fmt.Sprintf("smtptest: marshal the key of the server: %v", err))
+	}
+
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
 }
 
 // ClientTLSConfig returns a TLS configuration for a client that connects to

--- a/smtptest/smtptest.go
+++ b/smtptest/smtptest.go
@@ -1,0 +1,251 @@
+// Package smtptest provides utilities for SMTP testing. It runs a real
+// smtpd.Server on the loopback interface, so a test can drive an SMTP client
+// end to end: over a plain connection, over STARTTLS, or over implicit TLS.
+//
+// The package follows net/http/httptest. A Server starts on a port that the
+// system chooses, and it presents a self-signed certificate for "localhost"
+// when the test supplies none. A setup error that a test cannot correct,
+// such as a loopback interface that refuses a listener, causes a panic.
+//
+// Use a Recorder as the handler to read back the messages that the client
+// sent.
+package smtptest
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/chrj/smtpd/v2"
+)
+
+// shutdownTimeout is the time that Close gives the sessions that are still
+// open before it closes their connections.
+const shutdownTimeout = 5 * time.Second
+
+// Server is an SMTP server that listens on a port of the loopback interface
+// that the system chooses. Use it in end-to-end tests of an SMTP client.
+type Server struct {
+	// Addr is the "host:port" address of the listener. It is empty until a
+	// Start method returns.
+	Addr string
+
+	// Listener is the loopback listener that the server accepts on.
+	Listener net.Listener
+
+	// TLS is the TLS configuration of the server. Set it before a Start
+	// method to present your own certificate. StartTLS and StartSTARTTLS
+	// add the self-signed certificate for "localhost" only when this
+	// configuration holds no certificate of its own. TLS stays nil after a
+	// plain Start.
+	TLS *tls.Config
+
+	// Config is the server under test. Change its fields and register
+	// middleware with Use before a Start method. The Start methods set
+	// Config.TLSConfig, so do not set that field yourself: set Server.TLS.
+	Config *smtpd.Server
+
+	// serveErr carries the result of Serve back to Close. It is nil until a
+	// Start method runs, and Close sets it back to nil.
+	serveErr chan error
+}
+
+// NewServer starts a server that accepts plain connections and gives the
+// messages to h. The caller must call Close when the test is complete.
+func NewServer(h smtpd.Handler) *Server {
+	s := NewUnstartedServer(h)
+	s.Start()
+	return s
+}
+
+// NewSTARTTLSServer starts a server that accepts plain connections and
+// advertises STARTTLS. The caller must call Close when the test is complete.
+func NewSTARTTLSServer(h smtpd.Handler) *Server {
+	s := NewUnstartedServer(h)
+	s.StartSTARTTLS()
+	return s
+}
+
+// NewTLSServer starts a server that expects TLS from the first byte, as an
+// SMTPS service on port 465 does. The caller must call Close when the test
+// is complete.
+func NewTLSServer(h smtpd.Handler) *Server {
+	s := NewUnstartedServer(h)
+	s.StartTLS()
+	return s
+}
+
+// NewUnstartedServer opens a loopback listener and returns a server that
+// gives the messages to h. Change Config and TLS, then call one of the Start
+// methods.
+func NewUnstartedServer(h smtpd.Handler) *Server {
+	return &Server{
+		Listener: newLocalListener(),
+		Config: &smtpd.Server{
+			Hostname: "localhost",
+			Handler:  h,
+		},
+	}
+}
+
+// Start serves plain SMTP on the listener. The server does not offer
+// STARTTLS.
+func (s *Server) Start() {
+	s.serve(s.Listener)
+}
+
+// StartSTARTTLS serves plain SMTP on the listener and advertises STARTTLS in
+// the reply to EHLO.
+func (s *Server) StartSTARTTLS() {
+	s.Config.TLSConfig = s.tlsConfig()
+	s.serve(s.Listener)
+}
+
+// StartTLS wraps the listener in TLS, so the handshake comes before the SMTP
+// greeting. This is the SMTPS deployment on port 465.
+//
+// The server does not advertise STARTTLS on such a connection, because it is
+// already secure.
+func (s *Server) StartTLS() {
+	s.Config.TLSConfig = s.tlsConfig()
+	s.serve(tls.NewListener(s.Listener, s.Config.TLSConfig))
+}
+
+// Close stops the server and waits for the sessions that are still open. The
+// second call and every call after it does nothing.
+func (s *Server) Close() {
+	serveErr := s.serveErr
+	s.serveErr = nil
+
+	if serveErr == nil {
+		// The server never started, so only the listener holds a resource.
+		// A close error on an unused listener tells a test nothing.
+		_ = s.Listener.Close()
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+
+	if err := s.Config.Shutdown(ctx); err != nil {
+		panic(fmt.Sprintf("smtptest: stop the server on %s: %v", s.Addr, err))
+	}
+
+	// Serve reports every fault of the accept loop here. A test that ignores
+	// it sees an empty Recorder and no reason for it.
+	if err := <-serveErr; err != nil && !errors.Is(err, smtpd.ErrServerClosed) {
+		panic(fmt.Sprintf("smtptest: serve on %s: %v", s.Addr, err))
+	}
+}
+
+// Certificate returns the certificate that the server presents. It returns
+// nil when the server serves no TLS.
+func (s *Server) Certificate() *x509.Certificate {
+	if s.TLS == nil || len(s.TLS.Certificates) == 0 {
+		return nil
+	}
+
+	cert := s.TLS.Certificates[0]
+	if cert.Leaf != nil {
+		return cert.Leaf
+	}
+	if len(cert.Certificate) == 0 {
+		return nil
+	}
+
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		panic(fmt.Sprintf("smtptest: parse the certificate of the server: %v", err))
+	}
+	return leaf
+}
+
+// CertPEM returns the certificate of the server in PEM form. Use it for a
+// test that must write a trust anchor to a file. It returns nil when the
+// server serves no TLS.
+func (s *Server) CertPEM() []byte {
+	cert := s.Certificate()
+	if cert == nil {
+		return nil
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+}
+
+// ClientTLSConfig returns a TLS configuration for a client that connects to
+// this server. It trusts the certificate of the server and it sets the name
+// that the client expects. It returns nil when the server serves no TLS.
+func (s *Server) ClientTLSConfig() *tls.Config {
+	cert := s.Certificate()
+	if cert == nil {
+		return nil
+	}
+
+	pool := x509.NewCertPool()
+	pool.AddCert(cert)
+
+	name := "localhost"
+	if len(cert.DNSNames) > 0 {
+		name = cert.DNSNames[0]
+	}
+
+	return &tls.Config{
+		RootCAs:    pool,
+		ServerName: name,
+		MinVersion: tls.VersionTLS12,
+	}
+}
+
+// tlsConfig returns the TLS configuration for a Start method. It keeps a
+// certificate that the test supplied, and it adds the self-signed
+// certificate for "localhost" when the test supplied none.
+func (s *Server) tlsConfig() *tls.Config {
+	if s.TLS != nil {
+		s.TLS = s.TLS.Clone()
+	} else {
+		s.TLS = &tls.Config{MinVersion: tls.VersionTLS12}
+	}
+
+	if len(s.TLS.Certificates) == 0 && s.TLS.GetCertificate == nil {
+		s.TLS.Certificates = []tls.Certificate{localhostCert()}
+	}
+
+	return s.TLS
+}
+
+// serve records the address and runs the accept loop in its own goroutine.
+// The goroutine stops when Close stops the server.
+func (s *Server) serve(l net.Listener) {
+	if s.Addr != "" {
+		panic("smtptest: the server is already started")
+	}
+
+	s.Addr = s.Listener.Addr().String()
+
+	// The goroutine keeps its own reference, because Close clears the field.
+	serveErr := make(chan error, 1)
+	s.serveErr = serveErr
+
+	go func() {
+		serveErr <- s.Config.Serve(l)
+	}()
+}
+
+// newLocalListener opens a listener on a port of the loopback interface that
+// the system chooses.
+func newLocalListener() net.Listener {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err == nil {
+		return l
+	}
+
+	l6, err6 := net.Listen("tcp6", "[::1]:0")
+	if err6 != nil {
+		panic(fmt.Sprintf("smtptest: listen on the loopback interface: tcp: %v, tcp6: %v", err, err6))
+	}
+	return l6
+}

--- a/smtptest/smtptest_test.go
+++ b/smtptest/smtptest_test.go
@@ -13,6 +13,7 @@ import (
 	"math/big"
 	"net"
 	"net/smtp"
+	"strconv"
 	"testing"
 	"time"
 
@@ -37,18 +38,6 @@ func dialPlain(t *testing.T, addr string) *smtp.Client {
 	}
 	if err := c.Hello("client.example.org"); err != nil {
 		t.Fatalf("EHLO: %v", err)
-	}
-	return c
-}
-
-// dialSTARTTLS connects over a plain TCP connection and then upgrades the
-// connection with STARTTLS.
-func dialSTARTTLS(t *testing.T, srv *smtptest.Server) *smtp.Client {
-	t.Helper()
-
-	c := dialPlain(t, srv.Addr)
-	if err := c.StartTLS(srv.ClientTLSConfig()); err != nil {
-		t.Fatalf("STARTTLS: %v", err)
 	}
 	return c
 }
@@ -102,27 +91,11 @@ func TestServerDelivery(t *testing.T) {
 	tests := []struct {
 		name    string
 		start   func(smtpd.Handler) *smtptest.Server
-		dial    func(*testing.T, *smtptest.Server) *smtp.Client
 		wantTLS bool
 	}{
-		{
-			name:    "plain",
-			start:   smtptest.NewServer,
-			dial:    func(t *testing.T, s *smtptest.Server) *smtp.Client { return dialPlain(t, s.Addr) },
-			wantTLS: false,
-		},
-		{
-			name:    "starttls",
-			start:   smtptest.NewSTARTTLSServer,
-			dial:    dialSTARTTLS,
-			wantTLS: true,
-		},
-		{
-			name:    "implicit tls",
-			start:   smtptest.NewTLSServer,
-			dial:    dialTLS,
-			wantTLS: true,
-		},
+		{name: "plain", start: smtptest.NewServer, wantTLS: false},
+		{name: "starttls", start: smtptest.NewSTARTTLSServer, wantTLS: true},
+		{name: "implicit tls", start: smtptest.NewTLSServer, wantTLS: true},
 	}
 
 	for _, test := range tests {
@@ -135,7 +108,8 @@ func TestServerDelivery(t *testing.T) {
 				t.Fatal("Addr is empty after the server started")
 			}
 
-			deliver(t, test.dial(t, srv))
+			// Dial completes the handshake that the transport needs.
+			deliver(t, srv.Dial())
 
 			messages := rec.Messages()
 			if len(messages) != 1 {
@@ -152,8 +126,9 @@ func TestServerDelivery(t *testing.T) {
 			if want := "Subject: test\n\nThis is the email body\n"; string(got.Data) != want {
 				t.Errorf("Data: got %q, want %q", string(got.Data), want)
 			}
-			if got.Peer.HeloName != "client.example.org" {
-				t.Errorf("HeloName: got %q, want %q", got.Peer.HeloName, "client.example.org")
+			// net/smtp greets with "localhost" when the test sets no name.
+			if got.Peer.HeloName != "localhost" {
+				t.Errorf("HeloName: got %q, want %q", got.Peer.HeloName, "localhost")
 			}
 			if gotTLS := got.Peer.TLS != nil; gotTLS != test.wantTLS {
 				t.Errorf("Peer.TLS is set: got %v, want %v", gotTLS, test.wantTLS)
@@ -208,14 +183,9 @@ func TestServerAuth(t *testing.T) {
 	defer srv.Close()
 
 	// PlainAuth compares the host against the name that the client dialed,
-	// which is the host part of Addr.
-	host, _, err := net.SplitHostPort(srv.Addr)
-	if err != nil {
-		t.Fatalf("split the address %q: %v", srv.Addr, err)
-	}
-
-	c := dialSTARTTLS(t, srv)
-	if err := c.Auth(smtp.PlainAuth("", "joe", "secret", host)); err != nil {
+	// which is Host.
+	c := srv.Dial()
+	if err := c.Auth(smtp.PlainAuth("", "joe", "secret", srv.Host)); err != nil {
 		t.Fatalf("AUTH: %v", err)
 	}
 
@@ -299,6 +269,31 @@ func TestServerCustomCertificate(t *testing.T) {
 	if !errors.As(err, &invalid) || invalid.Reason != x509.Expired {
 		t.Errorf("STARTTLS error: got %v, want an out of date certificate", err)
 	}
+}
+
+func TestServerHostAndPort(t *testing.T) {
+	srv := smtptest.NewServer(nil)
+	defer srv.Close()
+
+	if want := net.JoinHostPort(srv.Host, strconv.Itoa(srv.Port)); want != srv.Addr {
+		t.Errorf("Host and Port: got %q, want the parts of Addr %q", want, srv.Addr)
+	}
+	if srv.Port == 0 {
+		t.Error("Port is zero after the server started")
+	}
+}
+
+func TestServerDialNotStarted(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("Dial did not panic on a server that is not started")
+		}
+	}()
+
+	srv := smtptest.NewUnstartedServer(nil)
+	defer srv.Close()
+
+	srv.Dial()
 }
 
 func TestServerCloseUnstarted(t *testing.T) {

--- a/smtptest/smtptest_test.go
+++ b/smtptest/smtptest_test.go
@@ -1,0 +1,357 @@
+package smtptest_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net"
+	"net/smtp"
+	"testing"
+	"time"
+
+	"github.com/chrj/smtpd/v2"
+	"github.com/chrj/smtpd/v2/middleware"
+	"github.com/chrj/smtpd/v2/smtptest"
+)
+
+const (
+	testSender    = "sender@example.org"
+	testRecipient = "recipient@example.net"
+	testBody      = "Subject: test\r\n\r\nThis is the email body\r\n"
+)
+
+// dialPlain connects over a plain TCP connection and greets the server.
+func dialPlain(t *testing.T, addr string) *smtp.Client {
+	t.Helper()
+
+	c, err := smtp.Dial(addr)
+	if err != nil {
+		t.Fatalf("Dial %s: %v", addr, err)
+	}
+	if err := c.Hello("client.example.org"); err != nil {
+		t.Fatalf("EHLO: %v", err)
+	}
+	return c
+}
+
+// dialSTARTTLS connects over a plain TCP connection and then upgrades the
+// connection with STARTTLS.
+func dialSTARTTLS(t *testing.T, srv *smtptest.Server) *smtp.Client {
+	t.Helper()
+
+	c := dialPlain(t, srv.Addr)
+	if err := c.StartTLS(srv.ClientTLSConfig()); err != nil {
+		t.Fatalf("STARTTLS: %v", err)
+	}
+	return c
+}
+
+// dialTLS connects with a TLS handshake before the SMTP greeting.
+func dialTLS(t *testing.T, srv *smtptest.Server) *smtp.Client {
+	t.Helper()
+
+	conn, err := tls.Dial("tcp", srv.Addr, srv.ClientTLSConfig())
+	if err != nil {
+		t.Fatalf("TLS dial %s: %v", srv.Addr, err)
+	}
+
+	c, err := smtp.NewClient(conn, "localhost")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if err := c.Hello("client.example.org"); err != nil {
+		t.Fatalf("EHLO: %v", err)
+	}
+	return c
+}
+
+// deliver sends one message and closes the session.
+func deliver(t *testing.T, c *smtp.Client) {
+	t.Helper()
+
+	if err := c.Mail(testSender); err != nil {
+		t.Fatalf("MAIL FROM: %v", err)
+	}
+	if err := c.Rcpt(testRecipient); err != nil {
+		t.Fatalf("RCPT TO: %v", err)
+	}
+
+	w, err := c.Data()
+	if err != nil {
+		t.Fatalf("DATA: %v", err)
+	}
+	if _, err := w.Write([]byte(testBody)); err != nil {
+		t.Fatalf("write the body: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close the body: %v", err)
+	}
+	if err := c.Quit(); err != nil {
+		t.Fatalf("QUIT: %v", err)
+	}
+}
+
+func TestServerDelivery(t *testing.T) {
+	tests := []struct {
+		name    string
+		start   func(smtpd.Handler) *smtptest.Server
+		dial    func(*testing.T, *smtptest.Server) *smtp.Client
+		wantTLS bool
+	}{
+		{
+			name:    "plain",
+			start:   smtptest.NewServer,
+			dial:    func(t *testing.T, s *smtptest.Server) *smtp.Client { return dialPlain(t, s.Addr) },
+			wantTLS: false,
+		},
+		{
+			name:    "starttls",
+			start:   smtptest.NewSTARTTLSServer,
+			dial:    dialSTARTTLS,
+			wantTLS: true,
+		},
+		{
+			name:    "implicit tls",
+			start:   smtptest.NewTLSServer,
+			dial:    dialTLS,
+			wantTLS: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rec := &smtptest.Recorder{}
+			srv := test.start(rec.Handler)
+			defer srv.Close()
+
+			if srv.Addr == "" {
+				t.Fatal("Addr is empty after the server started")
+			}
+
+			deliver(t, test.dial(t, srv))
+
+			messages := rec.Messages()
+			if len(messages) != 1 {
+				t.Fatalf("recorded %d messages, want 1", len(messages))
+			}
+
+			got := messages[0]
+			if got.Sender != testSender {
+				t.Errorf("Sender: got %q, want %q", got.Sender, testSender)
+			}
+			if len(got.Recipients) != 1 || got.Recipients[0] != testRecipient {
+				t.Errorf("Recipients: got %q, want [%q]", got.Recipients, testRecipient)
+			}
+			if want := "Subject: test\n\nThis is the email body\n"; string(got.Data) != want {
+				t.Errorf("Data: got %q, want %q", string(got.Data), want)
+			}
+			if got.Peer.HeloName != "client.example.org" {
+				t.Errorf("HeloName: got %q, want %q", got.Peer.HeloName, "client.example.org")
+			}
+			if gotTLS := got.Peer.TLS != nil; gotTLS != test.wantTLS {
+				t.Errorf("Peer.TLS is set: got %v, want %v", gotTLS, test.wantTLS)
+			}
+		})
+	}
+}
+
+func TestServerSTARTTLSAdvertised(t *testing.T) {
+	tests := []struct {
+		name  string
+		start func(smtpd.Handler) *smtptest.Server
+		want  bool
+	}{
+		{name: "plain", start: smtptest.NewServer, want: false},
+		{name: "starttls", start: smtptest.NewSTARTTLSServer, want: true},
+		{name: "implicit tls", start: smtptest.NewTLSServer, want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			srv := test.start(nil)
+			defer srv.Close()
+
+			var c *smtp.Client
+			if test.name == "implicit tls" {
+				c = dialTLS(t, srv)
+			} else {
+				c = dialPlain(t, srv.Addr)
+			}
+			defer func() { _ = c.Quit() }()
+
+			if got, _ := c.Extension("STARTTLS"); got != test.want {
+				t.Errorf("STARTTLS advertised: got %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestServerAuth(t *testing.T) {
+	rec := &smtptest.Recorder{}
+	srv := smtptest.NewUnstartedServer(rec.Handler)
+	srv.Config.Use(middleware.Authenticator(
+		func(_ context.Context, _ smtpd.Peer, user, pass string) error {
+			if user != "joe" || pass != "secret" {
+				return smtpd.Error{Code: 535, Message: "Denied"}
+			}
+			return nil
+		},
+	))
+	srv.StartSTARTTLS()
+	defer srv.Close()
+
+	// PlainAuth compares the host against the name that the client dialed,
+	// which is the host part of Addr.
+	host, _, err := net.SplitHostPort(srv.Addr)
+	if err != nil {
+		t.Fatalf("split the address %q: %v", srv.Addr, err)
+	}
+
+	c := dialSTARTTLS(t, srv)
+	if err := c.Auth(smtp.PlainAuth("", "joe", "secret", host)); err != nil {
+		t.Fatalf("AUTH: %v", err)
+	}
+
+	deliver(t, c)
+
+	messages := rec.Messages()
+	if len(messages) != 1 {
+		t.Fatalf("recorded %d messages, want 1", len(messages))
+	}
+	if got := messages[0].Peer.Username; got != "joe" {
+		t.Errorf("Username: got %q, want %q", got, "joe")
+	}
+}
+
+func TestServerCertificate(t *testing.T) {
+	srv := smtptest.NewSTARTTLSServer(nil)
+	defer srv.Close()
+
+	cert := srv.Certificate()
+	if cert == nil {
+		t.Fatal("Certificate returned nil for a TLS server")
+	}
+	if len(cert.DNSNames) != 1 || cert.DNSNames[0] != "localhost" {
+		t.Errorf("DNSNames: got %q, want [\"localhost\"]", cert.DNSNames)
+	}
+
+	block, rest := pem.Decode(srv.CertPEM())
+	if block == nil {
+		t.Fatal("CertPEM did not return a PEM block")
+	}
+	if len(rest) != 0 {
+		t.Errorf("CertPEM returned %d extra bytes after the block", len(rest))
+	}
+	if block.Type != "CERTIFICATE" {
+		t.Errorf("PEM type: got %q, want %q", block.Type, "CERTIFICATE")
+	}
+	if string(block.Bytes) != string(cert.Raw) {
+		t.Error("CertPEM does not hold the certificate of the server")
+	}
+}
+
+func TestServerWithoutTLS(t *testing.T) {
+	srv := smtptest.NewServer(nil)
+	defer srv.Close()
+
+	if got := srv.Certificate(); got != nil {
+		t.Errorf("Certificate: got %v, want nil", got)
+	}
+	if got := srv.CertPEM(); got != nil {
+		t.Errorf("CertPEM: got %q, want nil", got)
+	}
+	if got := srv.ClientTLSConfig(); got != nil {
+		t.Errorf("ClientTLSConfig: got %v, want nil", got)
+	}
+}
+
+// TestServerCustomCertificate makes sure that a Start method keeps a
+// certificate that the test supplied. The certificate is out of date, so a
+// client that verifies it must refuse the connection.
+func TestServerCustomCertificate(t *testing.T) {
+	expired := expiredCert(t)
+
+	srv := smtptest.NewUnstartedServer(nil)
+	srv.TLS = &tls.Config{Certificates: []tls.Certificate{expired}}
+	srv.StartSTARTTLS()
+	defer srv.Close()
+
+	if got := srv.Certificate().NotAfter; !got.Equal(expired.Leaf.NotAfter) {
+		t.Errorf("NotAfter: got %v, want %v", got, expired.Leaf.NotAfter)
+	}
+
+	c := dialPlain(t, srv.Addr)
+	defer func() { _ = c.Close() }()
+
+	err := c.StartTLS(srv.ClientTLSConfig())
+	if err == nil {
+		t.Fatal("STARTTLS succeeded with an out of date certificate")
+	}
+
+	var invalid x509.CertificateInvalidError
+	if !errors.As(err, &invalid) || invalid.Reason != x509.Expired {
+		t.Errorf("STARTTLS error: got %v, want an out of date certificate", err)
+	}
+}
+
+func TestServerCloseUnstarted(t *testing.T) {
+	srv := smtptest.NewUnstartedServer(nil)
+	addr := srv.Listener.Addr().String()
+
+	srv.Close()
+	srv.Close()
+
+	if _, err := net.DialTimeout("tcp", addr, time.Second); err == nil {
+		t.Errorf("the listener on %s still accepts connections after Close", addr)
+	}
+}
+
+func TestServerCloseTwice(t *testing.T) {
+	srv := smtptest.NewServer(nil)
+
+	srv.Close()
+	srv.Close()
+}
+
+// expiredCert returns a self-signed certificate for "localhost" that ran out
+// one hour in the past.
+func expiredCert(t *testing.T) tls.Certificate {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate the key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "localhost"},
+		NotBefore:             time.Now().Add(-24 * time.Hour),
+		NotAfter:              time.Now().Add(-time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create the certificate: %v", err)
+	}
+
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse the certificate: %v", err)
+	}
+
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key, Leaf: leaf}
+}

--- a/smtptest/smtptest_test.go
+++ b/smtptest/smtptest_test.go
@@ -10,10 +10,12 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"math/big"
 	"net"
 	"net/smtp"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -65,25 +67,8 @@ func dialTLS(t *testing.T, srv *smtptest.Server) *smtp.Client {
 func deliver(t *testing.T, c *smtp.Client) {
 	t.Helper()
 
-	if err := c.Mail(testSender); err != nil {
-		t.Fatalf("MAIL FROM: %v", err)
-	}
-	if err := c.Rcpt(testRecipient); err != nil {
-		t.Fatalf("RCPT TO: %v", err)
-	}
-
-	w, err := c.Data()
-	if err != nil {
-		t.Fatalf("DATA: %v", err)
-	}
-	if _, err := w.Write([]byte(testBody)); err != nil {
-		t.Fatalf("write the body: %v", err)
-	}
-	if err := w.Close(); err != nil {
-		t.Fatalf("close the body: %v", err)
-	}
-	if err := c.Quit(); err != nil {
-		t.Fatalf("QUIT: %v", err)
+	if err := smtptest.Send(c, testSender, []string{testRecipient}, testBody); err != nil {
+		t.Fatalf("send the message: %v", err)
 	}
 }
 
@@ -227,6 +212,22 @@ func TestServerCertificate(t *testing.T) {
 	}
 }
 
+// TestServerKeyPEM makes sure that CertPEM and KeyPEM are a pair, which a
+// server under test can load from two files.
+func TestServerKeyPEM(t *testing.T) {
+	srv := smtptest.NewSTARTTLSServer(nil)
+	defer srv.Close()
+
+	pair, err := tls.X509KeyPair(srv.CertPEM(), srv.KeyPEM())
+	if err != nil {
+		t.Fatalf("X509KeyPair from CertPEM and KeyPEM: %v", err)
+	}
+
+	if len(pair.Certificate) != 1 || string(pair.Certificate[0]) != string(srv.Certificate().Raw) {
+		t.Error("the pair does not hold the certificate of the server")
+	}
+}
+
 func TestServerWithoutTLS(t *testing.T) {
 	srv := smtptest.NewServer(nil)
 	defer srv.Close()
@@ -236,6 +237,9 @@ func TestServerWithoutTLS(t *testing.T) {
 	}
 	if got := srv.CertPEM(); got != nil {
 		t.Errorf("CertPEM: got %q, want nil", got)
+	}
+	if got := srv.KeyPEM(); got != nil {
+		t.Errorf("KeyPEM: got %q, want nil", got)
 	}
 	if got := srv.ClientTLSConfig(); got != nil {
 		t.Errorf("ClientTLSConfig: got %v, want nil", got)
@@ -294,6 +298,37 @@ func TestServerDialNotStarted(t *testing.T) {
 	defer srv.Close()
 
 	srv.Dial()
+}
+
+// TestServerDialAfterServeError makes sure that Dial reports why the server
+// stopped. Without the report, a test only sees a dial error and no reason.
+func TestServerDialAfterServeError(t *testing.T) {
+	srv := smtptest.NewUnstartedServer(nil)
+	srv.Config.BaseContext = func(net.Listener) context.Context { return nil }
+	srv.Start()
+
+	// Serve stops on its own here, so the test waits for that to happen.
+	// Close would panic on the same error, so this test does not call it.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		got := dialPanic(srv)
+		if got != nil && strings.Contains(fmt.Sprint(got), "BaseContext") {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Dial did not report the reason of the stop: got %v", got)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// dialPanic returns the panic value of Dial, or nil when Dial did not panic.
+func dialPanic(srv *smtptest.Server) (value any) {
+	defer func() { value = recover() }()
+
+	c := srv.Dial()
+	_ = c.Close()
+	return nil
 }
 
 func TestServerCloseUnstarted(t *testing.T) {


### PR DESCRIPTION
A new sub-package, `github.com/chrj/smtpd/v2/smtptest`. It runs a real
server on the loopback interface, so a test can drive an SMTP client end to
end.

## Why

A project that tests an SMTP client against `smtpd` writes the same 150
lines every time: mint a certificate, open a listener on a port that the
system chooses, start `Serve` in a goroutine, and shut it down again. The
work has nothing to do with the behavior under test, and the certificate
part is easy to get wrong.

## The shape

The package follows `net/http/httptest`. There is no `*testing.T`
parameter, so the package also works from a benchmark, a fuzz target or
`_examples`. A setup fault that a test cannot correct causes a panic,
as `httptest.newLocalListener` does.

| Function | Transport |
|----------|-----------|
| `NewServer` | Plain SMTP. |
| `NewSTARTTLSServer` | Plain SMTP, with STARTTLS in the reply to EHLO. |
| `NewTLSServer` | TLS before the greeting, as SMTPS on port 465. |
| `NewUnstartedServer` | None yet. Change `Config` or `TLS`, then call a `Start` method. |

`Recorder` is the counterpart of `httptest.ResponseRecorder`. It is an
`smtpd.Handler` that keeps the messages that it receives:

```go
rec := &smtptest.Recorder{}
srv := smtptest.NewSTARTTLSServer(rec.Handler)
defer srv.Close()

sendWithTheClientUnderTest(srv.Addr, srv.ClientTLSConfig())

if got := rec.Messages()[0].Sender; got != "sender@example.org" {
    t.Errorf("Sender: got %q, want %q", got, "sender@example.org")
}
```

`Recorder.Handler` reads the body into memory and then puts an equal stream
back on `env.Data`. A stage that runs after it reads the same bytes, so the
`Recorder` also works in front of a real delivery handler.

## Dial

`Dial` opens a connection and returns a `*smtp.Client` that completed the
handshake of the transport. A test that only needs a working client no
longer builds one:

```go
c := srv.Dial()
defer func() { _ = c.Quit() }()

if err := c.Auth(smtp.PlainAuth("", "joe", "secret", srv.Host)); err != nil {
    t.Fatalf("AUTH: %v", err)
}
```

The name is `Dial` and not `Client`, because each call opens one connection.
`httptest.Client` does no I/O and returns the same client every time.

The server gives its address in three forms: `Addr` for `net.Dial`, and
`Host` and `Port` for a client that takes them apart. `smtp.PlainAuth`
compares its host argument against the name that the client dialed, which is
`Host`.

## Send and Cmd

`Send` runs one transaction on a client: MAIL FROM, RCPT TO, DATA and QUIT.
It returns the first error, so a test can read the reply code of a
rejection. `Cmd` sends one raw command and compares the reply code, for a
command that `net/smtp` does not send, such as XCLIENT or PROXY.

Both take an `*smtp.Client` and not a `*smtptest.Server`, so a test of an
SMTP server of your own can use them against a server that this package did
not start.

`KeyPEM` returns the private key. With `CertPEM` it makes the pair that such
a server loads from two files.

`Dial` now reports why the server stopped. A bad configuration gave a dial
error and no reason before. `Close` accepts a closed listener from
`Shutdown` for the same case, because the result of `Serve` is the better
message.

## Why a TCP listener and not a pipe

The package tests real SMTP clients, and most of them take an address and
not a connection. `smtp.SendMail` takes an address. The SMTP probe of
`prometheus-ssl-exporter` takes a domain and a port from a configuration
file. An in-memory server reaches only the clients that accept a connection
that the test injects.

A pipe also has no address. `Peer.Addr` becomes `pipe`, so the RBL, the rate
limit and the SPF middleware lose the field that they read. `httptest` uses
a real listener for the same reasons.

A test that still wants another transport replaces `Listener` before a
`Start` method. The README names what such a listener costs.

## Certificates

Both TLS servers present a self-signed certificate for `localhost`,
`127.0.0.1` and `::1`. The test binary generates it one time and every
server in the binary shares it. `ClientTLSConfig()`, `Certificate()` and
`CertPEM()` pass it to the client under test.

A test that must present its own certificate sets `Server.TLS` before a
`Start` method. The `Start` methods keep that certificate and add the
default one only when the configuration holds none. This is the rule that
`httptest.StartTLS` uses, and it covers an out of date or wrong certificate
without more API.

## Tests

The tests drive `net/smtp` against the server:

- Delivery over a plain connection, over STARTTLS, and over implicit TLS,
  through `Dial`. Each one reads the envelope, the body and the TLS state
  back from a `Recorder`.
- `Host` and `Port` hold the parts of `Addr`, and `Dial` panics on a server
  that is not started.
- STARTTLS is in the reply to EHLO for `NewSTARTTLSServer` only. An implicit
  TLS server does not advertise it, because the connection is already
  secure.
- AUTH with `middleware.Authenticator`, which sets `Peer.Username`.
- A certificate that the test supplied and that ran out. The client refuses
  the connection with `x509.Expired`, which shows that the `Start` method
  kept the certificate.
- `Certificate`, `CertPEM` and `ClientTLSConfig` return nil for a server
  without TLS.
- `Close` on a server that never started, and `Close` two times.
- `Recorder`: the record of the envelope, the restored body, the copy of the
  recipients, a read error, `Reset`, and the use as a middleware stage.
- `Send` gives back a 550 from a `CheckRecipient` middleware as a
  `*textproto.Error`, and `Cmd` compares the reply code of XCLIENT.
- `CertPEM` and `KeyPEM` make a pair that `tls.X509KeyPair` accepts.
- `Dial` names the reason after `Serve` stopped on a `BaseContext` that
  returns nil.

`go test ./...` and `golangci-lint run ./...` are clean. The race detector
does not run on my machine (`unsupported VMA range` on this arm64 kernel),
so CI is the first race build of this code.

## Follow-up

`helpers_test.go` holds its own `runserver`, `runsslserver`,
`runImplicitTLSServer` and certificate builder. These can move to
`smtptest`. That change touches most test files in the root package, so it
is better as a separate pull request.
