### PR TITLE
fix: keep AUTH credentials out of the log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- The credentials of an `AUTH` command no longer go to the log. At the `DEBUG`
+  level the server writes every line it receives, and the inline forms of
+  `AUTH` carry the credentials on that line:
+
+  ```
+  line="AUTH PLAIN AGh1bnRlcjJ1c2VyAHN1cDNyczNjcjN0"
+  ```
+
+  Base64 is not protection, so anybody who read the log had the password. The
+  server now keeps the verb and the mechanism, and replaces the rest with
+  `[redacted]`.
+
+  Read your logs if you run with `DEBUG` and accept `AUTH`. Passwords in them
+  must be changed.
+
 ### Added
 
 - `PanicError` records a panic from a `Handler` or a middleware hook. `Value`

--- a/README.md
+++ b/README.md
@@ -135,6 +135,23 @@ Each accepted connection gets its own `context.Context`, derived from
 * is returned from every checker, so middleware can install its own values
   for later stages using `context.WithValue`
 
+### Logging and credentials
+
+At the `DEBUG` level the server writes every line it receives and every reply
+it sends. The credentials of an `AUTH` command do not go to the log: the
+server keeps the verb and the mechanism, and replaces the rest.
+
+```
+level=DEBUG msg=received peer=10.0.0.7:52344 line="AUTH PLAIN [redacted]"
+```
+
+The other form of `AUTH` sends the credentials on their own lines, after a
+`334` reply. The server reads those lines directly, so they never reach the
+log.
+
+`Peer.Username` holds the user name after a successful `AUTH`. The password is
+given to the `Authenticate` hooks and is not kept.
+
 ### Session lifecycle
 
 ```mermaid

--- a/logging.go
+++ b/logging.go
@@ -3,7 +3,39 @@ package smtpd
 import (
 	"context"
 	"log/slog"
+	"strings"
 )
+
+// redacted replaces the credentials of an AUTH command in the log.
+const redacted = "[redacted]"
+
+// redactLine removes the credentials from a line before it goes to the log.
+// The inline forms of AUTH carry them on the command line:
+//
+//	AUTH PLAIN <base64 of the user name and the password>
+//	AUTH LOGIN <base64 of the user name>
+//
+// Everything after the mechanism is replaced. The verb and the mechanism stay,
+// so an operator can still see that a client tried to authenticate. A line
+// that is not an AUTH command is returned as it was received.
+//
+// The other form of AUTH sends the credentials on their own lines, after a 334
+// reply. The session reads those lines directly, and they never reach the log.
+func redactLine(line string) string {
+	line = strings.TrimSpace(line)
+
+	verb, rest, hasRest := strings.Cut(line, " ")
+	if !hasRest || !strings.EqualFold(verb, "AUTH") {
+		return line
+	}
+
+	mechanism, credentials, hasCredentials := strings.Cut(strings.TrimSpace(rest), " ")
+	if !hasCredentials || strings.TrimSpace(credentials) == "" {
+		return line
+	}
+
+	return verb + " " + mechanism + " " + redacted
+}
 
 type contextKey string
 

--- a/logging_leak_test.go
+++ b/logging_leak_test.go
@@ -1,0 +1,131 @@
+package smtpd_test
+
+import (
+	"bytes"
+	"encoding/base64"
+	"log/slog"
+	"net/smtp"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/chrj/smtpd/v2"
+)
+
+// syncBuffer collects log output from the goroutine of the session while the
+// test reads it.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// TestAuthCredentialsStayOutOfTheLog runs a real AUTH against a server that
+// logs at the DEBUG level, and makes sure the credentials are not in the
+// output. The server logs every line it receives, and the inline form of AUTH
+// carries the credentials on that line.
+func TestAuthCredentialsStayOutOfTheLog(t *testing.T) {
+	t.Parallel()
+
+	const (
+		username = "hunter2user"
+		password = "sup3rs3cr3t"
+	)
+	encoded := base64.StdEncoding.EncodeToString([]byte("\x00" + username + "\x00" + password))
+
+	var out syncBuffer
+	ts := newTestServer(t, &smtpd.Server{
+		Logger:            slog.New(slog.NewTextHandler(&out, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		AllowInsecureAuth: true,
+	}, []smtpd.Middleware{acceptAuth()})
+	ts.Start()
+
+	c, err := smtp.Dial(ts.Addr)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	if err := c.Hello("client.example"); err != nil {
+		t.Fatalf("HELO failed: %v", err)
+	}
+	if err := c.Text.PrintfLine("AUTH PLAIN %s", encoded); err != nil {
+		t.Fatalf("AUTH failed: %v", err)
+	}
+	if _, _, err := c.Text.ReadResponse(235); err != nil {
+		t.Fatalf("AUTH was not accepted: %v", err)
+	}
+	_ = c.Quit()
+
+	logged := out.String()
+	for _, secret := range []string{encoded, password} {
+		if strings.Contains(logged, secret) {
+			t.Errorf("the log contains the credentials:\n%s", logged)
+		}
+	}
+
+	// The command still reaches the log, so an operator can see that a client
+	// tried to authenticate.
+	if !strings.Contains(logged, "AUTH PLAIN [redacted]") {
+		t.Errorf("expected the redacted AUTH line in the log, got:\n%s", logged)
+	}
+}
+
+// TestAuthContinuationStaysOutOfTheLog covers the form that sends the
+// credentials on their own lines, after a 334 reply.
+func TestAuthContinuationStaysOutOfTheLog(t *testing.T) {
+	t.Parallel()
+
+	const password = "sup3rs3cr3t"
+
+	var out syncBuffer
+	ts := newTestServer(t, &smtpd.Server{
+		Logger:            slog.New(slog.NewTextHandler(&out, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		AllowInsecureAuth: true,
+	}, []smtpd.Middleware{acceptAuth()})
+	ts.Start()
+
+	c, err := smtp.Dial(ts.Addr)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	if err := c.Hello("client.example"); err != nil {
+		t.Fatalf("HELO failed: %v", err)
+	}
+	if err := c.Text.PrintfLine("AUTH LOGIN"); err != nil {
+		t.Fatalf("AUTH failed: %v", err)
+	}
+	if _, _, err := c.Text.ReadResponse(334); err != nil {
+		t.Fatalf("expected a 334 reply: %v", err)
+	}
+	if err := c.Text.PrintfLine("%s", base64.StdEncoding.EncodeToString([]byte("hunter2user"))); err != nil {
+		t.Fatalf("sending the user name failed: %v", err)
+	}
+	if _, _, err := c.Text.ReadResponse(334); err != nil {
+		t.Fatalf("expected a second 334 reply: %v", err)
+	}
+	encodedPassword := base64.StdEncoding.EncodeToString([]byte(password))
+	if err := c.Text.PrintfLine("%s", encodedPassword); err != nil {
+		t.Fatalf("sending the password failed: %v", err)
+	}
+	if _, _, err := c.Text.ReadResponse(235); err != nil {
+		t.Fatalf("AUTH was not accepted: %v", err)
+	}
+	_ = c.Quit()
+
+	logged := out.String()
+	for _, secret := range []string{encodedPassword, password} {
+		if strings.Contains(logged, secret) {
+			t.Errorf("the log contains the credentials:\n%s", logged)
+		}
+	}
+}

--- a/redact_test.go
+++ b/redact_test.go
@@ -1,0 +1,74 @@
+package smtpd
+
+import "testing"
+
+// TestRedactLine covers the shapes of AUTH that carry the credentials on the
+// command line, and makes sure that every other command reaches the log as it
+// was received.
+func TestRedactLine(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{
+			name: "AUTH PLAIN with credentials",
+			line: "AUTH PLAIN AGh1bnRlcjJ1c2VyAHN1cDNyczNjcjN0",
+			want: "AUTH PLAIN [redacted]",
+		},
+		{
+			name: "AUTH LOGIN with a user name",
+			line: "AUTH LOGIN dXNlcm5hbWU=",
+			want: "AUTH LOGIN [redacted]",
+		},
+		{
+			name: "lower case verb and mechanism",
+			line: "auth plain AGZvbwBiYXI=",
+			want: "auth plain [redacted]",
+		},
+		{
+			name: "extra spaces around the credentials",
+			line: "AUTH  PLAIN   AGZvbwBiYXI=",
+			want: "AUTH PLAIN [redacted]",
+		},
+		{
+			name: "AUTH PLAIN without credentials keeps the line",
+			line: "AUTH PLAIN",
+			want: "AUTH PLAIN",
+		},
+		{
+			name: "AUTH alone keeps the line",
+			line: "AUTH",
+			want: "AUTH",
+		},
+		{
+			name: "an unknown mechanism is redacted too",
+			line: "AUTH CRAM-MD5 dGVzdA==",
+			want: "AUTH CRAM-MD5 [redacted]",
+		},
+		{
+			name: "MAIL FROM is not touched",
+			line: "MAIL FROM:<sender@example.org>",
+			want: "MAIL FROM:<sender@example.org>",
+		},
+		{
+			name: "AUTHENTICATE is not AUTH",
+			line: "AUTHENTICATE something",
+			want: "AUTHENTICATE something",
+		},
+		{
+			name: "an empty line stays empty",
+			line: "",
+			want: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := redactLine(test.line)
+			if got != test.want {
+				t.Errorf("redactLine(%q) = %q, want %q", test.line, got, test.want)
+			}
+		})
+	}
+}

--- a/session.go
+++ b/session.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"net"
 	"runtime/debug"
-	"strings"
 	"time"
 )
 
@@ -113,7 +112,7 @@ func (s *session) serve(ctx context.Context) {
 
 	for s.scanner.Scan() {
 		line := s.scanner.Text()
-		logger.DebugContext(ctx, "received", slog.String("line", strings.TrimSpace(line)))
+		logger.DebugContext(ctx, "received", slog.String("line", redactLine(line)))
 		ctx = s.handle(ctx, line)
 	}
 


### PR DESCRIPTION
At the `DEBUG` level the session writes every line it receives. The inline forms of `AUTH` carry the credentials on the command line, so the log held them.

Captured from a running server before the change:

```
level=DEBUG msg=received peer=127.0.0.1:38182 line="AUTH PLAIN AGh1bnRlcjJ1c2VyAHN1cDNyczNjcjN0"
```

That base64 decodes to `\0hunter2user\0sup3rs3cr3t`. Base64 is an encoding, not protection, so anybody who read the log had the password.

## After

```
level=DEBUG msg=received peer=127.0.0.1:38182 line="AUTH PLAIN [redacted]"
```

`redactLine` keeps the verb and the mechanism, so an operator can still see that a client tried to authenticate, and with which mechanism.

## What was affected

| Form | Before |
| --- | --- |
| `AUTH PLAIN <base64 user and password>` | The user name and the password were in the log. |
| `AUTH LOGIN <base64 user>` | The user name was in the log. |
| `AUTH PLAIN` then the credentials after `334` | Not in the log. |
| `AUTH LOGIN` then the credentials after `334` | Not in the log. |

The session reads the lines that follow a `334` reply directly, so those never reached the log. The inline form is the one that leaked, and it is what `smtp.PlainAuth` in the standard library sends.

## Tests

- `TestRedactLine`, 10 cases: both mechanisms, a lower case verb, extra spaces, `AUTH` with no credentials, an unknown mechanism, `MAIL FROM` left as it is, and `AUTHENTICATE` which is not `AUTH`.
- `TestAuthCredentialsStayOutOfTheLog` runs a real `AUTH PLAIN` against a server that logs at `DEBUG`, then reads the output for the base64 and for the password. It also asserts that `AUTH PLAIN [redacted]` is present, so the redaction cannot pass by dropping the line.
- `TestAuthContinuationStaysOutOfTheLog` covers the `334` form.

I reverted the call site and ran the tests again to make sure they fail without the change.

## Operators

Anybody who runs at the `DEBUG` level and accepts `AUTH` has credentials in their logs. The `CHANGELOG` says so under `Security`, and says that those passwords must be changed.

`go test ./...`, `golangci-lint run ./...`, `gofmt -l .` and `go vet ./...` are all clean.
