### PR TITLE
fix: contain a panic from a handler or a hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `PanicError` records a panic from a `Handler` or a middleware hook. `Value`
+  holds the value given to `panic`, and `Stack` holds the stack trace. The
+  `Disconnect` hooks receive it through their `err` argument.
+
+### Changed
+
+- A panic in a `Handler` or a middleware hook no longer stops the process. The
+  server writes the panic and the stack trace to the log at the `ERROR` level,
+  replies `421`, and closes that connection. Other sessions continue. A panic
+  in a `Disconnect` hook is contained the same way.
+
+  A server that must stop on a panic has to do the check in its own handler.
+
 ## [2.2.0] - 2026-08-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   A server that must stop on a panic has to do the check in its own handler.
 
+- A panic in `BaseContext` stops `Serve` with a `PanicError`, instead of
+  stopping the process. The hook runs once, before the accept loop.
+
+- A panic in `ConnContext` drops that connection only. The server writes the
+  panic to the log and keeps accepting. A `ConnContext` that returns a nil
+  context still stops `Serve`, because that fault repeats on every connection.
+
 ## [2.2.0] - 2026-08-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -196,6 +196,14 @@ smtpd.Middleware{
 A panic in a `Disconnect` hook is contained the same way, but it cannot
 reach a hook, so the server only writes it to the log.
 
+`BaseContext` and `ConnContext` run in the accept loop, not in a session, so
+they behave differently:
+
+| Hook | On a panic |
+| --- | --- |
+| `BaseContext` | `Serve` returns a `PanicError`. The hook runs once, before the accept loop, so the server never starts. |
+| `ConnContext` | The server writes the panic to the log, drops that connection, and keeps accepting. |
+
 Writing a handler
 -----------------
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,30 @@ is cleared after delivery or `RSET`.
 
 `Disconnect` always runs exactly once per session. `err` is nil on clean
 shutdown (QUIT or server `Shutdown`); non-nil if a TLS/scanner/DATA error
-terminated the session.
+terminated the session, or a `PanicError` if a hook panicked.
+
+### Panics
+
+A panic in `Server.Handler` or in a middleware hook stops that session only.
+The server writes the panic and the stack trace to the log at the `ERROR`
+level, replies `421`, and closes the connection. Other sessions continue.
+
+The `Disconnect` hooks receive the panic as a `smtpd.PanicError`. `Value`
+holds the value given to `panic` and `Stack` holds the stack trace:
+
+```go
+smtpd.Middleware{
+    Disconnect: func(ctx context.Context, peer smtpd.Peer, err error) {
+        var panicErr smtpd.PanicError
+        if errors.As(err, &panicErr) {
+            report(peer.Addr, panicErr.Value, panicErr.Stack)
+        }
+    },
+}
+```
+
+A panic in a `Disconnect` hook is contained the same way, but it cannot
+reach a hook, so the server only writes it to the log.
 
 Writing a handler
 -----------------

