### PR TITLE
fix: decode XCLIENT values and read the marks for no information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `XCLIENT` decodes its attribute values. The XCLIENT specification writes
+  them in the xtext encoding of RFC 1891, where `+` starts a byte written as
+  two hexadecimal digits. The server read them as they came, so
+  `LOGIN=user+40example.com` gave the user name `user+40example.com` instead
+  of `user@example.com`. A `+` that two such digits do not follow stands for
+  itself, so a value that the proxy sent without encoding still arrives whole.
+
+- `XCLIENT` reads `[UNAVAILABLE]` and `[TEMPUNAVAIL]` as the marks for an
+  attribute the proxy has no information for, and leaves that attribute as it
+  was. `HELO` and `LOGIN` took the mark itself as the name and the user
+  before, and `PORT=[UNAVAILABLE]` failed the whole command with `502`, which
+  dropped the address of the client along with it.
+
 - `XCLIENT` accepts a value that carries an equals sign, such as the padding
   of base64 in `LOGIN=dXNlcg==`. Every equals sign split the item before, so
   the server answered `502` and the proxy lost the attributes it sent.

--- a/README.md
+++ b/README.md
@@ -205,6 +205,26 @@ Commands that arrive in the same write as `STARTTLS` never run. The session
 builds a new reader on the TLS connection, so the bytes that were read into
 the buffer with `STARTTLS` are dropped.
 
+### XCLIENT
+
+Set `Server.EnableXCLIENT` to let a proxy in front of the server give the
+identity of the client it took the connection from. `ADDR` and `PORT` replace
+`Peer.Addr`, `HELO` replaces `Peer.HeloName`, `LOGIN` replaces
+`Peer.Username`, and `PROTO` replaces `Peer.Protocol`.
+
+Turn this on only where a proxy you trust reaches the server. The command
+gives the client any identity it asks for, and middleware such as the
+greylist, the RBL check and the rate limit all read `Peer.Addr`.
+
+Attribute values arrive in the xtext encoding of RFC 1891, where `+` starts a
+byte written as two hexadecimal digits. The server decodes them, so
+`LOGIN=user+40example.com` gives `user@example.com`. A `+` that two such
+digits do not follow stands for itself, so a value that the proxy sent without
+encoding still arrives whole.
+
+The values `[UNAVAILABLE]` and `[TEMPUNAVAIL]` say that the proxy has no
+information for that attribute, and leave it as it was.
+
 ### Panics
 
 A panic in `Server.Handler` or in a middleware hook stops that session only.

--- a/xclient.go
+++ b/xclient.go
@@ -36,31 +36,41 @@ func (s *session) handleXCLIENT(ctx context.Context, cmd *command) context.Conte
 			return s.reply(ctx, 502, "Couldn't decode the command.")
 		}
 
