### PR TITLE
fix: discard the state from before the TLS handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- A successful `STARTTLS` now clears `Peer.HeloName`, `Peer.Protocol` and
+  `Peer.Username`. The server kept the name from the greeting before the
+  handshake, which goes over the wire in plain text where anybody on the path
+  can change it. RFC 3207 says the server must drop what it learned there, and
+  names the argument of `EHLO`.
+
+  A handler or a middleware could therefore read a `HeloName` that an attacker
+  in the middle chose.
+
+  **This changes behavior.** The client must send `EHLO` or `HELO` again after
+  `STARTTLS`. Without it, `MAIL FROM` is answered with `502`. Client libraries
+  already do this: `StartTLS` in `net/smtp` sends `EHLO` again as part of the
+  call. A client of your own that skips it stops working.
+
 - `middleware.Greylist` holds at most 100000 triples and drops the oldest at
   that point. The map had no bound, so a client that sent many different
   triples made the server hold all of them until the 24 hour TTL removed them.

--- a/README.md
+++ b/README.md
@@ -190,6 +190,21 @@ is cleared after delivery or `RSET`.
 shutdown (QUIT or server `Shutdown`); non-nil if a TLS/scanner/DATA error
 terminated the session, or a `PanicError` if a hook panicked.
 
+### STARTTLS
+
+Everything the client sends before the handshake goes over the wire in plain
+text, where anybody on the path can change it. RFC 3207 says the server must
+drop what it learned there, so a successful `STARTTLS` clears `Peer.HeloName`,
+`Peer.Protocol` and `Peer.Username`, and the envelope.
+
+The client must send `EHLO` or `HELO` again. Without it, `MAIL FROM` is
+answered with `502`. Client libraries do this for themselves: `StartTLS` in
+`net/smtp` sends `EHLO` again as part of the call.
+
+Commands that arrive in the same write as `STARTTLS` never run. The session
+builds a new reader on the TLS connection, so the bytes that were read into
+the buffer with `STARTTLS` are dropped.
+
 ### Panics
 
 A panic in `Server.Handler` or in a middleware hook stops that session only.

--- a/protocol.go
+++ b/protocol.go
@@ -270,7 +270,17 @@ func (s *session) handleSTARTTLS(ctx context.Context, cmd *command) context.Cont
 		return s.close(ctx)
 	}
 
-	// Reset envelope as a new EHLO/HELO is required after STARTTLS
+	// Everything the client sent before the handshake went over the wire in
+	// plain text, where anybody on the path could change it. RFC 3207 gives
+	// the argument of EHLO as the example of what the server must drop.
+	//
+	// Clearing the name from the greeting is also what makes a new EHLO or
+	// HELO necessary: MAIL FROM asks for it, and turns the client away
+	// without one.
+	s.peer.HeloName = ""
+	s.peer.Protocol = ""
+	s.peer.Username = ""
+
 	ctx = s.reset(ctx)
 
 	// Reset deadlines on the underlying connection before I replace it