--- a/panic_test.go
+++ b/panic_test.go
@@ -3,6 +3,7 @@ package smtpd_test
 import (
 	"context"
 	"errors"
+	"net"
 	"net/smtp"
 	"strings"
 	"sync"
@@ -204,6 +205,105 @@ func TestPanicReachesDisconnectHook(t *testing.T) {
 	// recovered, or it gives an operator nothing to debug with.
 	if !strings.Contains(string(panicErr.Stack), "TestPanicReachesDisconnectHook") {
 		t.Fatalf("expected the stack to reach the handler that panicked, got:\n%s", panicErr.Stack)
+	}
+}
+
+// TestBaseContextPanicFailsServe verifies that a panic in BaseContext stops
+// Serve with a PanicError instead of stopping the process. BaseContext runs
+// once, before the accept loop, so the server never starts.
+func TestBaseContextPanicFailsServe(t *testing.T) {
+	t.Parallel()
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen failed: %v", err)
+	}
+	defer func() { _ = l.Close() }()
+
+	srv := &smtpd.Server{
+		Logger: testLogger(t),
+		BaseContext: func(_ net.Listener) context.Context {
+			panic("boom")
+		},
+	}
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(l) }()
+
+	select {
+	case err := <-serveErr:
+		var panicErr smtpd.PanicError
+		if !errors.As(err, &panicErr) {
+			t.Fatalf("expected a smtpd.PanicError from Serve, got %v", err)
+		}
+		if panicErr.Value != "boom" {
+			t.Fatalf("expected the panic value %q, got %v", "boom", panicErr.Value)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve did not return after BaseContext panicked")
+	}
+}
+
+// TestConnContextPanicKeepsServerAlive verifies that a panic in ConnContext
+// drops that connection only. ConnContext runs in the accept loop, once per
+// connection, so the loop has to continue accepting.
+func TestConnContextPanicKeepsServerAlive(t *testing.T) {
+	t.Parallel()
+
+	boom := panicOnce("boom")
+	ts := newTestServer(t, &smtpd.Server{
+		Logger: testLogger(t),
+		ConnContext: func(ctx context.Context, _ net.Conn) context.Context {
+			boom()
+			return ctx
+		},
+	}, nil)
+	ts.Start()
+
+	// The first connection hits the panic, so it never gets a greeting.
+	if err := sendMessage(t, ts.Addr); err == nil {
+		t.Fatal("expected an error on the connection that panicked")
+	}
+
+	// The accept loop survived, so a later transaction completes.
+	if err := sendMessage(t, ts.Addr); err != nil {
+		t.Fatalf("expected the second transaction to succeed, got %v", err)
+	}
+}
+
+// TestNilConnContextStopsServe verifies that a ConnContext which returns a
+// nil context still stops Serve. That is a fault in the configuration and
+// repeats on every connection, so it does not get the treatment of a panic.
+func TestNilConnContextStopsServe(t *testing.T) {
+	t.Parallel()
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen failed: %v", err)
+	}
+	defer func() { _ = l.Close() }()
+
+	srv := &smtpd.Server{
+		Logger:      testLogger(t),
+		ConnContext: func(_ context.Context, _ net.Conn) context.Context { return nil },
+	}
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(l) }()
+
+	c, err := net.Dial("tcp", l.Addr().String())
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	_ = c.Close()
+
+	select {
+	case err := <-serveErr:
+		if !strings.Contains(err.Error(), "ConnContext") {
+			t.Fatalf("expected the error to name ConnContext, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve did not return after ConnContext returned nil")
 	}
 }
 