+		value = decodeXtext(value)
+
+		// A value that says the proxy has no information leaves the
+		// attribute as it was. The name of the attribute is still read, so
+		// one that this server does not know is still refused.
+		none := isUnavailable(value)
+
 		switch name {
 
 		case "NAME":
 			// Unused in smtpd package
-			continue
 
 		case "HELO":
-			newHeloName = value
-			continue
+			if !none {
+				newHeloName = value
+			}
 
 		case "ADDR":
-			newAddr = net.ParseIP(value)
-			continue
+			if !none {
+				newAddr = net.ParseIP(value)
+			}
 
 		case "PORT":
-			var err error
-			newTCPPort, err = strconv.ParseUint(value, 10, 16)
-			if err != nil {
-				return s.reply(ctx, 502, "Couldn't decode the command.")
+			if !none {
+				port, err := strconv.ParseUint(value, 10, 16)
+				if err != nil {
+					return s.reply(ctx, 502, "Couldn't decode the command.")
+				}
+				newTCPPort = port
 			}
-			continue
 
 		case "LOGIN":
-			newUsername = value
-			continue
+			if !none {
+				newUsername = value
+			}
 
 		case "PROTO":
 			switch value {
@@ -69,7 +79,6 @@ func (s *session) handleXCLIENT(ctx context.Context, cmd *command) context.Conte
 			case "ESMTP":
 				newProto = ESMTP
 			}
-			continue
 
 		default:
 			return s.reply(ctx, 502, "Couldn't decode the command.")

--- a/xclient_test.go
+++ b/xclient_test.go
@@ -195,3 +195,133 @@ func TestXCLIENTValueIsEmpty(t *testing.T) {
 	}
 	_ = c.Quit()
 }
+
+// TestXCLIENTDecodesXtext verifies that an attribute value arrives decoded.
+// RFC 1891 xtext is what the XCLIENT specification of Postfix asks for.
+func TestXCLIENTDecodesXtext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		command string
+		field   func(smtpd.Peer) string
+		want    string
+	}{
+		{
+			name:    "an at sign in LOGIN",
+			command: "XCLIENT LOGIN=user+40example.com",
+			field:   func(p smtpd.Peer) string { return p.Username },
+			want:    "user@example.com",
+		},
+		{
+			name:    "a plus sign in HELO",
+			command: "XCLIENT HELO=a+2Bb",
+			field:   func(p smtpd.Peer) string { return p.HeloName },
+			want:    "a+b",
+		},
+		{
+			name:    "a plus that no digits follow stays as it is",
+			command: "XCLIENT LOGIN=user+tag@example.com",
+			field:   func(p smtpd.Peer) string { return p.Username },
+			want:    "user+tag@example.com",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			cap := &capturedPeer{}
+			srv := runserver(t, &smtpd.Server{
+				EnableXCLIENT: true,
+				Logger:        testLogger(t),
+			}, capturePeer(cap))
+
+			c := dialRaw(t, srv.Addr)
+			c.send("EHLO client.example")
+			if reply := c.send("%s", test.command); !strings.HasPrefix(reply, "220") {
+				t.Fatalf("%q was not accepted: %s", test.command, reply)
+			}
+			if reply := c.send("MAIL FROM:<sender@example.org>"); !strings.HasPrefix(reply, "250") {
+				t.Fatalf("MAIL FROM = %q, want 250", reply)
+			}
+
+			if got := test.field(cap.got); got != test.want {
+				t.Errorf("got %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+// TestXCLIENTUnavailable verifies that a value which says the proxy has no
+// information leaves the attribute as it was, and does not fail the command.
+func TestXCLIENTUnavailable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		command string
+	}{
+		{name: "HELO", command: "XCLIENT HELO=[UNAVAILABLE]"},
+		{name: "LOGIN", command: "XCLIENT LOGIN=[UNAVAILABLE]"},
+		{name: "ADDR", command: "XCLIENT ADDR=[UNAVAILABLE]"},
+		{name: "PORT", command: "XCLIENT PORT=[UNAVAILABLE]"},
+		{name: "NAME", command: "XCLIENT NAME=[TEMPUNAVAIL]"},
+		{name: "beside an attribute that has a value", command: "XCLIENT PORT=[UNAVAILABLE] ADDR=9.9.9.9"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			cap := &capturedPeer{}
+			srv := runserver(t, &smtpd.Server{
+				EnableXCLIENT: true,
+				Logger:        testLogger(t),
+			}, capturePeer(cap))
+
+			c := dialRaw(t, srv.Addr)
+			c.send("EHLO client.example")
+			if reply := c.send("%s", test.command); !strings.HasPrefix(reply, "220") {
+				t.Fatalf("%q was not accepted: %s", test.command, reply)
+			}
+			if reply := c.send("MAIL FROM:<sender@example.org>"); !strings.HasPrefix(reply, "250") {
+				t.Fatalf("MAIL FROM = %q, want 250", reply)
+			}
+
+			// Nothing takes the mark itself as a name or a user.
+			if strings.Contains(cap.got.HeloName, "UNAVAIL") {
+				t.Errorf("HeloName = %q, want the greeting to stand", cap.got.HeloName)
+			}
+			if strings.Contains(cap.got.Username, "UNAVAIL") {
+				t.Errorf("Username = %q, want it empty", cap.got.Username)
+			}
+		})
+	}
+}
+
+// TestXCLIENTUnavailableAddressKeepsThePeer verifies that the address of the
+// connection stands when the proxy reports no address.
+func TestXCLIENTUnavailableAddressKeepsThePeer(t *testing.T) {
+	t.Parallel()
+
+	cap := &capturedPeer{}
+	srv := runserver(t, &smtpd.Server{
+		EnableXCLIENT: true,
+		Logger:        testLogger(t),
+	}, capturePeer(cap))
+
+	c := dialRaw(t, srv.Addr)
+	c.send("EHLO client.example")
+	if reply := c.send("XCLIENT ADDR=[UNAVAILABLE] PORT=[UNAVAILABLE]"); !strings.HasPrefix(reply, "220") {
+		t.Fatalf("XCLIENT was not accepted: %s", reply)
+	}
+	c.send("MAIL FROM:<sender@example.org>")
+
+	if cap.got.Addr == nil {
+		t.Fatal("expected the address of the connection to stand")
+	}
+	if !strings.HasPrefix(cap.got.Addr.String(), "127.0.0.1:") {
+		t.Errorf("Addr = %v, want the address of the connection", cap.got.Addr)
+	}
+}

--- a/xtext.go
+++ b/xtext.go
@@ -1,0 +1,63 @@
+package smtpd
+
+import "strings"
+
+// decodeXtext decodes the xtext encoding of RFC 1891, which the XCLIENT
+// specification asks for on every attribute value. A "+" starts a byte
+// written as two hexadecimal digits, and every other character stands for
+// itself.
+//
+// A "+" that two hexadecimal digits do not follow stands for itself as well.
+// The specification does not allow that, but a proxy that sends a value
+// without encoding it is common, and a plus sign in an address is ordinary.
+// Reading such a value as it came keeps the rest of the command, where
+// refusing it would drop the address of the client with it.
+func decodeXtext(value string) string {
+	if !strings.Contains(value, "+") {
+		return value
+	}
+
+	var out strings.Builder
+	out.Grow(len(value))
+
+	for i := 0; i < len(value); i++ {
+		if value[i] != '+' || i+2 >= len(value) {
+			out.WriteByte(value[i])
+			continue
+		}
+
+		hi, hiOK := hexDigit(value[i+1])
+		lo, loOK := hexDigit(value[i+2])
+		if !hiOK || !loOK {
+			out.WriteByte(value[i])
+			continue
+		}
+
+		out.WriteByte(hi<<4 | lo)
+		i += 2
+	}
+
+	return out.String()
+}
+
+// hexDigit returns the value of one hexadecimal digit. RFC 1891 writes the
+// digits in upper case, and lower case is taken as well.
+func hexDigit(c byte) (byte, bool) {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0', true
+	case c >= 'A' && c <= 'F':
+		return c - 'A' + 10, true
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10, true
+	}
+	return 0, false
+}
+
+// isUnavailable reports whether an XCLIENT value says that the proxy has no
+// information for that attribute. Postfix sends these two marks, and the
+// attribute they carry has to stay as it was.
+func isUnavailable(value string) bool {
+	return strings.EqualFold(value, "[UNAVAILABLE]") ||
+		strings.EqualFold(value, "[TEMPUNAVAIL]")
+}

