### PR TITLE
fix: bound the read after the message size limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The server no longer reads a message without bound after it rejected the
+  size. It read to the end of the message to keep the SMTP stream in step,
+  which let a client hold the session for as long as `DataTimeout` allows. It
+  now stops at twice `MaxMessageSize`.
+
+  A message that ends inside that gets a `552` and the session goes on, as
+  before. A client that is still sending gets a `552` and loses the
+  connection, because the rest of the message would otherwise be read as SMTP
+  commands.
+
 - `middleware.Greylist` no longer reads the whole map on every `RCPT TO`. The
   sweep for expired entries ran on each check, under the lock, so each check
   cost as much as the map was large. At 20000 entries a check took 271µs. It

--- a/data.go
+++ b/data.go
@@ -32,10 +32,20 @@ func (s *session) handleDATA(ctx context.Context, cmd *command) context.Context 
 	_ = body.Close()
 
 	if body.tooBig {
-		return s.reset(s.reply(ctx, 552, fmt.Sprintf(
+		ctx = s.reply(ctx, 552, fmt.Sprintf(
 			"Message exceeded max message size of %d bytes",
 			s.server.MaxMessageSize,
-		)))
+		))
+
+		// The client was still sending when the drain gave up, so the rest
+		// of the message is on the wire. Reading it costs without bound, and
+		// leaving it would make the session read the body of the message as
+		// SMTP commands. Close instead.
+		if body.abandoned {
+			return s.close(ctx)
+		}
+
+		return s.reset(ctx)
 	}
 
 	if body.readErr != nil && !errors.Is(body.readErr, io.EOF) {
@@ -59,12 +69,14 @@ func (s *session) handleDATA(ctx context.Context, cmd *command) context.Context 
 // once the body crosses MaxMessageSize; Close drains whatever the handler
 // didn't read so the next SMTP command lands on a clean boundary.
 type dataReader struct {
-	r       io.Reader
-	max     int
-	n       int
-	tooBig  bool
-	readErr error
-	closed  bool
+	r   io.Reader
+	max int
+
+	n         int
+	tooBig    bool
+	abandoned bool
+	readErr   error
+	closed    bool
 }
 
 func (d *dataReader) Read(p []byte) (int, error) {
@@ -98,11 +110,18 @@ func (d *dataReader) Close() error {
 		return nil
 	}
 	d.closed = true
+
 	// Keep draining to detect oversize even if the handler stopped reading
-	// early, and to re-sync the protocol past <CRLF>.<CRLF>.
+	// early, and to re-sync the protocol past <CRLF>.<CRLF>. Reading stops
+	// at twice the limit: that reaches the end of a message that is a little
+	// over it, and it bounds the work for a client that keeps sending. The
+	// caller closes the connection when the message does not end by then.
+	limit := d.max * 2
+
 	buf := make([]byte, 4096)
-	for {
-		n, err := d.r.Read(buf)
+	for d.n < limit {
+		want := min(len(buf), limit-d.n)
+		n, err := d.r.Read(buf[:want])
 		d.n += n
 		if d.n > d.max {
 			d.tooBig = true
@@ -115,6 +134,9 @@ func (d *dataReader) Close() error {
 			return nil
 		}
 	}
+
+	d.abandoned = true
+	return nil
 }
 
 var errMessageTooLarge = errors.New("smtpd: message exceeded max size")

--- a/data_drain_test.go
+++ b/data_drain_test.go
@@ -1,0 +1,141 @@
+package smtpd
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+// endlessReader never reaches the end of the message. It stands for a client
+// that keeps sending after the server rejected the size.
+type endlessReader struct{}
+
+func (endlessReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 'a'
+	}
+	return len(p), nil
+}
+
+// TestDataReaderCloseStopsAtTheDrainLimit verifies that Close gives up on a
+// message that does not end inside the budget, instead of reading whatever
+// the client sends.
+func TestDataReaderCloseStopsAtTheDrainLimit(t *testing.T) {
+	t.Parallel()
+
+	d := &dataReader{r: endlessReader{}, max: 10}
+
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !d.tooBig {
+		t.Error("expected tooBig after the drain")
+	}
+	if !d.abandoned {
+		t.Error("expected abandoned when the message does not end in the budget")
+	}
+	if d.n > 20 {
+		t.Errorf("read %d bytes, want at most twice the limit = 20", d.n)
+	}
+}
+
+// TestDataReaderCloseFinishesInsideTheBudget verifies that a message which
+// ends inside the budget is drained to the end, so the session can go on.
+func TestDataReaderCloseFinishesInsideTheBudget(t *testing.T) {
+	t.Parallel()
+
+	// 15 bytes: over the limit of 10, inside twice the limit.
+	d := &dataReader{r: strings.NewReader(strings.Repeat("a", 15)), max: 10}
+
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !d.tooBig {
+		t.Error("expected tooBig after the drain")
+	}
+	if d.abandoned {
+		t.Error("did not expect abandoned for a message that ends in the budget")
+	}
+	if d.n != 15 {
+		t.Errorf("read %d bytes, want the whole 15", d.n)
+	}
+}
+
+// runDATAFrom wires handleDATA to r and returns the reply codes, and whether
+// the session was closed.
+func runDATAFrom(t *testing.T, srv *Server, env *Envelope, r io.Reader) ([]int, bool) {
+	t.Helper()
+
+	serverWrite := &bytes.Buffer{}
+	reader := bufio.NewReader(r)
+	s := &session{
+		server:   srv,
+		conn:     fakeConn{},
+		reader:   reader,
+		writer:   bufio.NewWriter(serverWrite),
+		scanner:  bufio.NewScanner(reader),
+		envelope: env,
+		peer:     Peer{ServerName: "localhost"},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.handleDATA(context.Background(), &command{})
+		_ = s.writer.Flush()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleDATA did not return: the drain is not bounded")
+	}
+
+	return parseReplyCodes(t, serverWrite.Bytes()), s.closed
+}
+
+// TestHandleDATAOversizeClosesWhenTheClientKeepsSending verifies that a client
+// which keeps sending after the size limit gets a 552 and loses the
+// connection. Leaving the rest of the message on the wire is not an option:
+// the session would read the body of the message as SMTP commands.
+func TestHandleDATAOversizeClosesWhenTheClientKeepsSending(t *testing.T) {
+	t.Parallel()
+
+	handler := &dataHandler{drain: true}
+	srv := &Server{MaxMessageSize: 64, Handler: handler.handler()}
+	env := &Envelope{Recipients: []string{"r@example.net"}}
+
+	codes, closed := runDATAFrom(t, srv, env, endlessReader{})
+
+	if len(codes) != 2 || codes[0] != 354 || codes[1] != 552 {
+		t.Fatalf("codes = %v, want [354 552]", codes)
+	}
+	if !closed {
+		t.Error("expected the session to be closed")
+	}
+}
+
+// TestHandleDATAOversizeKeepsTheSessionWhenTheMessageEnds verifies that a
+// message which is over the limit but ends inside the budget still gets a 552
+// and leaves the session open, as it did before.
+func TestHandleDATAOversizeKeepsTheSessionWhenTheMessageEnds(t *testing.T) {
+	t.Parallel()
+
+	handler := &dataHandler{drain: true}
+	srv := &Server{MaxMessageSize: 5, Handler: handler.handler()}
+	env := &Envelope{Recipients: []string{"r@example.net"}}
+
+	body := strings.Repeat("a", 20) + "\r\n.\r\n"
+	codes, closed := runDATAFrom(t, srv, env, strings.NewReader(body))
+
+	if len(codes) != 2 || codes[0] != 354 || codes[1] != 552 {
+		t.Fatalf("codes = %v, want [354 552]", codes)
+	}
+	if closed {
+		t.Error("did not expect the session to be closed for a message that ends")
+	}
+}


### PR DESCRIPTION
`dataReader.Close` read to the end of the message even after the size limit was passed. The read had no bound, so a client that kept sending held the session for as long as `DataTimeout` allows, at whatever rate the link carries. `DataTimeout` is 5 minutes by default, and the client can start again with the next `DATA` command.

## Why the read cannot simply stop

The drain is there to consume the stream through `<CRLF>.<CRLF>`. The session reads its commands from the same `bufio.Reader` that the dot-reader wraps, so a stream that is left part way through is read as SMTP commands. A body that carries a line like `RCPT TO:<victim@example.com>` would then run as a command.

So there are two choices, and no third: read the message to the end, or close the connection.

## The change

`Close` stops at twice `MaxMessageSize` and records that it gave up.

| The client | The server |
| --- | --- |
| Ends the message inside twice the limit | `552`, and the session goes on, as before. |
| Is still sending at that point | `552`, then closes the connection. |

Twice the limit reaches the end of a message that is a little over it, which is the honest case, and bounds the work for a client that keeps sending.

This also covers a handler that returns an error early. `Close` read the whole message before the rejection went out.

## Tests

- `Close` gives up on a message that never ends, sets the flag, and reads no more than twice the limit.
- `Close` reads a message that ends inside the budget to its end and does not set the flag.
- A client that keeps sending gets `[354 552]` and the session is closed.
- A message over the limit that ends gets `[354 552]` and the session stays open.

The tests use a reader that never ends. Without the bound the first two do not return, so the test for `handleDATA` carries a timeout that reports the reason.

The 10 tests that were already there pass unchanged.

`go test ./...`, `golangci-lint run ./...`, `gofmt -l .` and `go vet ./...` are all clean.