--- a/panic_test.go
+++ b/panic_test.go
@@ -1,0 +1,234 @@
+package smtpd_test
+
+import (
+	"context"
+	"errors"
+	"net/smtp"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/chrj/smtpd/v2"
+)
+
+// panicOnce returns a function that panics the first time it runs, and does
+// nothing on every call after that. A hook that panics on every call would
+// also panic on the connection that tests whether the server survived.
+func panicOnce(value any) func() {
+	var mu sync.Mutex
+	var done bool
+
+	return func() {
+		mu.Lock()
+		defer mu.Unlock()
+		if done {
+			return
+		}
+		done = true
+		panic(value)
+	}
+}
+
+// sendMessage runs a full transaction against addr and returns the first
+// error the client sees.
+func sendMessage(t *testing.T, addr string) error {
+	t.Helper()
+
+	c, err := smtp.Dial(addr)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = c.Close() }()
+
+	if err := c.Mail("sender@example.org"); err != nil {
+		return err
+	}
+	if err := c.Rcpt("recipient@example.net"); err != nil {
+		return err
+	}
+	w, err := c.Data()
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write([]byte("This is the email body\n")); err != nil {
+		return err
+	}
+	return w.Close()
+}
+
+// TestHandlerPanicKeepsServerAlive verifies that a panic in Server.Handler is
+// contained: the client that triggered it gets a 421, and a later transaction
+// completes. Before the recovery, the panic unwound out of the goroutine of
+// the session and took the whole process down with it.
+func TestHandlerPanicKeepsServerAlive(t *testing.T) {
+	t.Parallel()
+
+	boom := panicOnce("boom")
+	srv := runserver(t, &smtpd.Server{
+		Logger: testLogger(t),
+		Handler: func(ctx context.Context, _ smtpd.Peer, _ *smtpd.Envelope) (context.Context, error) {
+			boom()
+			return ctx, nil
+		},
+	})
+
+	err := sendMessage(t, srv.Addr)
+	if err == nil {
+		t.Fatal("expected an error from the transaction that panicked")
+	}
+	if !strings.Contains(err.Error(), "421") {
+		t.Fatalf("expected a 421 reply, got %v", err)
+	}
+
+	if err := sendMessage(t, srv.Addr); err != nil {
+		t.Fatalf("expected the second transaction to succeed, got %v", err)
+	}
+}
+
+// TestMiddlewarePanicKeepsServerAlive verifies the same containment for a
+// panic in each middleware phase hook.
+func TestMiddlewarePanicKeepsServerAlive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mw   func(boom func()) smtpd.Middleware
+	}{
+		{
+			name: "CheckConnection",
+			mw: func(boom func()) smtpd.Middleware {
+				return smtpd.Middleware{
+					CheckConnection: func(ctx context.Context, _ smtpd.Peer) (context.Context, error) {
+						boom()
+						return ctx, nil
+					},
+				}
+			},
+		},
+		{
+			name: "CheckHelo",
+			mw: func(boom func()) smtpd.Middleware {
+				return smtpd.Middleware{
+					CheckHelo: func(ctx context.Context, _ smtpd.Peer, _ string) (context.Context, error) {
+						boom()
+						return ctx, nil
+					},
+				}
+			},
+		},
+		{
+			name: "CheckSender",
+			mw: func(boom func()) smtpd.Middleware {
+				return smtpd.Middleware{
+					CheckSender: func(ctx context.Context, _ smtpd.Peer, _ string) (context.Context, error) {
+						boom()
+						return ctx, nil
+					},
+				}
+			},
+		},
+		{
+			name: "CheckRecipient",
+			mw: func(boom func()) smtpd.Middleware {
+				return smtpd.Middleware{
+					CheckRecipient: func(ctx context.Context, _ smtpd.Peer, _ string) (context.Context, error) {
+						boom()
+						return ctx, nil
+					},
+				}
+			},
+		},
+		{
+			name: "Handler",
+			mw: func(boom func()) smtpd.Middleware {
+				return smtpd.Middleware{
+					Handler: func(ctx context.Context, _ smtpd.Peer, _ *smtpd.Envelope) (context.Context, error) {
+						boom()
+						return ctx, nil
+					},
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := runserver(t, &smtpd.Server{Logger: testLogger(t)}, test.mw(panicOnce("boom")))
+
+			if err := sendMessage(t, srv.Addr); err == nil {
+				t.Fatal("expected an error from the transaction that panicked")
+			}
+
+			// The hook no longer panics, so a later transaction proves the
+			// server kept running.
+			if err := sendMessage(t, srv.Addr); err != nil {
+				t.Fatalf("expected the second transaction to succeed, got %v", err)
+			}
+		})
+	}
+}
+
+// TestPanicReachesDisconnectHook verifies that the panic surfaces to the
+// Disconnect hook as a smtpd.PanicError carrying the value passed to panic.
+func TestPanicReachesDisconnectHook(t *testing.T) {
+	t.Parallel()
+
+	var rec disconnectRecord
+	boom := panicOnce("boom")
+	srv := runserver(t, &smtpd.Server{
+		Logger: testLogger(t),
+		Handler: func(ctx context.Context, _ smtpd.Peer, _ *smtpd.Envelope) (context.Context, error) {
+			boom()
+			return ctx, nil
+		},
+	}, disconnectCounter(&rec))
+
+	_ = sendMessage(t, srv.Addr)
+
+	count, lastErr := waitDisconnect(&rec, time.Second)
+	if count != 1 {
+		t.Fatalf("expected exactly 1 Disconnect call, got %d", count)
+	}
+
+	var panicErr smtpd.PanicError
+	if !errors.As(lastErr, &panicErr) {
+		t.Fatalf("expected a smtpd.PanicError, got %v", lastErr)
+	}
+	if panicErr.Value != "boom" {
+		t.Fatalf("expected the panic value %q, got %v", "boom", panicErr.Value)
+	}
+	// The stack must reach the frame that panicked, not only the frame that
+	// recovered, or it gives an operator nothing to debug with.
+	if !strings.Contains(string(panicErr.Stack), "TestPanicReachesDisconnectHook") {
+		t.Fatalf("expected the stack to reach the handler that panicked, got:\n%s", panicErr.Stack)
+	}
+}
+
+// TestDisconnectHookPanicKeepsServerAlive verifies that a panic in a
+// Disconnect hook is contained too. That hook runs from the deferred close of
+// the session, which is outside the recovery around the body of the session.
+func TestDisconnectHookPanicKeepsServerAlive(t *testing.T) {
+	t.Parallel()
+
+	boom := panicOnce("boom")
+	srv := runserver(t, &smtpd.Server{Logger: testLogger(t)}, smtpd.Middleware{
+		Disconnect: func(_ context.Context, _ smtpd.Peer, _ error) {
+			boom()
+		},
+	})
+
+	c, err := smtp.Dial(srv.Addr)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	_ = c.Quit()
+
+	// The panicking hook ran on that session. The process is still alive, so
+	// a later transaction completes.
+	if err := sendMessage(t, srv.Addr); err != nil {
+		t.Fatalf("expected a later transaction to succeed, got %v", err)
+	}
+}

