### PR TITLE
docs: drop the Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Go smtpd v2 [![Go Reference](https://pkg.go.dev/badge/github.com/chrj/smtpd/v2.svg)](https://pkg.go.dev/github.com/chrj/smtpd/v2) [![Go Report Card](https://goreportcard.com/badge/github.com/chrj/smtpd/v2)](https://goreportcard.com/report/github.com/chrj/smtpd/v2)
+Go smtpd v2 [![Go Reference](https://pkg.go.dev/badge/github.com/chrj/smtpd/v2.svg)](https://pkg.go.dev/github.com/chrj/smtpd/v2)
 ========
 
 Package `smtpd` implements an SMTP server in Go.


### PR DESCRIPTION
The Go Report Card badge now reads `retired`.

`goreportcard.com` is sunset. The badge endpoint still answers with HTTP
200 and still returns a valid SVG, so a check of the status code or a
link checker does not catch it. The image itself reads:

```
go report: retired
```

A badge beside the name of the project that reads "retired" says the
wrong thing about the project.

The Go Reference badge stays. It renders.
