### PR TITLE
ci: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  # This repository tags releases by hand, so the prefix does not need to be a
+  # releasable type under release-please.
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: build
+      include: scope
+    groups:
+      go-deps:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Dependabot now watches this repository. It opens weekly pull requests for the Go modules and for the GitHub Actions.

## Configuration

Two ecosystems, both on a weekly schedule:

- `gomod` — grouped as `go-deps`, limited to minor and patch updates. A major update gets its own pull request, because it can break the build.
- `github-actions` — grouped as `actions`.

## Commit prefixes

The Go module updates use the `build` prefix, and the action updates use the `ci` prefix. Both keep the conventional commit format of this repository.

`vanguard` and `prometheus-ssl-exporter` use the `fix` prefix for Go modules. That prefix makes release-please cut a release from a dependency bump. This repository tags releases by hand, so the prefix does not need to be a releasable type.

## Effect

The actions of this repository are behind the current versions:

| Action | Pinned | Current |
| --- | --- | --- |
| `actions/checkout` | v4 | v6 |
| `actions/setup-go` | v5 | v6 |
| `golangci/golangci-lint-action` | v7 | v9 |

Dependabot opens pull requests for these after the merge.