--- a/session.go
+++ b/session.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"runtime/debug"
 	"strings"
 	"time"
 )
@@ -88,6 +89,15 @@ func (s *session) serve(ctx context.Context) {
 	// Closure so the deferred close sees the latest ctx after handlers
 	// have threaded values through it.
 	defer func() { s.close(ctx) }()
+
+	// Registered after the close defer, so it runs before it: the panic
+	// becomes a 421 reply while the connection is still open, and the close
+	// that follows reports it to the Disconnect hooks.
+	defer func() {
+		if v := recover(); v != nil {
+			ctx = s.recovered(ctx, v)
+		}
+	}()
 
 	// Implicit-TLS handshake (newSession) may have already failed; skip
 	// straight to the deferred close so Disconnect fires with closeErr.
@@ -215,7 +225,42 @@ func (s *session) close(ctx context.Context) context.Context {
 	}
 	s.closed = true
 	_ = s.writer.Flush()
-	s.server.disconnect(ctx, s.peer, s.closeErr)
+	s.notifyDisconnect(ctx)
 	_ = s.conn.Close()
 	return ctx
+}
+
+// recovered turns a panic from a Handler or a phase hook into a PanicError on
+// the session and a 421 reply. The connection closes afterwards, so the
+// client does not continue on a session whose state is unknown.
+func (s *session) recovered(ctx context.Context, v any) context.Context {
+	err := PanicError{Value: v, Stack: debug.Stack()}
+	s.setErr(err)
+
+	LoggerFromContext(ctx).ErrorContext(ctx, "recovered a panic",
+		slog.Any("panic", v),
+		slog.String("stack", string(err.Stack)),
+	)
+
+	if s.closed {
+		return ctx
+	}
+
+	return s.reply(ctx, 421, "Service not available, closing transmission channel")
+}
+
+// notifyDisconnect runs the Disconnect hooks. A panic in a hook is contained
+// here, because close runs from a deferred call in serve, after the recovery
+// around the body of the session.
+func (s *session) notifyDisconnect(ctx context.Context) {
+	defer func() {
+		if v := recover(); v != nil {
+			LoggerFromContext(ctx).ErrorContext(ctx, "recovered a panic in a Disconnect hook",
+				slog.Any("panic", v),
+				slog.String("stack", string(debug.Stack())),
+			)
+		}
+	}()
+
+	s.server.disconnect(ctx, s.peer, s.closeErr)
 }

