### PR TITLE
fix: bound the memory and the cost of the greylist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `middleware.Greylist` no longer reads the whole map on every `RCPT TO`. The
+  sweep for expired entries ran on each check, under the lock, so each check
+  cost as much as the map was large. At 20000 entries a check took 271µs. It
+  now takes 156ns, and the cost no longer grows with the map.
+
+  The sweep runs once a minute, and as soon as the map reaches the cap.
+  Whether a triple is past the TTL is read at the check itself, so the answer
+  does not depend on when the sweep runs.
+
 ### Security
+
+- `middleware.Greylist` holds at most 100000 triples and drops the oldest at
+  that point. The map had no bound, so a client that sent many different
+  triples made the server hold all of them until the 24 hour TTL removed them.
+  `WithGreylistMaxEntries` sets another cap.
 
 - The credentials of an `AUTH` command no longer go to the log. At the `DEBUG`
   level the server writes every line it receives, and the inline forms of

--- a/middleware/greylist.go
+++ b/middleware/greylist.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"net"
+	"slices"
 	"sync"
 	"time"
 
@@ -23,14 +24,34 @@ import (
 //	    Handler()
 //
 // The sender is read from context via smtpd.SenderFromContext.
+//
+// The checker holds at most MaxEntries triples and drops the oldest ones at
+// that point, so a client that sends many different triples cannot take all
+// the memory of the server. A dropped entry makes that triple start over,
+// which delays mail but never accepts mail that the delay would have held.
 type GreylistChecker struct {
-	delay time.Duration
-	ttl   time.Duration
-	now   func() time.Time
+	delay      time.Duration
+	ttl        time.Duration
+	maxEntries int
+	sweepEvery time.Duration
+	now        func() time.Time
 
 	mu      sync.Mutex
 	entries map[string]time.Time
+
+	// nextSweep is the time of the next sweep for memory. Reclaiming memory
+	// is separate from the TTL: RecipientCheck tests the age of an entry
+	// itself, so a stale entry that is still in the map is treated as new.
+	nextSweep time.Time
+
+	// sweeps counts the sweeps that ran. Tests read it to prove that a sweep
+	// does not run on every check.
+	sweeps int
 }
+
+// defaultGreylistMaxEntries is the cap that Greylist uses when the caller
+// gives none. At about 200 bytes for an entry, it is some 20MB.
+const defaultGreylistMaxEntries = 100_000
 
 // GreylistOption configures a GreylistChecker at construction time. Pass
 // options to Greylist.
@@ -48,6 +69,18 @@ func WithGreylistTTL(d time.Duration) GreylistOption {
 	return func(g *GreylistChecker) { g.ttl = d }
 }
 
+// WithGreylistMaxEntries sets how many triples the checker holds. At the cap
+// the oldest entries are dropped. Zero selects the default of 100000, which
+// is about 20MB.
+//
+// A client that sends many different triples fills the map, so the cap is
+// what stops it from taking all the memory of the server. A dropped entry
+// makes that triple start over, which delays mail but never accepts mail that
+// the delay would have held.
+func WithGreylistMaxEntries(n int) GreylistOption {
+	return func(g *GreylistChecker) { g.maxEntries = n }
+}
+
 // withGreylistClock is a test hook for overriding time.Now.
 func withGreylistClock(now func() time.Time) GreylistOption {
 	return func(g *GreylistChecker) { g.now = now }
@@ -57,14 +90,23 @@ func withGreylistClock(now func() time.Time) GreylistOption {
 // value is safe for concurrent use.
 func Greylist(opts ...GreylistOption) *GreylistChecker {
 	g := &GreylistChecker{
-		delay:   5 * time.Minute,
-		ttl:     24 * time.Hour,
-		now:     time.Now,
-		entries: make(map[string]time.Time),
+		delay:      5 * time.Minute,
+		ttl:        24 * time.Hour,
+		maxEntries: defaultGreylistMaxEntries,
+		sweepEvery: time.Minute,
+		now:        time.Now,
+		entries:    make(map[string]time.Time),
 	}
 	for _, opt := range opts {
 		opt(g)
 	}
+
+	// Zero means the default, as it does for the fields of smtpd.Server. A
+	// cap below one would make the sweep drop every entry.
+	if g.maxEntries < 1 {
+		g.maxEntries = defaultGreylistMaxEntries
+	}
+
 	return g
 }
 
@@ -82,10 +124,13 @@ func (g *GreylistChecker) RecipientCheck(ctx context.Context, peer smtpd.Peer, r
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
-	g.gc(now)
+	g.maybeSweep(now)
 
+	// An entry past the TTL is forgotten, whether or not the sweep already
+	// removed it. Reading the age here keeps the answer the same at every
+	// point between two sweeps.
 	first, seen := g.entries[key]
-	if !seen {
+	if !seen || now.Sub(first) > g.ttl {
 		g.entries[key] = now
 		smtpd.LoggerFromContext(ctx).InfoContext(ctx, "greylisted",
 			slog.String("ip", tcpAddr.IP.String()),
@@ -99,9 +144,47 @@ func (g *GreylistChecker) RecipientCheck(ctx context.Context, peer smtpd.Peer, r
 	return nil
 }
 
-func (g *GreylistChecker) gc(now time.Time) {
+// maybeSweep reclaims memory. It runs on an interval, and as soon as the map
+// reaches the cap. A sweep on every check costs as much as the whole map, and
+// holds the lock for that long.
+func (g *GreylistChecker) maybeSweep(now time.Time) {
+	if now.Before(g.nextSweep) && len(g.entries) < g.maxEntries {
+		return
+	}
+	g.sweep(now)
+	g.nextSweep = now.Add(g.sweepEvery)
+	g.sweeps++
+}
+
+// sweep drops the entries past the TTL. When the map is still at the cap
+// afterwards, it drops the oldest entries until the map is back under it.
+func (g *GreylistChecker) sweep(now time.Time) {
 	for k, t := range g.entries {
 		if now.Sub(t) > g.ttl {
+			delete(g.entries, k)
+		}
+	}
+
+	if len(g.entries) < g.maxEntries {
+		return
+	}
+
+	// The map is full of entries that are still live, so age decides. Sorting
+	// the times gives the cut, and one more pass drops everything at or
+	// before it. Going down to nine tenths of the cap keeps the next check
+	// from starting another sweep.
+	times := make([]time.Time, 0, len(g.entries))
+	for _, t := range g.entries {
+		times = append(times, t)
+	}
+	slices.SortFunc(times, func(a, b time.Time) int { return a.Compare(b) })
+
+	// A small cap makes nine tenths of it round down, so keep at least one
+	// entry and never more than the map holds.
+	keep := min(max(g.maxEntries*9/10, 1), len(times))
+	cut := times[len(times)-keep]
+	for k, t := range g.entries {
+		if !t.After(cut) {
 			delete(g.entries, k)
 		}
 	}

--- a/middleware/greylist_bounds_test.go
+++ b/middleware/greylist_bounds_test.go
@@ -1,0 +1,166 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/chrj/smtpd/v2"
+)
+
+// checkTriple runs one RecipientCheck for a made-up triple.
+func checkTriple(g *GreylistChecker, i int) error {
+	peer := smtpd.Peer{Addr: &net.TCPAddr{
+		IP:   net.IPv4(10, byte(i>>16), byte(i>>8), byte(i)),
+		Port: 25,
+	}}
+	return g.RecipientCheck(context.Background(), peer, fmt.Sprintf("r%d@example.net", i))
+}
+
+// TestGreylistBoundsMemory verifies that the map stops growing at the cap. A
+// client that sends many different triples must not be able to make the
+// server hold all of them.
+func TestGreylistBoundsMemory(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1_700_000_000, 0)
+	g := Greylist(
+		WithGreylistMaxEntries(100),
+		withGreylistClock(func() time.Time { return now }),
+	)
+
+	for i := range 1000 {
+		_ = checkTriple(g, i)
+	}
+
+	g.mu.Lock()
+	got := len(g.entries)
+	g.mu.Unlock()
+
+	if got > 100 {
+		t.Fatalf("expected at most 100 entries, got %d", got)
+	}
+}
+
+// TestGreylistEvictsOldestFirst verifies that the cap drops the oldest
+// entries. A triple that was seen recently has to survive an eviction, or a
+// sender that is part way through the delay starts over.
+func TestGreylistEvictsOldestFirst(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1_700_000_000, 0)
+	g := Greylist(
+		WithGreylistMaxEntries(50),
+		withGreylistClock(func() time.Time { return now }),
+	)
+
+	// The oldest triple goes in first.
+	_ = checkTriple(g, 0)
+
+	// Every later triple is one second newer.
+	for i := 1; i < 500; i++ {
+		now = now.Add(time.Second)
+		_ = checkTriple(g, i)
+	}
+
+	g.mu.Lock()
+	_, oldestKept := g.entries[keyOf(0)]
+	_, newestKept := g.entries[keyOf(499)]
+	g.mu.Unlock()
+
+	if oldestKept {
+		t.Error("expected the oldest entry to be evicted")
+	}
+	if !newestKept {
+		t.Error("expected the newest entry to be kept")
+	}
+}
+
+// keyOf builds the map key that checkTriple produces for i.
+func keyOf(i int) string {
+	ip := net.IPv4(10, byte(i>>16), byte(i>>8), byte(i))
+	return ip.String() + "|" + "" + "|" + fmt.Sprintf("r%d@example.net", i)
+}
+
+// TestGreylistExpiryDoesNotDependOnTheSweep verifies that a triple past the
+// TTL is treated as new, even when the sweep that reclaims memory has not run
+// yet. Correctness must not depend on when the sweep happens.
+func TestGreylistExpiryDoesNotDependOnTheSweep(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1_700_000_000, 0)
+	g := Greylist(
+		WithGreylistDelay(5*time.Minute),
+		WithGreylistTTL(time.Hour),
+		withGreylistClock(func() time.Time { return now }),
+	)
+
+	if err := checkTriple(g, 1); err == nil {
+		t.Fatal("expected the first attempt to be greylisted")
+	}
+
+	// Move past the TTL. The entry is stale, so the triple starts over.
+	now = now.Add(2 * time.Hour)
+
+	if err := checkTriple(g, 1); err == nil {
+		t.Fatal("expected a triple past the TTL to be greylisted again")
+	}
+
+	// It is now a fresh entry, so the delay applies from this point.
+	now = now.Add(10 * time.Minute)
+
+	if err := checkTriple(g, 1); err != nil {
+		t.Fatalf("expected the retry after the delay to pass, got %v", err)
+	}
+}
+
+// TestGreylistSweepIsNotRunOnEveryCheck verifies that the sweep is amortized.
+// A sweep on every check makes each one cost as much as the whole map.
+func TestGreylistSweepIsNotRunOnEveryCheck(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1_700_000_000, 0)
+	g := Greylist(
+		WithGreylistMaxEntries(10_000),
+		withGreylistClock(func() time.Time { return now }),
+	)
+
+	for i := range 200 {
+		_ = checkTriple(g, i)
+	}
+
+	g.mu.Lock()
+	sweeps := g.sweeps
+	g.mu.Unlock()
+
+	// The clock does not move, so only the first check may sweep.
+	if sweeps > 1 {
+		t.Fatalf("expected at most 1 sweep over 200 checks, got %d", sweeps)
+	}
+}
+
+// TestGreylistTinyCap covers a cap so small that the low-water mark rounds
+// down to zero.
+func TestGreylistTinyCap(t *testing.T) {
+	t.Parallel()
+
+	for _, max := range []int{1, 2, 5} {
+		now := time.Unix(1_700_000_000, 0)
+		g := Greylist(
+			WithGreylistMaxEntries(max),
+			withGreylistClock(func() time.Time { return now }),
+		)
+		for i := range 20 {
+			now = now.Add(time.Second)
+			_ = checkTriple(g, i)
+		}
+		g.mu.Lock()
+		got := len(g.entries)
+		g.mu.Unlock()
+		if got > max {
+			t.Errorf("max=%d: expected at most %d entries, got %d", max, max, got)
+		}
+	}
+}


### PR DESCRIPTION
`middleware.Greylist` swept the whole map for expired entries on every `RCPT TO`, while holding the lock. Each check cost as much as the map was large, and every check on the server waited for the same lock.

The map also had no bound. A client that sent many different triples made the server hold all of them until the 24 hour TTL removed them, and made every later check slower.

## Measured

Same test either side of the change: seed the map with n triples, then time a steady check.

| Entries | Before | After |
| --- | --- | --- |
| 1000 | 16.5µs | 159ns |
| 5000 | 54µs | 160ns |
| 20000 | 271µs | 156ns |

The cost no longer grows with the map. Filling the map went from `O(n²)` to `O(n)`: seeding 20000 entries took 2.42s and now takes 32ms. My first attempt to measure at 100000 entries did not finish inside two minutes.

## The change

**The sweep is amortized.** It runs once a minute, and as soon as the map reaches the cap.

**The TTL is read at the check.** `RecipientCheck` tests the age of the entry it found, so a stale entry that the sweep has not reached yet is still treated as forgotten. Without this, moving the sweep off the check path would have made the answer depend on when the sweep last ran.

**The map has a cap.** 100000 triples by default, about 20MB. At the cap the sweep drops the oldest entries down to nine tenths of it. `WithGreylistMaxEntries` sets another cap, and zero selects the default, as the fields of `smtpd.Server` do.

Dropping an entry makes that triple start over, so it gets a `450` and waits for the delay again. That direction is the safe one: eviction delays mail, and never accepts mail that the delay would have held.

## Tests

`greylist_bounds_test.go`:

- The map stops growing at the cap, over 1000 triples with a cap of 100.
- Eviction drops the oldest entry and keeps the newest.
- A triple past the TTL is greylisted again even when no sweep has run, and the delay then applies from that point.
- At most one sweep runs over 200 checks while the clock stands still.
- A cap of 1, 2 and 5 stays inside the cap.

That last test found a panic in the first version of this change: nine tenths of a cap below ten rounds down to zero, which indexed one past the end of the sorted times. The bound is now at least one entry and never more than the map holds.

The four tests that were already there pass unchanged.

`go test ./...`, `golangci-lint run ./...`, `gofmt -l .` and `go vet ./...` are all clean.