--- a/xtext_test.go
+++ b/xtext_test.go
@@ -1,0 +1,122 @@
+package smtpd
+
+import "testing"
+
+// TestDecodeXtext covers the encoding that RFC 1891 defines and that XCLIENT
+// uses for its attribute values.
+func TestDecodeXtext(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "a value with nothing to decode",
+			in:   "mail.example.com",
+			want: "mail.example.com",
+		},
+		{
+			name: "an at sign",
+			in:   "user+40example.com",
+			want: "user@example.com",
+		},
+		{
+			name: "a plus sign",
+			in:   "a+2Bb",
+			want: "a+b",
+		},
+		{
+			name: "an equals sign",
+			in:   "a+3Db",
+			want: "a=b",
+		},
+		{
+			name: "a space",
+			in:   "two+20words",
+			want: "two words",
+		},
+		{
+			name: "lower case digits",
+			in:   "user+40example.com",
+			want: "user@example.com",
+		},
+		{
+			name: "lower case letters in the digits",
+			in:   "a+2bb",
+			want: "a+b",
+		},
+		{
+			name: "more than one",
+			in:   "a+2Bb+40c",
+			want: "a+b@c",
+		},
+		{
+			name: "at the start and at the end",
+			in:   "+40middle+40",
+			want: "@middle@",
+		},
+		{
+			name: "a plus that no digits follow stands for itself",
+			in:   "user+tag@example.com",
+			want: "user+tag@example.com",
+		},
+		{
+			name: "a plus at the end stands for itself",
+			in:   "trailing+",
+			want: "trailing+",
+		},
+		{
+			name: "a plus with one digit stands for itself",
+			in:   "short+4",
+			want: "short+4",
+		},
+		{
+			name: "a plus that one digit and one letter follow",
+			in:   "mixed+4z",
+			want: "mixed+4z",
+		},
+		{
+			name: "an empty value",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "the mark for no information",
+			in:   "[UNAVAILABLE]",
+			want: "[UNAVAILABLE]",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := decodeXtext(test.in); got != test.want {
+				t.Errorf("decodeXtext(%q) = %q, want %q", test.in, got, test.want)
+			}
+		})
+	}
+}
+
+// TestIsUnavailable covers the values that say the proxy has no information.
+func TestIsUnavailable(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"[UNAVAILABLE]", true},
+		{"[TEMPUNAVAIL]", true},
+		{"[unavailable]", true},
+		{"[TempUnavail]", true},
+		{"UNAVAILABLE", false},
+		{"[UNAVAILABLE", false},
+		{"mail.example.com", false},
+		{"", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.in, func(t *testing.T) {
+			if got := isUnavailable(test.in); got != test.want {
+				t.Errorf("isUnavailable(%q) = %v, want %v", test.in, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Two faults in how `handleXCLIENT` reads an attribute value.

## The encoding

The XCLIENT specification writes attribute values in the xtext encoding of RFC 1891, where `+` starts a byte written as two hexadecimal digits. The server read them as they came:

| The proxy sends | Before | After |
| --- | --- | --- |
| `LOGIN=user+40example.com` | `user+40example.com` | `user@example.com` |
| `HELO=a+2Bb` | `a+2Bb` | `a+b` |

A handler or a middleware that matched on the user name saw a name that no account carries.

A `+` that two hexadecimal digits do not follow stands for itself. The specification does not allow that, but a proxy that sends a value without encoding it is common, and a plus sign in an address is ordinary. `LOGIN=user+tag@example.com` therefore arrives whole, where refusing it would drop the address of the client with it.

## The marks for no information

`[UNAVAILABLE]` and `[TEMPUNAVAIL]` say that the proxy has no information for an attribute. Postfix sends them.

| The proxy sends | Before | After |
| --- | --- | --- |
| `HELO=[UNAVAILABLE]` | `Peer.HeloName` became `[UNAVAILABLE]` | the greeting stands |
| `LOGIN=[UNAVAILABLE]` | `Peer.Username` became `[UNAVAILABLE]` | stays empty |
| `PORT=[UNAVAILABLE]` | `502` for the whole command | the port stands |

`ADDR=[UNAVAILABLE]` already worked, because `net.ParseIP` returns nil for it.

The `PORT` case is the one that costs most. One attribute the server could not read fails the whole command, so a command such as

```
XCLIENT PORT=[UNAVAILABLE] ADDR=9.9.9.9
```

was answered `502` and the address went with it. The server then went on with the address of the proxy, and the greylist, the RBL check and the rate limit all read that address instead of the address of the client.

A test holds this: it fails on `main` with `502 Couldn't decode the command.`

## Kept as it was

- An item with no equals sign is refused.
- An attribute name this server does not know is refused, whatever its value.
- `PORT` with a value that is neither a number nor one of the marks is refused.

## Tests

`decodeXtext` and `isUnavailable` are pure functions with a table each: 15 cases for the encoding, covering both cases of the digits, more than one escape in a value, an escape at each end, and the four shapes of a `+` that stands for itself; 8 cases for the marks, covering the case of the letters and a mark that is not closed.

Over a socket: the encoding on `LOGIN` and on `HELO`, a `+` that stands for itself, each of the five attributes with a mark, a mark beside an attribute that has a value, and the address of the connection standing when the proxy reports none.

`go test ./...`, `golangci-lint run ./...`, `gofmt -l .` and `go vet ./...` are all clean.
