### PR TITLE
test: run the smtpd tests on smtptest.

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,10 @@ itself.
 If the server stopped, `Dial` panics with the reason from `Serve`. A test
 with a bad configuration reads that reason instead of a dial error.
 
+`Close` waits five seconds for the sessions that are still open, then closes
+their connections and writes one line to stderr. A test that ends with a
+connection open is the usual cause, so `Close` does not fail for it.
+
 ### Send and Cmd
 
 `Send` runs one transaction on a client: MAIL FROM, RCPT TO, DATA and QUIT.

--- a/auth_test.go
+++ b/auth_test.go
@@ -2,12 +2,12 @@ package smtpd_test
 
 import (
 	"context"
-	"crypto/tls"
 	"net/smtp"
 	"strings"
 	"testing"
 
 	"github.com/chrj/smtpd/v2"
+	"github.com/chrj/smtpd/v2/smtptest"
 )
 
 // captureAuthState records the credentials Authenticate was given plus the
@@ -35,17 +35,10 @@ func captureAuth(state *captureAuthState) smtpd.Middleware {
 func TestAUTHNoArgs(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, acceptAuth())
-	defer closer()
+	srv := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, acceptAuth())
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
-	if err := c.StartTLS(&tls.Config{InsecureSkipVerify: true}); err != nil {
-		t.Fatalf("STARTTLS failed: %v", err)
-	}
-	if err := cmd(c.Text, 502, "AUTH"); err != nil {
+	c := srv.Dial()
+	if err := smtptest.Cmd(c.Text, 502, "AUTH"); err != nil {
 		t.Fatalf("AUTH with no mechanism didn't 502: %v", err)
 	}
 	_ = c.Quit()
@@ -55,18 +48,11 @@ func TestAUTHWithoutAuthenticator(t *testing.T) {
 	t.Parallel()
 
 	// No Authenticate middleware is registered, so AUTH must be rejected.
-	addr, closer := runsslserver(t, &smtpd.Server{Logger: testLogger(t), Handler: serveAssert(t)})
-	defer closer()
+	srv := runsslserver(t, &smtpd.Server{Logger: testLogger(t), Handler: serveAssert(t)})
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
-	if err := c.StartTLS(&tls.Config{InsecureSkipVerify: true}); err != nil {
-		t.Fatalf("STARTTLS failed: %v", err)
-	}
+	c := srv.Dial()
 	// StartTLS re-issues EHLO, so HeloName is already set.
-	if err := cmd(c.Text, 502, "AUTH PLAIN Zm9vAGJhcgBxdXV4"); err != nil {
+	if err := smtptest.Cmd(c.Text, 502, "AUTH PLAIN Zm9vAGJhcgBxdXV4"); err != nil {
 		t.Fatalf("AUTH without authenticator didn't 502: %v", err)
 	}
 	_ = c.Quit()
@@ -75,24 +61,18 @@ func TestAUTHWithoutAuthenticator(t *testing.T) {
 func TestAUTHBeforeHELO(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, acceptAuth())
-	defer closer()
+	srv := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, acceptAuth())
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
-	if err := c.StartTLS(&tls.Config{InsecureSkipVerify: true}); err != nil {
-		t.Fatalf("STARTTLS failed: %v", err)
-	}
+	c := srv.Dial()
 	// Note: StartTLS re-does EHLO, so we need a fresh connection instead.
 	_ = c.Quit()
 
-	c2, err := smtp.Dial(addr)
+	// A fresh connection stays in plain text, so AUTH arrives before HELO.
+	c2, err := smtp.Dial(srv.Addr)
 	if err != nil {
 		t.Fatalf("Dial failed: %v", err)
 	}
-	if err := cmd(c2.Text, 502, "AUTH PLAIN Zm9vAGJhcgBxdXV4"); err != nil {
+	if err := smtptest.Cmd(c2.Text, 502, "AUTH PLAIN Zm9vAGJhcgBxdXV4"); err != nil {
 		t.Fatalf("AUTH before HELO didn't 502: %v", err)
 	}
 	_ = c2.Quit()
@@ -101,17 +81,13 @@ func TestAUTHBeforeHELO(t *testing.T) {
 func TestAUTHWithoutTLS(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runserver(t, &smtpd.Server{Logger: testLogger(t)}, acceptAuth())
-	defer closer()
+	srv := runserver(t, &smtpd.Server{Logger: testLogger(t)}, acceptAuth())
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	c := srv.Dial()
 	if err := c.Hello("localhost"); err != nil {
 		t.Fatalf("HELO failed: %v", err)
 	}
-	if err := cmd(c.Text, 502, "AUTH PLAIN Zm9vAGJhcgBxdXV4"); err != nil {
+	if err := smtptest.Cmd(c.Text, 502, "AUTH PLAIN Zm9vAGJhcgBxdXV4"); err != nil {
 		t.Fatalf("AUTH without TLS didn't 502: %v", err)
 	}
 	_ = c.Quit()
@@ -120,17 +96,10 @@ func TestAUTHWithoutTLS(t *testing.T) {
 func TestAUTHUnknownMechanism(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, acceptAuth())
-	defer closer()
+	srv := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, acceptAuth())
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
-	if err := c.StartTLS(&tls.Config{InsecureSkipVerify: true}); err != nil {
-		t.Fatalf("STARTTLS failed: %v", err)
-	}
-	if err := cmd(c.Text, 502, "AUTH WHATEVER"); err != nil {
+	c := srv.Dial()
+	if err := smtptest.Cmd(c.Text, 502, "AUTH WHATEVER"); err != nil {
 		t.Fatalf("AUTH WHATEVER didn't 502: %v", err)
 	}
 	_ = c.Quit()
@@ -139,17 +108,10 @@ func TestAUTHUnknownMechanism(t *testing.T) {
 func TestAUTHPLAINBadBase64(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, acceptAuth())
-	defer closer()
+	srv := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, acceptAuth())
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
-	if err := c.StartTLS(&tls.Config{InsecureSkipVerify: true}); err != nil {
-		t.Fatalf("STARTTLS failed: %v", err)
-	}
-	if err := cmd(c.Text, 502, "AUTH PLAIN !!!not-base64!!!"); err != nil {
+	c := srv.Dial()
+	if err := smtptest.Cmd(c.Text, 502, "AUTH PLAIN !!!not-base64!!!"); err != nil {
 		t.Fatalf("AUTH PLAIN bad base64 didn't 502: %v", err)
 	}
 	_ = c.Quit()
@@ -158,18 +120,11 @@ func TestAUTHPLAINBadBase64(t *testing.T) {
 func TestAUTHPLAINWrongParts(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, acceptAuth())
-	defer closer()
+	srv := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, acceptAuth())
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
-	if err := c.StartTLS(&tls.Config{InsecureSkipVerify: true}); err != nil {
-		t.Fatalf("STARTTLS failed: %v", err)
-	}
+	c := srv.Dial()
 	// "foo\x00bar" - only two parts, PLAIN requires three.
-	if err := cmd(c.Text, 502, "AUTH PLAIN Zm9vAGJhcg=="); err != nil {
+	if err := smtptest.Cmd(c.Text, 502, "AUTH PLAIN Zm9vAGJhcg=="); err != nil {
 		t.Fatalf("AUTH PLAIN malformed didn't 502: %v", err)
 	}
 	_ = c.Quit()
@@ -179,18 +134,11 @@ func TestAUTHPLAINCapturesUsername(t *testing.T) {
 	t.Parallel()
 
 	cap := &captureAuthState{}
-	addr, closer := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, captureAuth(cap))
-	defer closer()
+	srv := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, captureAuth(cap))
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
-	if err := c.StartTLS(&tls.Config{InsecureSkipVerify: true}); err != nil {
-		t.Fatalf("STARTTLS failed: %v", err)
-	}
+	c := srv.Dial()
 	// "\x00foo\x00bar"
-	if err := c.Auth(smtp.PlainAuth("", "foo", "bar", "127.0.0.1")); err != nil {
+	if err := c.Auth(smtp.PlainAuth("", "foo", "bar", srv.Host)); err != nil {
 		t.Fatalf("Auth failed: %v", err)
 	}
 	if err := c.Mail("sender@example.org"); err != nil {
@@ -208,17 +156,10 @@ func TestAUTHPLAINCapturesUsername(t *testing.T) {
 func TestAUTHLOGINBadBase64Username(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, acceptAuth())
-	defer closer()
+	srv := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, acceptAuth())
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
-	if err := c.StartTLS(&tls.Config{InsecureSkipVerify: true}); err != nil {
-		t.Fatalf("STARTTLS failed: %v", err)
-	}
-	if err := cmd(c.Text, 502, "AUTH LOGIN !!!"); err != nil {
+	c := srv.Dial()
+	if err := smtptest.Cmd(c.Text, 502, "AUTH LOGIN !!!"); err != nil {
 		t.Fatalf("AUTH LOGIN bad base64 didn't 502: %v", err)
 	}
 	_ = c.Quit()
@@ -227,21 +168,14 @@ func TestAUTHLOGINBadBase64Username(t *testing.T) {
 func TestAUTHLOGINBadBase64Password(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, acceptAuth())
-	defer closer()
+	srv := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, acceptAuth())
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
-	if err := c.StartTLS(&tls.Config{InsecureSkipVerify: true}); err != nil {
-		t.Fatalf("STARTTLS failed: %v", err)
-	}
+	c := srv.Dial()
 	// Kick off LOGIN with valid username, then send a garbage password.
-	if err := cmd(c.Text, 334, "AUTH LOGIN Zm9v"); err != nil {
+	if err := smtptest.Cmd(c.Text, 334, "AUTH LOGIN Zm9v"); err != nil {
 		t.Fatalf("AUTH LOGIN failed: %v", err)
 	}
-	if err := cmd(c.Text, 502, "!!!"); err != nil {
+	if err := smtptest.Cmd(c.Text, 502, "!!!"); err != nil {
 		t.Fatalf("LOGIN bad-base64 password didn't 502: %v", err)
 	}
 	_ = c.Quit()
@@ -250,17 +184,10 @@ func TestAUTHLOGINBadBase64Password(t *testing.T) {
 func TestAUTHRejected(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, rejectAuth())
-	defer closer()
+	srv := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, rejectAuth())
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
-	if err := c.StartTLS(&tls.Config{InsecureSkipVerify: true}); err != nil {
-		t.Fatalf("STARTTLS failed: %v", err)
-	}
-	if err := cmd(c.Text, 550, "AUTH PLAIN Zm9vAGJhcgBxdXV4"); err != nil {
+	c := srv.Dial()
+	if err := smtptest.Cmd(c.Text, 550, "AUTH PLAIN Zm9vAGJhcgBxdXV4"); err != nil {
 		t.Fatalf("authenticator error not mapped to 550: %v", err)
 	}
 	_ = c.Quit()
@@ -273,16 +200,12 @@ func TestAUTHInsecureAllowed(t *testing.T) {
 
 	// No TLSConfig at all: AllowInsecureAuth is the only reason AUTH is
 	// reachable on this listener.
-	addr, closer := runserver(t, &smtpd.Server{
+	srv := runserver(t, &smtpd.Server{
 		Logger:            testLogger(t),
 		AllowInsecureAuth: true,
 	}, captureAuth(state))
-	defer closer()
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	c := srv.Dial()
 	if err := c.Hello("localhost"); err != nil {
 		t.Fatalf("HELO failed: %v", err)
 	}
@@ -294,7 +217,7 @@ func TestAUTHInsecureAllowed(t *testing.T) {
 		t.Fatalf("PLAIN not offered on a plain connection, got mechanisms %q", mechs)
 	}
 
-	if err := c.Auth(smtp.PlainAuth("", "foo", "bar", "127.0.0.1")); err != nil {
+	if err := c.Auth(smtp.PlainAuth("", "foo", "bar", srv.Host)); err != nil {
 		t.Fatalf("AUTH over a plain connection failed: %v", err)
 	}
 	if state.gotUser != "foo" {
@@ -321,13 +244,9 @@ func TestAUTHInsecureDeniedByDefault(t *testing.T) {
 
 	// Same listener as above but with AllowInsecureAuth left at its zero
 	// value, which must keep AUTH both unadvertised and unusable.
-	addr, closer := runserver(t, &smtpd.Server{Logger: testLogger(t)}, acceptAuth())
-	defer closer()
+	srv := runserver(t, &smtpd.Server{Logger: testLogger(t)}, acceptAuth())
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	c := srv.Dial()
 	if err := c.Hello("localhost"); err != nil {
 		t.Fatalf("HELO failed: %v", err)
 	}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -2,79 +2,14 @@ package smtpd_test
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
-	"crypto/tls"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
 	"errors"
 	"io"
 	"log/slog"
-	"math/big"
-	"net"
-	"net/textproto"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/chrj/smtpd/v2"
+	"github.com/chrj/smtpd/v2/smtptest"
 )
-
-// testCert returns a freshly-minted self-signed localhost cert, cached for the
-// rest of the test run so we only pay the keygen cost once.
-var testCert = sync.OnceValues(generateLocalhostCert)
-
-func generateLocalhostCert() (tls.Certificate, error) {
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		return tls.Certificate{}, err
-	}
-
-	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
-	if err != nil {
-		return tls.Certificate{}, err
-	}
-
-	tmpl := &x509.Certificate{
-		SerialNumber:          serial,
-		Subject:               pkix.Name{CommonName: "localhost"},
-		NotBefore:             time.Now().Add(-time.Hour),
-		NotAfter:              time.Now().Add(24 * time.Hour),
-		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		DNSNames:              []string{"localhost"},
-		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
-		IsCA:                  true,
-		BasicConstraintsValid: true,
-	}
-
-	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
-	if err != nil {
-		return tls.Certificate{}, err
-	}
-
-	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
-	if err != nil {
-		return tls.Certificate{}, err
-	}
-
-	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
-	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
-	return tls.X509KeyPair(certPEM, keyPEM)
-}
-
-// localhostTLSCert fetches the cached test certificate, failing the test if
-// generation ever errors.
-func localhostTLSCert(t *testing.T) tls.Certificate {
-	t.Helper()
-	cert, err := testCert()
-	if err != nil {
-		t.Fatalf("generate test cert: %v", err)
-	}
-	return cert
-}
 
 // testLogger returns a discard logger so tests don't spam stdout.
 // Flip to t.Log / os.Stdout during debugging.
@@ -82,78 +17,51 @@ func testLogger(_ *testing.T) *slog.Logger {
 	return slog.New(slog.DiscardHandler)
 }
 
-// cmd issues a raw textproto command and asserts the expected reply code.
-func cmd(c *textproto.Conn, expectedCode int, format string, args ...any) error {
-	id, err := c.Cmd(format, args...)
-	if err != nil {
-		return err
-	}
-	c.StartResponse(id)
-	_, _, err = c.ReadResponse(expectedCode)
-	c.EndResponse(id)
-	return err
-}
-
-// runserver starts an in-process server on a random localhost port and returns
-// the address plus a closer that stops the listener. Optional middlewares are
-// registered before Serve.
-func runserver(t *testing.T, server *smtpd.Server, mws ...smtpd.Middleware) (addr string, closer func()) {
+// newTestServer wraps server and its middlewares in a test server that stops
+// when the test ends. The caller starts it.
+func newTestServer(t *testing.T, server *smtpd.Server, mws []smtpd.Middleware) *smtptest.Server {
 	t.Helper()
+
+	ts := smtptest.NewUnstartedServer(nil)
+	ts.Config = server
 
 	for _, m := range mws {
-		server.Use(m)
+		ts.Config.Use(m)
 	}
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("Listen failed: %v", err)
-	}
-
-	go func() {
-		_ = server.Serve(ln)
-	}()
-
-	done := make(chan bool)
-	go func() {
-		<-done
-		_ = ln.Close()
-	}()
-
-	return ln.Addr().String(), func() {
-		done <- true
-	}
+	t.Cleanup(ts.Close)
+	return ts
 }
 
-// runsslserver wires a localhost TLS cert into server.TLSConfig and delegates
-// to runserver.
-func runsslserver(t *testing.T, server *smtpd.Server, mws ...smtpd.Middleware) (addr string, closer func()) {
+// runserver starts an in-process server on a random localhost port. Optional
+// middlewares are registered before Serve.
+func runserver(t *testing.T, server *smtpd.Server, mws ...smtpd.Middleware) *smtptest.Server {
 	t.Helper()
 
-	server.TLSConfig = &tls.Config{Certificates: []tls.Certificate{localhostTLSCert(t)}}
-	return runserver(t, server, mws...)
+	ts := newTestServer(t, server, mws)
+	ts.Start()
+	return ts
 }
 
-// runImplicitTLSServer starts a server on a tls.NewListener-wrapped listener,
-// so that newSession sees a *tls.Conn and forces the handshake before the
-// SMTP session begins. Mirrors the "SMTPS on :465" deployment.
-func runImplicitTLSServer(t *testing.T, server *smtpd.Server, mws ...smtpd.Middleware) (addr string, closer func()) {
+// runsslserver starts a server that advertises STARTTLS with a certificate
+// for localhost. Dial on the result upgrades the connection.
+func runsslserver(t *testing.T, server *smtpd.Server, mws ...smtpd.Middleware) *smtptest.Server {
 	t.Helper()
 
-	for _, m := range mws {
-		server.Use(m)
-	}
+	ts := newTestServer(t, server, mws)
+	ts.StartSTARTTLS()
+	return ts
+}
 
-	tlsCfg := &tls.Config{Certificates: []tls.Certificate{localhostTLSCert(t)}}
+// runImplicitTLSServer starts a server behind a TLS handshake, so that
+// newSession sees a *tls.Conn and forces the handshake before the SMTP
+// session begins. Mirrors the "SMTPS on :465" deployment.
+func runImplicitTLSServer(t *testing.T, server *smtpd.Server, mws ...smtpd.Middleware) *smtptest.Server {
+	t.Helper()
 
-	raw, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("Listen failed: %v", err)
-	}
-	ln := tls.NewListener(raw, tlsCfg)
-
-	go func() { _ = server.Serve(ln) }()
-
-	return ln.Addr().String(), func() { _ = ln.Close() }
+	ts := newTestServer(t, server, mws)
+	ts.StartTLS()
+	return ts
 }
 
 // acceptAuth returns a Middleware that accepts every AUTH attempt.

--- a/logging_test.go
+++ b/logging_test.go
@@ -2,13 +2,12 @@ package smtpd_test
 
 import (
 	"context"
-	"crypto/tls"
 	"log/slog"
-	"net/smtp"
 	"sync"
 	"testing"
 
 	"github.com/chrj/smtpd/v2"
+	"github.com/chrj/smtpd/v2/smtptest"
 )
 
 // capturedRecord is a flattened log record: the message plus every attribute,
@@ -99,38 +98,18 @@ func logHandler(message string) smtpd.Handler {
 func TestPhaseLoggingReplacesPhase(t *testing.T) {
 	rec := &recorder{}
 
-	addr, closer := runsslserver(t, &smtpd.Server{
+	srv := runsslserver(t, &smtpd.Server{
 		Logger:  slog.New(rec.handler()),
 		Handler: logHandler("delivered"),
 	})
-	defer closer()
 
-	c, err := smtp.Dial(addr)
+	err := smtptest.Send(srv.Dial(),
+		"sender@example.org",
+		[]string{"recipient@example.net"},
+		"This is the email body\n",
+	)
 	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
-
-	if err := c.StartTLS(&tls.Config{InsecureSkipVerify: true}); err != nil {
-		t.Fatalf("STARTTLS failed: %v", err)
-	}
-	if err := c.Mail("sender@example.org"); err != nil {
-		t.Fatalf("MAIL failed: %v", err)
-	}
-	if err := c.Rcpt("recipient@example.net"); err != nil {
-		t.Fatalf("RCPT failed: %v", err)
-	}
-	wc, err := c.Data()
-	if err != nil {
-		t.Fatalf("DATA failed: %v", err)
-	}
-	if _, err := wc.Write([]byte("This is the email body\n")); err != nil {
-		t.Fatalf("Data write failed: %v", err)
-	}
-	if err := wc.Close(); err != nil {
-		t.Fatalf("Data close failed: %v", err)
-	}
-	if err := c.Quit(); err != nil {
-		t.Fatalf("QUIT failed: %v", err)
+		t.Fatalf("send the message: %v", err)
 	}
 
 	delivered, ok := rec.find("delivered")

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -3,11 +3,11 @@ package smtpd_test
 import (
 	"context"
 	"net"
-	"net/smtp"
 	"net/textproto"
 	"testing"
 
 	"github.com/chrj/smtpd/v2"
+	"github.com/chrj/smtpd/v2/smtptest"
 )
 
 // capturedAddr holds the peer.Addr value recorded by capturePeerAddr.
@@ -41,14 +41,10 @@ func dialRawProxy(t *testing.T, addr string) (*textproto.Conn, net.Conn) {
 func TestPROXYDisabled(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runserver(t, &smtpd.Server{Logger: testLogger(t)})
-	defer closer()
+	srv := runserver(t, &smtpd.Server{Logger: testLogger(t)})
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
-	if err := cmd(c.Text, 550, "PROXY TCP4 1.2.3.4 5.6.7.8 12345 25"); err != nil {
+	c := srv.Dial()
+	if err := smtptest.Cmd(c.Text, 550, "PROXY TCP4 1.2.3.4 5.6.7.8 12345 25"); err != nil {
 		t.Fatalf("PROXY with protocol disabled didn't 550: %v", err)
 	}
 }
@@ -56,15 +52,14 @@ func TestPROXYDisabled(t *testing.T) {
 func TestPROXYTooFewFields(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runserver(t, &smtpd.Server{
+	srv := runserver(t, &smtpd.Server{
 		EnableProxyProtocol: true,
 		Logger:              testLogger(t),
 	})
-	defer closer()
 
-	tp, raw := dialRawProxy(t, addr)
+	tp, raw := dialRawProxy(t, srv.Addr)
 	defer func() { _ = raw.Close() }()
-	if err := cmd(tp, 502, "PROXY TCP4 1.2.3.4 5.6.7.8 12345"); err != nil {
+	if err := smtptest.Cmd(tp, 502, "PROXY TCP4 1.2.3.4 5.6.7.8 12345"); err != nil {
 		t.Fatalf("PROXY with too few fields didn't 502: %v", err)
 	}
 }
@@ -72,15 +67,14 @@ func TestPROXYTooFewFields(t *testing.T) {
 func TestPROXYBadPort(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runserver(t, &smtpd.Server{
+	srv := runserver(t, &smtpd.Server{
 		EnableProxyProtocol: true,
 		Logger:              testLogger(t),
 	})
-	defer closer()
 
-	tp, raw := dialRawProxy(t, addr)
+	tp, raw := dialRawProxy(t, srv.Addr)
 	defer func() { _ = raw.Close() }()
-	if err := cmd(tp, 502, "PROXY TCP4 1.2.3.4 5.6.7.8 notanumber 25"); err != nil {
+	if err := smtptest.Cmd(tp, 502, "PROXY TCP4 1.2.3.4 5.6.7.8 notanumber 25"); err != nil {
 		t.Fatalf("PROXY with bad port didn't 502: %v", err)
 	}
 }
@@ -89,30 +83,29 @@ func TestPROXYOverridesPeerAddr(t *testing.T) {
 	t.Parallel()
 
 	cap := &capturedAddr{}
-	addr, closer := runserver(t, &smtpd.Server{
+	srv := runserver(t, &smtpd.Server{
 		EnableProxyProtocol: true,
 		Logger:              testLogger(t),
 	}, capturePeerAddr(cap))
-	defer closer()
 
-	conn, err := net.Dial("tcp", addr)
+	conn, err := net.Dial("tcp", srv.Addr)
 	if err != nil {
 		t.Fatalf("Dial failed: %v", err)
 	}
 	defer func() { _ = conn.Close() }()
 
 	tp := textproto.NewConn(conn)
-	if err := cmd(tp, 220, "PROXY TCP4 42.42.42.42 5.6.7.8 4242 25"); err != nil {
+	if err := smtptest.Cmd(tp, 220, "PROXY TCP4 42.42.42.42 5.6.7.8 4242 25"); err != nil {
 		t.Fatalf("PROXY failed: %v", err)
 	}
 
 	// Hand the live connection over to net/smtp, using a bufio.Reader so
 	// NewClient re-reads the 220 we just saw? No - NewClient expects the
 	// banner, so continue with raw textproto commands instead.
-	if err := cmd(tp, 250, "HELO localhost"); err != nil {
+	if err := smtptest.Cmd(tp, 250, "HELO localhost"); err != nil {
 		t.Fatalf("HELO failed: %v", err)
 	}
-	if err := cmd(tp, 250, "MAIL FROM:<sender@example.org>"); err != nil {
+	if err := smtptest.Cmd(tp, 250, "MAIL FROM:<sender@example.org>"); err != nil {
 		t.Fatalf("MAIL failed: %v", err)
 	}
 	if cap.got == nil {
@@ -121,5 +114,5 @@ func TestPROXYOverridesPeerAddr(t *testing.T) {
 	if cap.got.String() != "42.42.42.42:4242" {
 		t.Fatalf("peer.Addr after PROXY = %s, want 42.42.42.42:4242", cap.got)
 	}
-	_ = cmd(tp, 221, "QUIT")
+	_ = smtptest.Cmd(tp, 221, "QUIT")
 }

--- a/smtpd_test.go
+++ b/smtpd_test.go
@@ -2,7 +2,6 @@ package smtpd_test
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"net"
 	"net/smtp"
@@ -13,22 +12,19 @@ import (
 	"time"
 
 	"github.com/chrj/smtpd/v2"
+	"github.com/chrj/smtpd/v2/smtptest"
 )
 
 func TestSMTP(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runserver(t, &smtpd.Server{
+	srv := runserver(t, &smtpd.Server{
 		Logger: testLogger(t),
 	})
-	defer closer()
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	c := srv.Dial()
 
-	if err := cmd(c.Text, 250, "HELO localhost"); err != nil {
+	if err := smtptest.Cmd(c.Text, 250, "HELO localhost"); err != nil {
 		t.Fatalf("HELO failed: %v", err)
 	}
 
@@ -79,7 +75,7 @@ func TestSMTP(t *testing.T) {
 		t.Fatal("Unexpected support for VRFY")
 	}
 
-	if err := cmd(c.Text, 250, "NOOP"); err != nil {
+	if err := smtptest.Cmd(c.Text, 250, "NOOP"); err != nil {
 		t.Fatalf("NOOP failed: %v", err)
 	}
 
@@ -91,8 +87,11 @@ func TestSMTP(t *testing.T) {
 func TestListenAndServe(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runserver(t, &smtpd.Server{})
-	closer()
+	// Stop a running server so that ListenAndServe gets a free address. The
+	// second Close from the cleanup of runserver does nothing.
+	ts := runserver(t, &smtpd.Server{})
+	addr := ts.Addr
+	ts.Close()
 
 	server := &smtpd.Server{
 		Logger: testLogger(t),
@@ -134,13 +133,13 @@ func dialUntilReady(addr string, timeout time.Duration) (*smtp.Client, error) {
 func TestSTARTTLS(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runsslserver(t, &smtpd.Server{
+	srv := runsslserver(t, &smtpd.Server{
 		Logger: testLogger(t),
 	}, acceptAuth())
 
-	defer closer()
-
-	c, err := smtp.Dial(addr)
+	// This test reads the state before and after the upgrade, so it opens a
+	// plain connection instead of the one from Dial.
+	c, err := smtp.Dial(srv.Addr)
 	if err != nil {
 		t.Fatalf("Dial failed: %v", err)
 	}
@@ -149,11 +148,11 @@ func TestSTARTTLS(t *testing.T) {
 		t.Fatal("AUTH supported before TLS")
 	}
 
-	if err := c.StartTLS(&tls.Config{InsecureSkipVerify: true}); err != nil {
+	if err := c.StartTLS(srv.ClientTLSConfig()); err != nil {
 		t.Fatalf("STARTTLS failed: %v", err)
 	}
 
-	if err := c.StartTLS(&tls.Config{InsecureSkipVerify: true}); err == nil {
+	if err := c.StartTLS(srv.ClientTLSConfig()); err == nil {
 		t.Fatal("STARTTLS worked twice")
 	}
 
@@ -169,7 +168,7 @@ func TestSTARTTLS(t *testing.T) {
 		t.Fatal("LOGIN AUTH not supported after TLS")
 	}
 
-	if err := c.Auth(smtp.PlainAuth("foo", "foo", "bar", "127.0.0.1")); err != nil {
+	if err := c.Auth(smtp.PlainAuth("foo", "foo", "bar", srv.Host)); err != nil {
 		t.Fatalf("Auth failed: %v", err)
 	}
 
@@ -208,13 +207,11 @@ func TestSTARTTLS(t *testing.T) {
 func TestConnectionCheck(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runserver(t, &smtpd.Server{
+	srv := runserver(t, &smtpd.Server{
 		Logger: testLogger(t),
 	}, rejectConnSMTPErr())
 
-	defer closer()
-
-	if _, err := smtp.Dial(addr); err == nil {
+	if _, err := smtp.Dial(srv.Addr); err == nil {
 		t.Fatal("Dial succeeded despite ConnectionCheck")
 	}
 
@@ -223,13 +220,11 @@ func TestConnectionCheck(t *testing.T) {
 func TestConnectionCheckSimpleError(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runserver(t, &smtpd.Server{
+	srv := runserver(t, &smtpd.Server{
 		Logger: testLogger(t),
 	}, rejectConnPlainErr())
 
-	defer closer()
-
-	if _, err := smtp.Dial(addr); err == nil {
+	if _, err := smtp.Dial(srv.Addr); err == nil {
 		t.Fatal("Dial succeeded despite ConnectionCheck")
 	}
 
@@ -238,16 +233,11 @@ func TestConnectionCheckSimpleError(t *testing.T) {
 func TestHELOCheck(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runserver(t, &smtpd.Server{
+	srv := runserver(t, &smtpd.Server{
 		Logger: testLogger(t),
 	}, heloAssert(t))
 
-	defer closer()
-
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	c := srv.Dial()
 
 	if err := c.Hello("foobar.local"); err == nil {
 		t.Fatal("Unexpected HELO success")
@@ -258,16 +248,11 @@ func TestHELOCheck(t *testing.T) {
 func TestSenderCheck(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runserver(t, &smtpd.Server{
+	srv := runserver(t, &smtpd.Server{
 		Logger: testLogger(t),
 	}, rejectSender())
 
-	defer closer()
-
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	c := srv.Dial()
 
 	if err := c.Mail("sender@example.org"); err == nil {
 		t.Fatal("Unexpected MAIL success")
@@ -278,16 +263,11 @@ func TestSenderCheck(t *testing.T) {
 func TestRecipientCheck(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runserver(t, &smtpd.Server{
+	srv := runserver(t, &smtpd.Server{
 		Logger: testLogger(t),
 	}, rejectRecipient())
 
-	defer closer()
-
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	c := srv.Dial()
 
 	if err := c.Mail("sender@example.org"); err != nil {
 		t.Fatalf("Mail failed: %v", err)
@@ -302,18 +282,14 @@ func TestRecipientCheck(t *testing.T) {
 func TestMAILFromWithESMTPParams(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runserver(t, &smtpd.Server{Logger: testLogger(t)})
-	defer closer()
+	srv := runserver(t, &smtpd.Server{Logger: testLogger(t)})
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	c := srv.Dial()
 
-	if err := cmd(c.Text, 250, "EHLO localhost"); err != nil {
+	if err := smtptest.Cmd(c.Text, 250, "EHLO localhost"); err != nil {
 		t.Fatalf("EHLO failed: %v", err)
 	}
-	if err := cmd(c.Text, 250, "MAIL FROM:<sender@example.org> SIZE=123 BODY=8BITMIME AUTH=<>"); err != nil {
+	if err := smtptest.Cmd(c.Text, 250, "MAIL FROM:<sender@example.org> SIZE=123 BODY=8BITMIME AUTH=<>"); err != nil {
 		t.Fatalf("MAIL with ESMTP params failed: %v", err)
 	}
 	if err := c.Quit(); err != nil {
@@ -324,21 +300,17 @@ func TestMAILFromWithESMTPParams(t *testing.T) {
 func TestMAILFromRejectsOversizeDeclaration(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runserver(t, &smtpd.Server{
+	srv := runserver(t, &smtpd.Server{
 		Logger:         testLogger(t),
 		MaxMessageSize: 32,
 	})
-	defer closer()
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	c := srv.Dial()
 
-	if err := cmd(c.Text, 250, "EHLO localhost"); err != nil {
+	if err := smtptest.Cmd(c.Text, 250, "EHLO localhost"); err != nil {
 		t.Fatalf("EHLO failed: %v", err)
 	}
-	if err := cmd(c.Text, 552, "MAIL FROM:<sender@example.org> SIZE=33"); err != nil {
+	if err := smtptest.Cmd(c.Text, 552, "MAIL FROM:<sender@example.org> SIZE=33"); err != nil {
 		t.Fatalf("MAIL with oversize SIZE didn't 552: %v", err)
 	}
 	_ = c.Quit()
@@ -347,18 +319,14 @@ func TestMAILFromRejectsOversizeDeclaration(t *testing.T) {
 func TestMAILFromRejectsUnknownESMTPParam(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runserver(t, &smtpd.Server{Logger: testLogger(t)})
-	defer closer()
+	srv := runserver(t, &smtpd.Server{Logger: testLogger(t)})
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	c := srv.Dial()
 
-	if err := cmd(c.Text, 250, "EHLO localhost"); err != nil {
+	if err := smtptest.Cmd(c.Text, 250, "EHLO localhost"); err != nil {
 		t.Fatalf("EHLO failed: %v", err)
 	}
-	if err := cmd(c.Text, 555, "MAIL FROM:<sender@example.org> FROB=1"); err != nil {
+	if err := smtptest.Cmd(c.Text, 555, "MAIL FROM:<sender@example.org> FROB=1"); err != nil {
 		t.Fatalf("MAIL with unknown param didn't 555: %v", err)
 	}
 	_ = c.Quit()
@@ -367,18 +335,14 @@ func TestMAILFromRejectsUnknownESMTPParam(t *testing.T) {
 func TestMAILFromRejectsParamsWithoutEHLO(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runserver(t, &smtpd.Server{Logger: testLogger(t)})
-	defer closer()
+	srv := runserver(t, &smtpd.Server{Logger: testLogger(t)})
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	c := srv.Dial()
 
-	if err := cmd(c.Text, 250, "HELO localhost"); err != nil {
+	if err := smtptest.Cmd(c.Text, 250, "HELO localhost"); err != nil {
 		t.Fatalf("HELO failed: %v", err)
 	}
-	if err := cmd(c.Text, 555, "MAIL FROM:<sender@example.org> SIZE=1"); err != nil {
+	if err := smtptest.Cmd(c.Text, 555, "MAIL FROM:<sender@example.org> SIZE=1"); err != nil {
 		t.Fatalf("MAIL with params after HELO didn't 555: %v", err)
 	}
 	_ = c.Quit()
@@ -483,13 +447,9 @@ func TestResetHook(t *testing.T) {
 	t.Parallel()
 
 	var rec resetRecord
-	addr, closer := runserver(t, &smtpd.Server{Logger: testLogger(t)}, resetCounter(&rec))
-	defer closer()
+	srv := runserver(t, &smtpd.Server{Logger: testLogger(t)}, resetCounter(&rec))
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	c := srv.Dial()
 	// Explicit RSET.
 	if err := c.Reset(); err != nil {
 		t.Fatalf("Reset failed: %v", err)
@@ -520,13 +480,9 @@ func TestDisconnectHook(t *testing.T) {
 	t.Parallel()
 
 	var rec disconnectRecord
-	addr, closer := runserver(t, &smtpd.Server{Logger: testLogger(t)}, disconnectCounter(&rec))
-	defer closer()
+	srv := runserver(t, &smtpd.Server{Logger: testLogger(t)}, disconnectCounter(&rec))
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	c := srv.Dial()
 	_ = c.Quit()
 
 	count, lastErr := waitDisconnect(&rec, time.Second)
@@ -546,10 +502,9 @@ func TestDisconnectHookAbruptClose(t *testing.T) {
 	t.Parallel()
 
 	var rec disconnectRecord
-	addr, closer := runserver(t, &smtpd.Server{Logger: testLogger(t)}, disconnectCounter(&rec))
-	defer closer()
+	srv := runserver(t, &smtpd.Server{Logger: testLogger(t)}, disconnectCounter(&rec))
 
-	conn, err := net.Dial("tcp", addr)
+	conn, err := net.Dial("tcp", srv.Addr)
 	if err != nil {
 		t.Fatalf("Dial failed: %v", err)
 	}
@@ -577,10 +532,9 @@ func TestDisconnectHookAbruptClose(t *testing.T) {
 // the handshake failure.
 func TestDisconnectHookImplicitTLSHandshakeFail(t *testing.T) {
 	var rec disconnectRecord
-	addr, closer := runImplicitTLSServer(t, &smtpd.Server{Logger: testLogger(t)}, disconnectCounter(&rec))
-	defer closer()
+	srv := runImplicitTLSServer(t, &smtpd.Server{Logger: testLogger(t)}, disconnectCounter(&rec))
 
-	conn, err := net.Dial("tcp", addr)
+	conn, err := net.Dial("tcp", srv.Addr)
 	if err != nil {
 		t.Fatalf("Dial failed: %v", err)
 	}
@@ -604,10 +558,11 @@ func TestDisconnectHookImplicitTLSHandshakeFail(t *testing.T) {
 // the handshake error.
 func TestDisconnectHookSTARTTLSHandshakeFail(t *testing.T) {
 	var rec disconnectRecord
-	addr, closer := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, disconnectCounter(&rec))
-	defer closer()
+	srv := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, disconnectCounter(&rec))
 
-	c, err := smtp.Dial(addr)
+	// Dial would upgrade the connection, and this test drives STARTTLS
+	// itself, so it opens a plain connection.
+	c, err := smtp.Dial(srv.Addr)
 	if err != nil {
 		t.Fatalf("Dial failed: %v", err)
 	}
@@ -615,7 +570,7 @@ func TestDisconnectHookSTARTTLSHandshakeFail(t *testing.T) {
 		t.Fatalf("HELO failed: %v", err)
 	}
 	// Ask for STARTTLS and get the 220 go-ahead.
-	if err := cmd(c.Text, 220, "STARTTLS"); err != nil {
+	if err := smtptest.Cmd(c.Text, 220, "STARTTLS"); err != nil {
 		t.Fatalf("STARTTLS failed: %v", err)
 	}
 	// Send garbage where a TLS ClientHello is expected.
@@ -639,14 +594,13 @@ func TestDisconnectHookSTARTTLSHandshakeFail(t *testing.T) {
 func TestDisconnectHookDataInterrupted(t *testing.T) {
 	var rec disconnectRecord
 	readErr := make(chan error, 1)
-	addr, closer := runserver(t,
+	srv := runserver(t,
 		&smtpd.Server{Logger: testLogger(t)},
 		smtpd.Middleware{Handler: interruptServe(readErr)},
 		disconnectCounter(&rec),
 	)
-	defer closer()
 
-	conn, err := net.Dial("tcp", addr)
+	conn, err := net.Dial("tcp", srv.Addr)
 	if err != nil {
 		t.Fatalf("Dial failed: %v", err)
 	}
@@ -654,16 +608,16 @@ func TestDisconnectHookDataInterrupted(t *testing.T) {
 	if _, _, err := tp.ReadResponse(220); err != nil {
 		t.Fatalf("banner: %v", err)
 	}
-	if err := cmd(tp, 250, "HELO localhost"); err != nil {
+	if err := smtptest.Cmd(tp, 250, "HELO localhost"); err != nil {
 		t.Fatalf("HELO: %v", err)
 	}
-	if err := cmd(tp, 250, "MAIL FROM:<a@example.org>"); err != nil {
+	if err := smtptest.Cmd(tp, 250, "MAIL FROM:<a@example.org>"); err != nil {
 		t.Fatalf("MAIL: %v", err)
 	}
-	if err := cmd(tp, 250, "RCPT TO:<b@example.net>"); err != nil {
+	if err := smtptest.Cmd(tp, 250, "RCPT TO:<b@example.net>"); err != nil {
 		t.Fatalf("RCPT: %v", err)
 	}
-	if err := cmd(tp, 354, "DATA"); err != nil {
+	if err := smtptest.Cmd(tp, 354, "DATA"); err != nil {
 		t.Fatalf("DATA: %v", err)
 	}
 	// Partial body, then close without the terminating ".\r\n".
@@ -693,13 +647,9 @@ func TestSenderInContext(t *testing.T) {
 	t.Parallel()
 
 	wants := &senderInRecipientWants{wantSender: "sender@example.org", wantSenderSeen: true}
-	addr, closer := runserver(t, &smtpd.Server{Logger: testLogger(t)}, senderInRecipient(t, wants))
-	defer closer()
+	srv := runserver(t, &smtpd.Server{Logger: testLogger(t)}, senderInRecipient(t, wants))
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	c := srv.Dial()
 	if err := c.Mail("sender@example.org"); err != nil {
 		t.Fatalf("Mail failed: %v", err)
 	}
@@ -726,19 +676,17 @@ func TestSenderInContext(t *testing.T) {
 func TestMaxConnections(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runserver(t, &smtpd.Server{
+	srv := runserver(t, &smtpd.Server{
 		MaxConnections: 1,
 		Logger:         testLogger(t),
 	})
 
-	defer closer()
-
-	c1, err := smtp.Dial(addr)
+	c1, err := smtp.Dial(srv.Addr)
 	if err != nil {
 		t.Fatalf("Dial failed: %v", err)
 	}
 
-	_, err = smtp.Dial(addr)
+	_, err = smtp.Dial(srv.Addr)
 	if err == nil {
 		t.Fatal("Dial succeeded despite MaxConnections = 1")
 	}
@@ -749,14 +697,12 @@ func TestMaxConnections(t *testing.T) {
 func TestNoMaxConnections(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runserver(t, &smtpd.Server{
+	srv := runserver(t, &smtpd.Server{
 		MaxConnections: -1,
 		Logger:         testLogger(t),
 	})
 
-	defer closer()
-
-	c1, err := smtp.Dial(addr)
+	c1, err := smtp.Dial(srv.Addr)
 	if err != nil {
 		t.Fatalf("Dial failed: %v", err)
 	}
@@ -767,17 +713,12 @@ func TestNoMaxConnections(t *testing.T) {
 func TestMaxRecipients(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runserver(t, &smtpd.Server{
+	srv := runserver(t, &smtpd.Server{
 		MaxRecipients: 1,
 		Logger:        testLogger(t),
 	})
 
-	defer closer()
-
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	c := srv.Dial()
 
 	if err := c.Mail("sender@example.org"); err != nil {
 		t.Fatalf("MAIL failed: %v", err)
@@ -804,17 +745,12 @@ func TestInterruptedDATA(t *testing.T) {
 	// starts, but reading to EOF on an interrupted connection must fail -
 	// otherwise the server would commit partial messages.
 	readErr := make(chan error, 1)
-	addr, closer := runserver(t, &smtpd.Server{
+	srv := runserver(t, &smtpd.Server{
 		Logger:  testLogger(t),
 		Handler: interruptServe(readErr),
 	})
 
-	defer closer()
-
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	c := srv.Dial()
 
 	if err := c.Mail("sender@example.org"); err != nil {
 		t.Fatalf("MAIL failed: %v", err)
@@ -849,23 +785,21 @@ func TestInterruptedDATA(t *testing.T) {
 func TestTimeoutClose(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runserver(t, &smtpd.Server{
+	srv := runserver(t, &smtpd.Server{
 		MaxConnections: 1,
 		ReadTimeout:    time.Second,
 		WriteTimeout:   time.Second,
 		Logger:         testLogger(t),
 	})
 
-	defer closer()
-
-	c1, err := smtp.Dial(addr)
+	c1, err := smtp.Dial(srv.Addr)
 	if err != nil {
 		t.Fatalf("Dial failed: %v", err)
 	}
 
 	time.Sleep(time.Second * 2)
 
-	c2, err := smtp.Dial(addr)
+	c2, err := smtp.Dial(srv.Addr)
 	if err != nil {
 		t.Fatalf("Dial failed: %v", err)
 	}
@@ -888,22 +822,14 @@ func TestTimeoutClose(t *testing.T) {
 func TestTLSTimeout(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runsslserver(t, &smtpd.Server{
+	srv := runsslserver(t, &smtpd.Server{
 		ReadTimeout:  time.Second * 2,
 		WriteTimeout: time.Second * 2,
 		Logger:       testLogger(t),
 	})
 
-	defer closer()
-
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
-
-	if err := c.StartTLS(&tls.Config{InsecureSkipVerify: true}); err != nil {
-		t.Fatalf("STARTTLS failed: %v", err)
-	}
+	// Dial sends STARTTLS, so the session below runs on a TLS connection.
+	c := srv.Dial()
 
 	time.Sleep(time.Second)
 
@@ -934,16 +860,11 @@ func TestTLSTimeout(t *testing.T) {
 func TestLongLine(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runserver(t, &smtpd.Server{
+	srv := runserver(t, &smtpd.Server{
 		Logger: testLogger(t),
 	})
 
-	defer closer()
-
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	c := srv.Dial()
 
 	if err := c.Mail(fmt.Sprintf("%s@example.org", strings.Repeat("x", 65*1024))); err == nil {
 		t.Fatalf("MAIL failed: %v", err)
@@ -964,46 +885,19 @@ func TestLongLine(t *testing.T) {
 func TestTLSListener(t *testing.T) {
 	t.Parallel()
 
-	cfg := &tls.Config{
-		Certificates: []tls.Certificate{localhostTLSCert(t)},
-	}
+	srv := runImplicitTLSServer(t, &smtpd.Server{Logger: testLogger(t)}, tlsAuthAssert(t))
 
-	ln, err := tls.Listen("tcp", "127.0.0.1:0", cfg)
-	if err != nil {
-		t.Fatalf("tls.Listen failed: %v", err)
-	}
-	defer func() { _ = ln.Close() }()
-
-	addr := ln.Addr().String()
-
-	server := &smtpd.Server{
-		Logger: testLogger(t),
-	}
-	server.Use(tlsAuthAssert(t))
-
-	go func() {
-		_ = server.Serve(ln)
-	}()
-
-	conn, err := tls.Dial("tcp", addr, &tls.Config{InsecureSkipVerify: true})
-	if err != nil {
-		t.Fatalf("couldn't connect to tls socket: %v", err)
-	}
-
-	c, err := smtp.NewClient(conn, "localhost")
-	if err != nil {
-		t.Fatalf("couldn't create client: %v", err)
-	}
+	c := srv.Dial()
 
 	if err := c.Hello("localhost"); err != nil {
 		t.Fatalf("HELO failed: %v", err)
 	}
 
-	if err := cmd(c.Text, 334, "AUTH PLAIN"); err != nil {
+	if err := smtptest.Cmd(c.Text, 334, "AUTH PLAIN"); err != nil {
 		t.Fatalf("AUTH didn't work: %v", err)
 	}
 
-	if err := cmd(c.Text, 235, "Zm9vAGJhcgBxdXV4"); err != nil {
+	if err := smtptest.Cmd(c.Text, 235, "Zm9vAGJhcgBxdXV4"); err != nil {
 		t.Fatalf("AUTH didn't work: %v", err)
 	}
 

--- a/smtptest/smtptest.go
+++ b/smtptest/smtptest.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"net/smtp"
+	"os"
 	"strconv"
 	"time"
 
@@ -214,12 +215,28 @@ func (s *Server) Close() {
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
 
-	// A server that stopped on its own already closed the listener. The
-	// reason for that stop comes from serveErr below, which is the better
-	// message.
-	if err := s.Config.Shutdown(ctx); err != nil && !errors.Is(err, net.ErrClosed) {
+	switch err := s.Config.Shutdown(ctx); {
+	case err == nil:
+	case errors.Is(err, net.ErrClosed):
+		// A server that stopped on its own already closed the listener. The
+		// reason for that stop comes from serveErr below, which is the
+		// better message.
+	case errors.Is(err, context.DeadlineExceeded):
+		// A test that ends with a connection still open reaches this every
+		// time. Shutdown closed those connections, so the server is down.
+		// The note goes to stderr because a test failure is the usual cause,
+		// and a panic here would hide it.
+		fmt.Fprintf(os.Stderr,
+			"smtptest: the server on %s still had open sessions after %s, and closed them\n",
+			s.Addr, shutdownTimeout)
+	default:
 		panic(fmt.Sprintf("smtptest: stop the server on %s: %v", s.Addr, err))
 	}
+
+	// Serve leaves the listener open when Shutdown reached the server first,
+	// because it stops before it registers the close. Close the listener
+	// here so that the port is free for the next server.
+	_ = s.Listener.Close()
 
 	// Serve reports every fault of the accept loop here. A test that ignores
 	// it sees an empty Recorder and no reason for it.

--- a/smtptest/smtptest_test.go
+++ b/smtptest/smtptest_test.go
@@ -343,6 +343,21 @@ func TestServerCloseUnstarted(t *testing.T) {
 	}
 }
 
+// TestServerCloseRightAfterStart makes sure that Close frees the port even
+// when it reaches the server before Serve did. Serve stops without a close of
+// the listener in that order.
+func TestServerCloseRightAfterStart(t *testing.T) {
+	srv := smtptest.NewServer(nil)
+	addr := srv.Addr
+	srv.Close()
+
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	if err == nil {
+		_ = conn.Close()
+		t.Errorf("the listener on %s still accepts connections after Close", addr)
+	}
+}
+
 func TestServerCloseTwice(t *testing.T) {
 	srv := smtptest.NewServer(nil)
 

--- a/xclient_test.go
+++ b/xclient_test.go
@@ -1,26 +1,22 @@
 package smtpd_test
 
 import (
-	"net/smtp"
 	"testing"
 
 	"github.com/chrj/smtpd/v2"
+	"github.com/chrj/smtpd/v2/smtptest"
 )
 
 func TestXCLIENTNoArgs(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runserver(t, &smtpd.Server{
+	srv := runserver(t, &smtpd.Server{
 		EnableXCLIENT: true,
 		Logger:        testLogger(t),
 	})
-	defer closer()
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
-	if err := cmd(c.Text, 502, "XCLIENT"); err != nil {
+	c := srv.Dial()
+	if err := smtptest.Cmd(c.Text, 502, "XCLIENT"); err != nil {
 		t.Fatalf("XCLIENT with no args didn't 502: %v", err)
 	}
 }
@@ -28,14 +24,10 @@ func TestXCLIENTNoArgs(t *testing.T) {
 func TestXCLIENTDisabled(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runserver(t, &smtpd.Server{Logger: testLogger(t)})
-	defer closer()
+	srv := runserver(t, &smtpd.Server{Logger: testLogger(t)})
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
-	if err := cmd(c.Text, 550, "XCLIENT NAME=ignored"); err != nil {
+	c := srv.Dial()
+	if err := smtptest.Cmd(c.Text, 550, "XCLIENT NAME=ignored"); err != nil {
 		t.Fatalf("XCLIENT with extension disabled didn't 550: %v", err)
 	}
 }
@@ -43,17 +35,13 @@ func TestXCLIENTDisabled(t *testing.T) {
 func TestXCLIENTMalformedItem(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runserver(t, &smtpd.Server{
+	srv := runserver(t, &smtpd.Server{
 		EnableXCLIENT: true,
 		Logger:        testLogger(t),
 	})
-	defer closer()
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
-	if err := cmd(c.Text, 502, "XCLIENT NAMEwithoutequals"); err != nil {
+	c := srv.Dial()
+	if err := smtptest.Cmd(c.Text, 502, "XCLIENT NAMEwithoutequals"); err != nil {
 		t.Fatalf("XCLIENT with malformed item didn't 502: %v", err)
 	}
 }
@@ -61,17 +49,13 @@ func TestXCLIENTMalformedItem(t *testing.T) {
 func TestXCLIENTBadPort(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runserver(t, &smtpd.Server{
+	srv := runserver(t, &smtpd.Server{
 		EnableXCLIENT: true,
 		Logger:        testLogger(t),
 	})
-	defer closer()
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
-	if err := cmd(c.Text, 502, "XCLIENT PORT=notanumber"); err != nil {
+	c := srv.Dial()
+	if err := smtptest.Cmd(c.Text, 502, "XCLIENT PORT=notanumber"); err != nil {
 		t.Fatalf("XCLIENT with bad port didn't 502: %v", err)
 	}
 }
@@ -79,17 +63,13 @@ func TestXCLIENTBadPort(t *testing.T) {
 func TestXCLIENTUnknownAttribute(t *testing.T) {
 	t.Parallel()
 
-	addr, closer := runserver(t, &smtpd.Server{
+	srv := runserver(t, &smtpd.Server{
 		EnableXCLIENT: true,
 		Logger:        testLogger(t),
 	})
-	defer closer()
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
-	if err := cmd(c.Text, 502, "XCLIENT BOGUS=value"); err != nil {
+	c := srv.Dial()
+	if err := smtptest.Cmd(c.Text, 502, "XCLIENT BOGUS=value"); err != nil {
 		t.Fatalf("XCLIENT with unknown attribute didn't 502: %v", err)
 	}
 }
@@ -98,18 +78,14 @@ func TestXCLIENTProtoESMTP(t *testing.T) {
 	t.Parallel()
 
 	cap := &capturedAddr{}
-	addr, closer := runserver(t, &smtpd.Server{
+	srv := runserver(t, &smtpd.Server{
 		EnableXCLIENT: true,
 		Logger:        testLogger(t),
 	}, capturePeerAddr(cap))
-	defer closer()
 
-	c, err := smtp.Dial(addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
+	c := srv.Dial()
 	// Valid XCLIENT with PROTO=ESMTP and an ADDR/PORT that can be captured.
-	if err := cmd(c.Text, 220, "XCLIENT ADDR=9.9.9.9 PORT=999 PROTO=ESMTP"); err != nil {
+	if err := smtptest.Cmd(c.Text, 220, "XCLIENT ADDR=9.9.9.9 PORT=999 PROTO=ESMTP"); err != nil {
 		t.Fatalf("XCLIENT failed: %v", err)
 	}
 	if err := c.Hello("localhost"); err != nil {


### PR DESCRIPTION
The follow-up to #31. The tests of the root package now run on `smtptest`.

Net result: 536 lines out, 241 lines in.

## The helpers

`helpers_test.go` built a certificate, a listener, a goroutine and a closer
for every server. `smtptest` does all of that, so the three run functions
are now three lines each and give back the test server:

```go
func runsslserver(t *testing.T, server *smtpd.Server, mws ...smtpd.Middleware) *smtptest.Server {
	t.Helper()

	ts := newTestServer(t, server, mws)
	ts.StartSTARTTLS()
	return ts
}
```

`t.Cleanup` stops the server, so `defer closer()` is gone from every test.
The certificate builder and the local `cmd` function are gone as well.
`smtptest.Cmd` replaces `cmd`, and the certificate comes from the test
server.

## The call sites

`ClientTLSConfig` gives the client the certificate of the server, so
`InsecureSkipVerify` is gone from all 15 places that had it. The tests now
verify the certificate that they get.

`Dial` completes the handshake, so a dial and a STARTTLS command become one
line:

```go
c := srv.Dial()
```

Three tests still open the connection themselves, because `Dial` would do
too much:

- `TestSTARTTLS` reads the reply to EHLO before and after the upgrade.
- `TestDisconnectHookSTARTTLSHandshakeFail` sends the STARTTLS command and
  then bad bytes.
- The dials that must fail, such as `TestConnectionCheck` and the second
  connection of `TestMaxConnections`.

`logging_test.go` sends its message with `smtptest.Send`, which replaces 28
lines with 4.

`command_test.go` and `data_test.go` are in package `smtpd` and test
unexported code. They cannot import `smtptest`, and they do not use the
helpers, so this pull request does not touch them.

## Two faults in smtptest

The refactor found both. They are in the first commit, and each one broke a
test of the root package.

`smtpd.Serve` returns `ErrServerClosed` before it registers the close of the
listener. A `Close` that reaches the server before `Serve` did therefore
left the port bound with nothing to accept on it. `TestListenAndServe`
stops a server to get a free address, and the next server on that address
got connections that never saw a greeting. `Close` now closes the listener
itself.

`Close` also accepts a timeout from `Shutdown` now. A test that ends with a
connection still open reaches that timeout every time. `Shutdown` closes
those connections, so the server is down, and the panic only hid the real
failure of the test. `Close` writes one line to stderr instead.

`TestServerCloseRightAfterStart` covers the first fault.

## Tests

`go test ./...` passes, and `-count=5` passes. The run time of the root
package is 4.0s, the same as before this change. `golangci-lint run ./...`
is clean. The race detector does not run on my machine, so CI is the first
race build.