--- a/smtpd.go
+++ b/smtpd.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -164,11 +165,15 @@ type Server struct {
 
 	// BaseContext optionally specifies a function that returns the base
 	// context for incoming connections. If nil, context.Background() is used.
+	// It runs once, before the accept loop, so a panic here stops Serve with
+	// a PanicError.
 	BaseContext func(net.Listener) context.Context
 
 	// ConnContext optionally specifies a function that modifies the context
 	// used for a new connection. The provided ctx is derived from BaseContext
-	// and has a per-connection cancel.
+	// and has a per-connection cancel. A panic here drops that connection
+	// only: the server logs it and keeps accepting. Returning a nil context
+	// stops Serve, because that fault repeats on every connection.
 	ConnContext func(ctx context.Context, conn net.Conn) context.Context
 
 	// Handler is the terminal delivery stage. It runs after every middleware
@@ -344,6 +349,52 @@ func (srv *Server) configureDefaults() error {
 	return nil
 }
 
+// errNilConnContext reports a ConnContext that returned a nil context. It
+// separates that fault, which repeats on every connection, from a panic,
+// which the accept loop survives.
+var errNilConnContext = errors.New("smtpd: ConnContext returned nil")
+
+// baseContext calls Server.BaseContext and contains a panic from it. The
+// hook runs once, before the accept loop, so a panic there stops Serve.
+func (srv *Server) baseContext(l net.Listener) (ctx context.Context, err error) {
+	if srv.BaseContext == nil {
+		return context.Background(), nil
+	}
+
+	defer func() {
+		if v := recover(); v != nil {
+			ctx, err = nil, PanicError{Value: v, Stack: debug.Stack()}
+		}
+	}()
+
+	ctx = srv.BaseContext(l)
+	if ctx == nil {
+		return nil, errors.New("smtpd: BaseContext returned nil")
+	}
+	return ctx, nil
+}
+
+// connContext calls Server.ConnContext and contains a panic from it. The hook
+// runs once per connection, so the caller drops that connection and keeps
+// accepting.
+func (srv *Server) connContext(in context.Context, conn net.Conn) (ctx context.Context, err error) {
+	if srv.ConnContext == nil {
+		return in, nil
+	}
+
+	defer func() {
+		if v := recover(); v != nil {
+			ctx, err = nil, PanicError{Value: v, Stack: debug.Stack()}
+		}
+	}()
+
+	ctx = srv.ConnContext(in, conn)
+	if ctx == nil {
+		return nil, errNilConnContext
+	}
+	return ctx, nil
+}
+
 // ListenAndServe opens a TCP listener on addr and serves SMTP on it.
 func (srv *Server) ListenAndServe(addr string) error {
 	if srv.inShutdown.Load() {
@@ -372,12 +423,9 @@ func (srv *Server) Serve(l net.Listener) error {
 	srv.listener = l
 	srv.mu.Unlock()
 
-	baseCtx := context.Background()
-	if srv.BaseContext != nil {
-		baseCtx = srv.BaseContext(l)
-		if baseCtx == nil {
-			return errors.New("smtpd: BaseContext returned nil")
-		}
+	baseCtx, err := srv.baseContext(l)
+	if err != nil {
+		return err
 	}
 
 	var limiter chan struct{}
@@ -400,13 +448,25 @@ func (srv *Server) Serve(l net.Listener) error {
 		}
 
 		connCtx, cancel := context.WithCancel(baseCtx)
-		if srv.ConnContext != nil {
-			connCtx = srv.ConnContext(connCtx, conn)
-			if connCtx == nil {
-				cancel()
-				_ = conn.Close()
-				return errors.New("smtpd: ConnContext returned nil")
+		connCtx, err = srv.connContext(connCtx, conn)
+		if err != nil {
+			// Read the address before the close, so the log line still
+			// names the peer.
+			peer := conn.RemoteAddr().String()
+			cancel()
+			_ = conn.Close()
+
+			// A nil context is a fault in the configuration and repeats on
+			// every connection, so it stops the server. A panic stops the
+			// one connection that caused it.
+			if errors.Is(err, errNilConnContext) {
+				return err
 			}
+			srv.newLogger().Error("dropped a connection",
+				slog.String("peer", peer),
+				slog.Any("error", err),
+			)
+			continue
 		}
 
 		ctx, s := srv.newSession(connCtx, conn)

--- a/smtpd.go
+++ b/smtpd.go
@@ -60,11 +60,28 @@ func (e Error) Error() string {
 	return fmt.Sprintf("%d %s", e.Code, e.Message)
 }
 
+// PanicError is the error recorded on a session when a Handler or a
+// middleware hook panics. Value is the value given to panic and Stack is the
+// stack trace taken at the point of recovery. Disconnect hooks receive it
+// through their err argument, and callers match it with errors.As.
+type PanicError struct {
+	Value any
+	Stack []byte
+}
+
+func (e PanicError) Error() string {
+	return fmt.Sprintf("smtpd: panic: %v", e.Value)
+}
+
 // Handler delivers a received message. It is the terminal stage of an SMTP
 // transaction: the server invokes Server.Handler once per accepted DATA
 // payload, after every middleware-contributed Handler stage has run. The
 // returned context replaces the session context for any subsequent commands
 // on the connection.
+//
+// A panic in a Handler stops that session only: the server logs it, replies
+// 421, closes the connection, and reports a PanicError to the Disconnect
+// hooks. Other sessions continue.
 type Handler func(ctx context.Context, peer Peer, env *Envelope) (context.Context, error)
 
 // Middleware participates in one or more SMTP phases. Every field is optional;


### PR DESCRIPTION
A panic in `Server.Handler` or in a middleware hook unwound out of the goroutine of the session and stopped the process. One bad message from one client took down every other session on the server.

`net/http` contains a panic per connection. This library did not.

## Before

```
panic: boom

goroutine 18 [running]:
...
github.com/chrj/smtpd/v2.(*session).deliver(...)
	/home/razor/projects/smtpd/session.go:207
github.com/chrj/smtpd/v2.(*session).serve(...)
	/home/razor/projects/smtpd/session.go:107
github.com/chrj/smtpd/v2.(*Server).Serve.func2()
	/home/razor/projects/smtpd/smtpd.go:424
```

## After

| Where the panic happens | What the server does |
| --- | --- |
| `Server.Handler`, `CheckConnection`, `CheckHelo`, `CheckSender`, `CheckRecipient`, `Authenticate`, a middleware `Handler` | Writes the panic and the stack trace to the log, replies `421`, closes that connection. Other sessions continue. |
| `Disconnect` | Writes the panic to the log. The connection closes as usual. |
| `ConnContext` | Writes the panic to the log, drops that connection, keeps accepting. |
| `BaseContext` | `Serve` returns a `PanicError`. The hook runs once, before the accept loop, so the server never starts. |

`421` is "service not available, closing transmission channel" from RFC 5321, so a client retries later. The state of the session is unknown after a panic, so the connection closes instead of continuing.

## Where the recovery runs

User code runs in three places, and each one needs its own recovery:

1. **The body of the session.** The recovery is registered after the deferred close, so it runs before it. The panic becomes a `421` reply while the connection is still open. The close that follows reports the panic to the `Disconnect` hooks.
2. **The `Disconnect` hooks.** Those run from the deferred close, which is outside the recovery above. `notifyDisconnect` contains a panic from a hook, so the connection still closes.
3. **The accept loop.** `BaseContext` and `ConnContext` run there, not in the goroutine of a session. `baseContext` and `connContext` wrap them.

A `ConnContext` that returns a nil context still stops `Serve`. That fault is in the configuration and repeats on every connection, so the server does not continue past it. `errNilConnContext` separates it from a panic.

## New type

```go
type PanicError struct {
    Value any    // the value given to panic
    Stack []byte // the stack trace
}
```

The `Disconnect` hooks receive it through their `err` argument, which already carries the TLS, scanner and DATA errors. `Serve` returns it for a panic in `BaseContext`. Match it with `errors.As`.

The stack reaches the frame that panicked, not only the frame that recovered. A test asserts this, because `debug.Stack()` after `recover()` is easy to get wrong.

## Tests

`panic_test.go`, 12 cases. Each one stops the test binary before the change:

- A panic in `Server.Handler` gives a `421`, and a later transaction completes.
- A panic in `CheckConnection`, `CheckHelo`, `CheckSender`, `CheckRecipient` and a middleware `Handler` (table-driven), each with the same two assertions.
- The `Disconnect` hooks receive a `PanicError` with the right `Value` and a stack that reaches the handler.
- A panic in a `Disconnect` hook does not stop the process.
- A panic in `BaseContext` gives a `PanicError` from `Serve`.
- A panic in `ConnContext` drops one connection, and a later transaction completes.
- A `ConnContext` that returns nil stops `Serve` with an error that names the hook.

`go test ./...`, `golangci-lint run ./...`, `gofmt -l .` and `go vet ./...` are all clean.
