### PR TITLE
fix: split an XCLIENT item on the first equals sign only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `XCLIENT` accepts a value that carries an equals sign, such as the padding
+  of base64 in `LOGIN=dXNlcg==`. Every equals sign split the item before, so
+  the server answered `502` and the proxy lost the attributes it sent.
+
 - The server no longer reads a message without bound after it rejected the
   size. It read to the end of the message to keep the SMTP stream in step,
   which let a client hold the session for as long as `DataTimeout` allows. It

--- a/xclient.go
+++ b/xclient.go
@@ -28,14 +28,13 @@ func (s *session) handleXCLIENT(ctx context.Context, cmd *command) context.Conte
 
 	for _, item := range fields {
 
-		parts := strings.Split(item, "=")
-
-		if len(parts) != 2 {
+		// Only the first equals sign splits the item. A value that carries
+		// one of its own, such as the padding of base64, belongs to the
+		// value.
+		name, value, ok := strings.Cut(item, "=")
+		if !ok {
 			return s.reply(ctx, 502, "Couldn't decode the command.")
 		}
-
-		name := parts[0]
-		value := parts[1]
 
 		switch name {
 

--- a/xclient_test.go
+++ b/xclient_test.go
@@ -1,6 +1,8 @@
 package smtpd_test
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	"github.com/chrj/smtpd/v2"
@@ -96,6 +98,100 @@ func TestXCLIENTProtoESMTP(t *testing.T) {
 	}
 	if cap.got == nil || cap.got.String() != "9.9.9.9:999" {
 		t.Fatalf("peer.Addr after XCLIENT = %v, want 9.9.9.9:999", cap.got)
+	}
+	_ = c.Quit()
+}
+
+// capturedPeer holds the Peer recorded by capturePeer.
+type capturedPeer struct{ got smtpd.Peer }
+
+// capturePeer returns a Middleware whose CheckSender stores the first Peer it
+// sees into state.got.
+func capturePeer(state *capturedPeer) smtpd.Middleware {
+	return smtpd.Middleware{
+		CheckSender: func(ctx context.Context, peer smtpd.Peer, _ string) (context.Context, error) {
+			if state.got.Addr == nil {
+				state.got = peer
+			}
+			return ctx, nil
+		},
+	}
+}
+
+// TestXCLIENTValueWithEquals verifies that only the first equals sign splits
+// an item. A value that carries one of its own, such as the padding of base64,
+// belongs to the value.
+func TestXCLIENTValueWithEquals(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		command string
+		field   func(smtpd.Peer) string
+		want    string
+	}{
+		{
+			name:    "padding of base64 in LOGIN",
+			command: "XCLIENT LOGIN=dXNlcg==",
+			field:   func(p smtpd.Peer) string { return p.Username },
+			want:    "dXNlcg==",
+		},
+		{
+			name:    "equals inside HELO",
+			command: "XCLIENT HELO=a=b",
+			field:   func(p smtpd.Peer) string { return p.HeloName },
+			want:    "a=b",
+		},
+		{
+			name:    "an item with equals beside others",
+			command: "XCLIENT ADDR=9.9.9.9 LOGIN=dXNlcg== HELO=a=b",
+			field:   func(p smtpd.Peer) string { return p.Username },
+			want:    "dXNlcg==",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			cap := &capturedPeer{}
+			srv := runserver(t, &smtpd.Server{
+				EnableXCLIENT: true,
+				Logger:        testLogger(t),
+			}, capturePeer(cap))
+
+			// A raw client, because XCLIENT gives the name of the greeting
+			// here. A client library sends its own greeting for MAIL FROM,
+			// which would write over that name after XCLIENT set it.
+			c := dialRaw(t, srv.Addr)
+			c.send("EHLO client.example")
+			if reply := c.send("%s", test.command); !strings.HasPrefix(reply, "220") {
+				t.Fatalf("%q was not accepted: %s", test.command, reply)
+			}
+			if reply := c.send("MAIL FROM:<sender@example.org>"); !strings.HasPrefix(reply, "250") {
+				t.Fatalf("MAIL FROM = %q, want 250", reply)
+			}
+
+			if got := test.field(cap.got); got != test.want {
+				t.Errorf("got %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+// TestXCLIENTValueIsEmpty verifies that an item with nothing after the equals
+// sign is accepted and changes nothing.
+func TestXCLIENTValueIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	srv := runserver(t, &smtpd.Server{
+		EnableXCLIENT: true,
+		Logger:        testLogger(t),
+	})
+
+	c := srv.Dial()
+	if err := smtptest.Cmd(c.Text, 220, "XCLIENT LOGIN="); err != nil {
+		t.Fatalf("XCLIENT with an empty value was not accepted: %v", err)
 	}
 	_ = c.Quit()
 }


### PR DESCRIPTION
`handleXCLIENT` split each item on every equals sign and rejected anything that did not give exactly two parts:

```go
parts := strings.Split(item, "=")
if len(parts) != 2 {
    return s.reply(ctx, 502, "Couldn't decode the command.")
}
```

A value that carries an equals sign of its own therefore failed. The padding of base64 is the common case:

```
XCLIENT LOGIN=dXNlcg==     502 Couldn't decode the command.
XCLIENT HELO=a=b           502 Couldn't decode the command.
```

One bad item rejects the whole command, so the proxy loses every attribute it sent, including `ADDR`. The server then goes on with the address of the proxy instead of the address of the client, which is the reason to run `XCLIENT` at all.

## The change

`strings.Cut` takes the first equals sign and leaves the rest with the value. An item with no equals sign is still rejected, as before.

## Tests

- A value with the padding of base64 in `LOGIN`.
- A value with an equals sign inside `HELO`.
- One such item beside others in the same command.
- An item with nothing after the equals sign is accepted and changes nothing.

The three tests for the first case fail before the change with `502`.

The tests drive a socket directly. `XCLIENT` gives the name of the greeting, and a client library sends a greeting of its own before `MAIL FROM`, which writes over that name before the check can read it.

The five tests that were already there pass unchanged, including the one that holds an item with no equals sign at `502`.

`go test ./...`, `golangci-lint run ./...`, `gofmt -l .` and `go vet ./...` are all clean.