--- a/starttls_test.go
+++ b/starttls_test.go
@@ -1,0 +1,243 @@
+package smtpd_test
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/chrj/smtpd/v2"
+)
+
+// rawClient drives a session over a socket, so a test can leave out the
+// greeting that a client library sends for itself after STARTTLS.
+type rawClient struct {
+	t    *testing.T
+	conn net.Conn
+	br   *bufio.Reader
+}
+
+func dialRaw(t *testing.T, addr string) *rawClient {
+	t.Helper()
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	c := &rawClient{t: t, conn: conn, br: bufio.NewReader(conn)}
+	c.line() // the banner
+	return c
+}
+
+// line reads one reply line.
+func (c *rawClient) line() string {
+	c.t.Helper()
+
+	_ = c.conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	l, err := c.br.ReadString('\n')
+	if err != nil {
+		c.t.Fatalf("read failed: %v", err)
+	}
+	return strings.TrimSpace(l)
+}
+
+// send writes one command and returns the last line of the reply.
+func (c *rawClient) send(format string, args ...any) string {
+	c.t.Helper()
+
+	if _, err := fmt.Fprintf(c.conn, format+"\r\n", args...); err != nil {
+		c.t.Fatalf("write failed: %v", err)
+	}
+	for {
+		l := c.line()
+		if len(l) >= 4 && l[3] == '-' {
+			continue
+		}
+		return l
+	}
+}
+
+// startTLS runs the handshake and points the client at the TLS connection.
+func (c *rawClient) startTLS() {
+	c.t.Helper()
+
+	if reply := c.send("STARTTLS"); !strings.HasPrefix(reply, "220") {
+		c.t.Fatalf("STARTTLS reply = %q, want 220", reply)
+	}
+
+	tconn := tls.Client(c.conn, &tls.Config{
+		InsecureSkipVerify: true,
+		ServerName:         "127.0.0.1",
+	})
+	if err := tconn.HandshakeContext(context.Background()); err != nil {
+		c.t.Fatalf("handshake failed: %v", err)
+	}
+
+	c.conn = tconn
+	c.br = bufio.NewReader(tconn)
+}
+
+// TestSTARTTLSDiscardsTheGreeting verifies that the name from the greeting
+// before TLS is discarded. RFC 3207 says the server must drop what it learned
+// from the client outside the TLS negotiation, and the argument of EHLO is
+// the example the RFC gives. A client that sends no new greeting has to be
+// turned away.
+func TestSTARTTLSDiscardsTheGreeting(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, &smtpd.Server{Logger: testLogger(t)}, nil)
+	ts.StartSTARTTLS()
+
+	c := dialRaw(t, ts.Addr)
+	c.send("EHLO before-tls.example")
+	c.startTLS()
+
+	// No new greeting. The name from before TLS must not carry over.
+	if reply := c.send("MAIL FROM:<s@example.org>"); !strings.HasPrefix(reply, "502") {
+		t.Fatalf("MAIL without a new greeting = %q, want 502", reply)
+	}
+}
+
+// TestSTARTTLSTakesTheNewGreeting verifies that the name from the greeting
+// after TLS is the one the handler sees.
+func TestSTARTTLSTakesTheNewGreeting(t *testing.T) {
+	t.Parallel()
+
+	var seen atomic.Value
+	seen.Store("")
+
+	ts := newTestServer(t, &smtpd.Server{
+		Logger: testLogger(t),
+		Handler: func(ctx context.Context, peer smtpd.Peer, env *smtpd.Envelope) (context.Context, error) {
+			seen.Store(peer.HeloName)
+			_ = env.Data.Close()
+			return ctx, nil
+		},
+	}, nil)
+	ts.StartSTARTTLS()
+
+	c := dialRaw(t, ts.Addr)
+	c.send("EHLO before-tls.example")
+	c.startTLS()
+	c.send("EHLO after-tls.example")
+
+	c.send("MAIL FROM:<s@example.org>")
+	c.send("RCPT TO:<r@example.net>")
+	c.send("DATA")
+	if reply := c.send("body\r\n."); !strings.HasPrefix(reply, "250") {
+		t.Fatalf("end of message = %q, want 250", reply)
+	}
+
+	if got := seen.Load().(string); got != "after-tls.example" {
+		t.Fatalf("the handler saw HeloName %q, want %q", got, "after-tls.example")
+	}
+}
+
+// TestSTARTTLSDiscardsTheUsername verifies that a user name from an AUTH
+// before TLS is discarded too.
+func TestSTARTTLSDiscardsTheUsername(t *testing.T) {
+	t.Parallel()
+
+	var seen atomic.Value
+	seen.Store("unset")
+
+	ts := newTestServer(t, &smtpd.Server{
+		Logger:            testLogger(t),
+		AllowInsecureAuth: true,
+		Handler: func(ctx context.Context, peer smtpd.Peer, env *smtpd.Envelope) (context.Context, error) {
+			seen.Store(peer.Username)
+			_ = env.Data.Close()
+			return ctx, nil
+		},
+	}, []smtpd.Middleware{acceptAuth()})
+	ts.StartSTARTTLS()
+
+	c := dialRaw(t, ts.Addr)
+	c.send("EHLO before-tls.example")
+	// AGJlZm9yZQBwdw== is "\x00before\x00pw".
+	if reply := c.send("AUTH PLAIN AGJlZm9yZQBwdw=="); !strings.HasPrefix(reply, "235") {
+		t.Fatalf("AUTH before TLS = %q, want 235", reply)
+	}
+	c.startTLS()
+	c.send("EHLO after-tls.example")
+
+	c.send("MAIL FROM:<s@example.org>")
+	c.send("RCPT TO:<r@example.net>")
+	c.send("DATA")
+	c.send("body\r\n.")
+
+	if got := seen.Load().(string); got != "" {
+		t.Fatalf("the handler saw Username %q, want it discarded", got)
+	}
+}
+
+// TestSTARTTLSDiscardsPipelinedPlaintext verifies that commands sent in the
+// same write as STARTTLS never run. An attacker in the middle sends them in
+// plain text, and the client that follows the TLS negotiation never wrote
+// them. The session builds a new reader on the TLS connection, so the bytes
+// that were buffered are dropped. This test holds that property in place.
+func TestSTARTTLSDiscardsPipelinedPlaintext(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var senders []string
+
+	ts := newTestServer(t, &smtpd.Server{Logger: testLogger(t)}, []smtpd.Middleware{{
+		CheckSender: func(ctx context.Context, _ smtpd.Peer, addr string) (context.Context, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			senders = append(senders, addr)
+			return ctx, nil
+		},
+	}})
+	ts.StartSTARTTLS()
+
+	c := dialRaw(t, ts.Addr)
+	c.send("EHLO before-tls.example")
+
+	// STARTTLS and an injected transaction in one write. The sender of the
+	// injected MAIL FROM is one that the client never sends itself, so it
+	// names the injected command and nothing else.
+	if _, err := fmt.Fprint(c.conn, "STARTTLS\r\nMAIL FROM:<injected@evil.example>\r\n"); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	if reply := c.line(); !strings.HasPrefix(reply, "220") {
+		t.Fatalf("STARTTLS reply = %q, want 220", reply)
+	}
+
+	tconn := tls.Client(c.conn, &tls.Config{
+		InsecureSkipVerify: true,
+		ServerName:         "127.0.0.1",
+	})
+	if err := tconn.HandshakeContext(context.Background()); err != nil {
+		t.Fatalf("handshake failed: %v", err)
+	}
+	c.conn = tconn
+	c.br = bufio.NewReader(tconn)
+
+	// A command over TLS proves the session is in step: a reply to the
+	// injected command would have been answered here instead.
+	if reply := c.send("EHLO after-tls.example"); !strings.HasPrefix(reply, "250") {
+		t.Fatalf("EHLO after TLS = %q, want 250", reply)
+	}
+	c.send("MAIL FROM:<legit@example.org>")
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, addr := range senders {
+		if addr == "injected@evil.example" {
+			t.Fatalf("the injected command ran: senders = %v", senders)
+		}
+	}
+	if len(senders) != 1 || senders[0] != "legit@example.org" {
+		t.Fatalf("senders = %v, want [legit@example.org]", senders)
+	}
+}


### PR DESCRIPTION
`STARTTLS` cleared the envelope but kept `Peer.HeloName`, `Peer.Protocol` and `Peer.Username`.

Everything the client sends before the handshake goes over the wire in plain text, where anybody on the path can change it. RFC 3207 section 4 says the server must drop what it learned there, and gives the argument of `EHLO` as the example.

## What this allowed

Captured from a running server before the change. The client greets, runs `STARTTLS`, and then sends a whole transaction with no greeting after the handshake:

```
starttls: 220 Go ahead
MAIL without a new greeting: 250 Go ahead
RCPT: 250 Go ahead
DATA: 354 Go ahead. End your data with <CR><LF>.<CR><LF>
end: 250 Thank you.
HeloName seen by the handler: "attacker-controlled.example"
```

The name reached the handler, and reaches every middleware that reads `Peer`. An attacker in the middle chooses it, because it was sent in plain text.

The comment at that point in the code already said that a new `EHLO` or `HELO` was required after `STARTTLS`. Nothing asked for one.

## The change

A successful handshake clears the three fields. `MAIL FROM` already asks for a greeting, so it now turns away a client that did not send one.

## This changes behavior

A client must send `EHLO` or `HELO` again after `STARTTLS`. Without it, `MAIL FROM` is answered with `502`.

Client libraries already do this. `StartTLS` in `net/smtp` sends `EHLO` again as part of the call, so the tests that use it needed no change. A client of your own that skips the second greeting stops working.

## What was already right

Commands that arrive in the same write as `STARTTLS` never ran. The session builds a new `bufio.Reader` and a new `bufio.Scanner` on the TLS connection, so the plain text that was read into the buffer alongside `STARTTLS` is dropped.

I checked this against a running server with an injected `MAIL FROM`, and the injected command did not run. There is now a test that holds the property in place, because the code that gives it is easy to read as a needless allocation and remove.

I first meant to add a check on `s.reader.Buffered()` here. Measured on a running server, that value is `0` even with pipelined plain text: the bytes sit in the buffer of the `bufio.Scanner`, which has no way to report them. The check would have read as a control while testing nothing, so it is not in this change.

## Tests

`starttls_test.go` drives a socket directly, so a test can leave out the greeting that a client library sends for itself:

- A client that sends no greeting after `STARTTLS` gets `502` for `MAIL FROM`.
- The handler sees the name from the greeting after the handshake, not the one before it.
- A user name from an `AUTH` before the handshake is discarded.
- A `MAIL FROM` pipelined with `STARTTLS` never reaches `CheckSender`, while the one the client sends over TLS does.

The first three fail before the change. The fourth passes before and after, which is the point of it.

`go test ./...`, `golangci-lint run ./...`, `gofmt -l .` and `go vet ./...` are all clean.
