### PR TITLE
fix: answer with the reply code that RFC 5321 gives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The server answers with the reply code that RFC 5321 gives for each fault.
+  It used `502`, which means that the command is not implemented, for a
+  command that came in the wrong order and for one with a bad argument.
+
+  | The client does this | Before | Now |
+  | --- | --- | --- |
+  | Sends a command this server does not know | `502` | `500` |
+  | Sends a line that is not a command | `502` | `500` |
+  | Leaves out the name on `HELO` or `EHLO` | `502` | `501` |
+  | Writes `MAIL FROM` or `RCPT TO` wrongly | `502` | `501` |
+  | Gives an address that does not parse | `502` | `501` |
+  | Writes `XCLIENT` or `PROXY` wrongly | `502` | `501` |
+  | Sends `AUTH` with no mechanism | `502` | `501` |
+  | Sends credentials that do not decode | `502` | `501` |
+  | Sends `MAIL FROM` before a greeting | `502` | `503` |
+  | Sends `MAIL FROM` twice | `502` | `503` |
+  | Sends `RCPT TO` before `MAIL FROM` | `502` | `503` |
+  | Sends `DATA` before `RCPT TO` | `502` | `503` |
+  | Sends `AUTH` before a greeting | `502` | `503` |
+  | Sends `STARTTLS` inside TLS | `502` | `503` |
+  | Asks for a mechanism this server does not have | `502` | `504` |
+  | Sends `AUTH` in plain text where STARTTLS is offered | `502` | `530` |
+
+  `502` stays where the command really is not implemented: `AUTH` with no
+  authenticator, `STARTTLS` with no TLS, `AUTH` in plain text where STARTTLS
+  is not offered, and `XCLIENT` or `PROXY` on a connection that is not TCP.
+
+  A client that reads the first digit only sees no change. One that matches
+  the whole code has to be read again.
+
 ### Fixed
 
 - `XCLIENT` decodes its attribute values. The XCLIENT specification writes

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ drop what it learned there, so a successful `STARTTLS` clears `Peer.HeloName`,
 `Peer.Protocol` and `Peer.Username`, and the envelope.
 
 The client must send `EHLO` or `HELO` again. Without it, `MAIL FROM` is
-answered with `502`. Client libraries do this for themselves: `StartTLS` in
+answered with `503`. Client libraries do this for themselves: `StartTLS` in
 `net/smtp` sends `EHLO` again as part of the call.
 
 Commands that arrive in the same write as `STARTTLS` never run. The session

--- a/auth.go
+++ b/auth.go
@@ -13,7 +13,7 @@ func (s *session) handleAUTH(ctx context.Context, cmd *command) context.Context 
 
 	args := cmd.args()
 	if len(args) < 1 || len(args) > 2 {
-		return s.reply(ctx, 502, "Invalid syntax.")
+		return s.reply(ctx, 501, "Invalid syntax.")
 	}
 
 	if !s.server.hasAuthenticator() {
@@ -21,14 +21,14 @@ func (s *session) handleAUTH(ctx context.Context, cmd *command) context.Context 
 	}
 
 	if s.peer.HeloName == "" {
-		return s.reply(ctx, 502, "Please introduce yourself first.")
+		return s.reply(ctx, 503, "Please introduce yourself first.")
 	}
 
 	if !s.tls && !s.server.AllowInsecureAuth {
 		if s.server.TLSConfig == nil {
 			return s.reply(ctx, 502, "Cannot AUTH in plain text mode and STARTTLS is not available.")
 		}
-		return s.reply(ctx, 502, "Cannot AUTH in plain text mode. Use STARTTLS.")
+		return s.reply(ctx, 530, "Cannot AUTH in plain text mode. Use STARTTLS.")
 	}
 
 	mechanism := strings.ToUpper(args[0])
@@ -55,13 +55,13 @@ func (s *session) handleAUTH(ctx context.Context, cmd *command) context.Context 
 		data, err := base64.StdEncoding.DecodeString(auth)
 
 		if err != nil {
-			return s.reply(ctx, 502, "Couldn't decode your credentials")
+			return s.reply(ctx, 501, "Couldn't decode your credentials")
 		}
 
 		parts := bytes.Split(data, []byte{0})
 
 		if len(parts) != 3 {
-			return s.reply(ctx, 502, "Couldn't decode your credentials")
+			return s.reply(ctx, 501, "Couldn't decode your credentials")
 		}
 
 		username = string(parts[1])
@@ -84,7 +84,7 @@ func (s *session) handleAUTH(ctx context.Context, cmd *command) context.Context 
 		byteUsername, err := base64.StdEncoding.DecodeString(encodedUsername)
 
 		if err != nil {
-			return s.reply(ctx, 502, "Couldn't decode your credentials")
+			return s.reply(ctx, 501, "Couldn't decode your credentials")
 		}
 
 		ctx = s.reply(ctx, 334, "UGFzc3dvcmQ6")
@@ -96,7 +96,7 @@ func (s *session) handleAUTH(ctx context.Context, cmd *command) context.Context 
 		bytePassword, err := base64.StdEncoding.DecodeString(s.scanner.Text())
 
 		if err != nil {
-			return s.reply(ctx, 502, "Couldn't decode your credentials")
+			return s.reply(ctx, 501, "Couldn't decode your credentials")
 		}
 
 		username = string(byteUsername)
@@ -105,7 +105,7 @@ func (s *session) handleAUTH(ctx context.Context, cmd *command) context.Context 
 	default:
 
 		logger.WarnContext(ctx, "unknown authentication mechanism", slog.String("mechanism", mechanism))
-		return s.reply(ctx, 502, "Unknown authentication mechanism")
+		return s.reply(ctx, 504, "Unknown authentication mechanism")
 
 	}
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -38,8 +38,8 @@ func TestAUTHNoArgs(t *testing.T) {
 	srv := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, acceptAuth())
 
 	c := srv.Dial()
-	if err := smtptest.Cmd(c.Text, 502, "AUTH"); err != nil {
-		t.Fatalf("AUTH with no mechanism didn't 502: %v", err)
+	if err := smtptest.Cmd(c.Text, 501, "AUTH"); err != nil {
+		t.Fatalf("AUTH with no mechanism didn't 501: %v", err)
 	}
 	_ = c.Quit()
 }
@@ -72,8 +72,8 @@ func TestAUTHBeforeHELO(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Dial failed: %v", err)
 	}
-	if err := smtptest.Cmd(c2.Text, 502, "AUTH PLAIN Zm9vAGJhcgBxdXV4"); err != nil {
-		t.Fatalf("AUTH before HELO didn't 502: %v", err)
+	if err := smtptest.Cmd(c2.Text, 503, "AUTH PLAIN Zm9vAGJhcgBxdXV4"); err != nil {
+		t.Fatalf("AUTH before HELO didn't 503: %v", err)
 	}
 	_ = c2.Quit()
 }
@@ -99,8 +99,8 @@ func TestAUTHUnknownMechanism(t *testing.T) {
 	srv := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, acceptAuth())
 
 	c := srv.Dial()
-	if err := smtptest.Cmd(c.Text, 502, "AUTH WHATEVER"); err != nil {
-		t.Fatalf("AUTH WHATEVER didn't 502: %v", err)
+	if err := smtptest.Cmd(c.Text, 504, "AUTH WHATEVER"); err != nil {
+		t.Fatalf("AUTH WHATEVER didn't 504: %v", err)
 	}
 	_ = c.Quit()
 }
@@ -111,8 +111,8 @@ func TestAUTHPLAINBadBase64(t *testing.T) {
 	srv := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, acceptAuth())
 
 	c := srv.Dial()
-	if err := smtptest.Cmd(c.Text, 502, "AUTH PLAIN !!!not-base64!!!"); err != nil {
-		t.Fatalf("AUTH PLAIN bad base64 didn't 502: %v", err)
+	if err := smtptest.Cmd(c.Text, 501, "AUTH PLAIN !!!not-base64!!!"); err != nil {
+		t.Fatalf("AUTH PLAIN bad base64 didn't 501: %v", err)
 	}
 	_ = c.Quit()
 }
@@ -124,8 +124,8 @@ func TestAUTHPLAINWrongParts(t *testing.T) {
 
 	c := srv.Dial()
 	// "foo\x00bar" - only two parts, PLAIN requires three.
-	if err := smtptest.Cmd(c.Text, 502, "AUTH PLAIN Zm9vAGJhcg=="); err != nil {
-		t.Fatalf("AUTH PLAIN malformed didn't 502: %v", err)
+	if err := smtptest.Cmd(c.Text, 501, "AUTH PLAIN Zm9vAGJhcg=="); err != nil {
+		t.Fatalf("AUTH PLAIN malformed didn't 501: %v", err)
 	}
 	_ = c.Quit()
 }
@@ -159,8 +159,8 @@ func TestAUTHLOGINBadBase64Username(t *testing.T) {
 	srv := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, acceptAuth())
 
 	c := srv.Dial()
-	if err := smtptest.Cmd(c.Text, 502, "AUTH LOGIN !!!"); err != nil {
-		t.Fatalf("AUTH LOGIN bad base64 didn't 502: %v", err)
+	if err := smtptest.Cmd(c.Text, 501, "AUTH LOGIN !!!"); err != nil {
+		t.Fatalf("AUTH LOGIN bad base64 didn't 501: %v", err)
 	}
 	_ = c.Quit()
 }
@@ -175,8 +175,8 @@ func TestAUTHLOGINBadBase64Password(t *testing.T) {
 	if err := smtptest.Cmd(c.Text, 334, "AUTH LOGIN Zm9v"); err != nil {
 		t.Fatalf("AUTH LOGIN failed: %v", err)
 	}
-	if err := smtptest.Cmd(c.Text, 502, "!!!"); err != nil {
-		t.Fatalf("LOGIN bad-base64 password didn't 502: %v", err)
+	if err := smtptest.Cmd(c.Text, 501, "!!!"); err != nil {
+		t.Fatalf("LOGIN bad-base64 password didn't 501: %v", err)
 	}
 	_ = c.Quit()
 }
@@ -272,4 +272,22 @@ func TestAUTHInsecureDeniedByDefault(t *testing.T) {
 	}
 
 	_ = c.Quit()
+}
+
+// TestAUTHBeforeSTARTTLS verifies that a server which offers STARTTLS answers
+// 530 to an AUTH in plain text. RFC 3207 gives that code for a command that
+// needs the TLS layer first, and middleware.RequireTLS uses it too.
+func TestAUTHBeforeSTARTTLS(t *testing.T) {
+	t.Parallel()
+
+	srv := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, acceptAuth())
+
+	// A raw client, so that the connection stays in plain text. Dial on the
+	// test server runs STARTTLS for itself.
+	c := dialRaw(t, srv.Addr)
+	c.send("EHLO client.example")
+
+	if reply := c.send("AUTH PLAIN Zm9vAGJhcgBxdXV4"); !strings.HasPrefix(reply, "530") {
+		t.Fatalf("AUTH in plain text = %q, want 530", reply)
+	}
 }

--- a/data.go
+++ b/data.go
@@ -13,7 +13,7 @@ func (s *session) handleDATA(ctx context.Context, cmd *command) context.Context 
 	ctx, _ = phasedLoggerFromContext(ctx, "data")
 
 	if s.envelope == nil || len(s.envelope.Recipients) == 0 {
-		return s.reply(ctx, 502, "Missing RCPT TO command.")
+		return s.reply(ctx, 503, "Missing RCPT TO command.")
 	}
 
 	ctx = s.reply(ctx, 354, "Go ahead. End your data with <CR><LF>.<CR><LF>")

--- a/data_test.go
+++ b/data_test.go
@@ -303,8 +303,8 @@ func TestHandleDATAMissingRCPT(t *testing.T) {
 
 	srv := &Server{MaxMessageSize: 1024}
 	codes := runDATA(t, srv, nil, "")
-	if len(codes) != 1 || codes[0] != 502 {
-		t.Fatalf("codes = %v, want [502]", codes)
+	if len(codes) != 1 || codes[0] != 503 {
+		t.Fatalf("codes = %v, want [503]", codes)
 	}
 }
 

--- a/protocol.go
+++ b/protocol.go
@@ -51,7 +51,7 @@ func (s *session) validateMailParams(params map[string]string) error {
 func (s *session) handle(ctx context.Context, line string) context.Context {
 	cmd, err := parseCommand(line)
 	if err != nil {
-		return s.reply(ctx, 502, "Invalid syntax.")
+		return s.reply(ctx, 500, "Invalid syntax.")
 	}
 
 	// Commands are dispatched to the appropriate handler functions.
@@ -98,7 +98,7 @@ func (s *session) handle(ctx context.Context, line string) context.Context {
 
 	}
 
-	return s.reply(ctx, 502, "Unsupported command.")
+	return s.reply(ctx, 500, "Unsupported command.")
 
 }
 
@@ -107,7 +107,7 @@ func (s *session) handleHELO(ctx context.Context, cmd *command) context.Context 
 
 	name, ok := cmd.singleArg()
 	if !ok {
-		return s.reply(ctx, 502, "Missing parameter")
+		return s.reply(ctx, 501, "Missing parameter")
 	}
 
 	if s.peer.HeloName != "" {
@@ -132,7 +132,7 @@ func (s *session) handleEHLO(ctx context.Context, cmd *command) context.Context 
 
 	name, ok := cmd.singleArg()
 	if !ok {
-		return s.reply(ctx, 502, "Missing parameter")
+		return s.reply(ctx, 501, "Missing parameter")
 	}
 
 	if s.peer.HeloName != "" {
@@ -168,15 +168,15 @@ func (s *session) handleMAIL(ctx context.Context, cmd *command) context.Context 
 
 	addrSpec, params, err := cmd.pathArg("FROM")
 	if err != nil {
-		return s.reply(ctx, 502, "Invalid syntax.")
+		return s.reply(ctx, 501, "Invalid syntax.")
 	}
 
 	if s.peer.HeloName == "" {
-		return s.reply(ctx, 502, "Please introduce yourself first.")
+		return s.reply(ctx, 503, "Please introduce yourself first.")
 	}
 
 	if s.envelope != nil {
-		return s.reply(ctx, 502, "Duplicate MAIL")
+		return s.reply(ctx, 503, "Duplicate MAIL")
 	}
 
 	addr := "" // null sender
@@ -186,7 +186,7 @@ func (s *session) handleMAIL(ctx context.Context, cmd *command) context.Context 
 		addr, err = parseAddress(addrSpec)
 
 		if err != nil {
-			return s.reply(ctx, 502, "Malformed e-mail address")
+			return s.reply(ctx, 501, "Malformed e-mail address")
 		}
 	}
 
@@ -214,11 +214,11 @@ func (s *session) handleRCPT(ctx context.Context, cmd *command) context.Context 
 
 	addrSpec, params, err := cmd.pathArg("TO")
 	if err != nil {
-		return s.reply(ctx, 502, "Invalid syntax.")
+		return s.reply(ctx, 501, "Invalid syntax.")
 	}
 
 	if s.envelope == nil {
-		return s.reply(ctx, 502, "Missing MAIL FROM command.")
+		return s.reply(ctx, 503, "Missing MAIL FROM command.")
 	}
 
 	if len(s.envelope.Recipients) >= s.server.MaxRecipients {
@@ -232,7 +232,7 @@ func (s *session) handleRCPT(ctx context.Context, cmd *command) context.Context 
 	addr, err := parseAddress(addrSpec)
 
 	if err != nil {
-		return s.reply(ctx, 502, "Malformed e-mail address")
+		return s.reply(ctx, 501, "Malformed e-mail address")
 	}
 
 	ctx, err = s.server.checkRecipient(ctx, s.peer, addr)
@@ -250,7 +250,7 @@ func (s *session) handleSTARTTLS(ctx context.Context, cmd *command) context.Cont
 	ctx, logger := phasedLoggerFromContext(ctx, "starttls")
 
 	if s.tls {
-		return s.reply(ctx, 502, "Already running in TLS")
+		return s.reply(ctx, 503, "Already running in TLS")
 	}
 
 	if s.server.TLSConfig == nil {

--- a/proxy.go
+++ b/proxy.go
@@ -14,7 +14,7 @@ func (s *session) handlePROXY(ctx context.Context, cmd *command) context.Context
 	}
 
 	if len(fields) < 5 {
-		return s.reply(ctx, 502, "Couldn't decode the command.")
+		return s.reply(ctx, 501, "Couldn't decode the command.")
 	}
 
 	var (
@@ -27,7 +27,7 @@ func (s *session) handlePROXY(ctx context.Context, cmd *command) context.Context
 
 	newTCPPort, err = strconv.ParseUint(fields[3], 10, 16)
 	if err != nil {
-		return s.reply(ctx, 502, "Couldn't decode the command.")
+		return s.reply(ctx, 501, "Couldn't decode the command.")
 	}
 
 	tcpAddr, ok := s.peer.Addr.(*net.TCPAddr)

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -59,8 +59,8 @@ func TestPROXYTooFewFields(t *testing.T) {
 
 	tp, raw := dialRawProxy(t, srv.Addr)
 	defer func() { _ = raw.Close() }()
-	if err := smtptest.Cmd(tp, 502, "PROXY TCP4 1.2.3.4 5.6.7.8 12345"); err != nil {
-		t.Fatalf("PROXY with too few fields didn't 502: %v", err)
+	if err := smtptest.Cmd(tp, 501, "PROXY TCP4 1.2.3.4 5.6.7.8 12345"); err != nil {
+		t.Fatalf("PROXY with too few fields didn't 501: %v", err)
 	}
 }
 
@@ -74,8 +74,8 @@ func TestPROXYBadPort(t *testing.T) {
 
 	tp, raw := dialRawProxy(t, srv.Addr)
 	defer func() { _ = raw.Close() }()
-	if err := smtptest.Cmd(tp, 502, "PROXY TCP4 1.2.3.4 5.6.7.8 notanumber 25"); err != nil {
-		t.Fatalf("PROXY with bad port didn't 502: %v", err)
+	if err := smtptest.Cmd(tp, 501, "PROXY TCP4 1.2.3.4 5.6.7.8 notanumber 25"); err != nil {
+		t.Fatalf("PROXY with bad port didn't 501: %v", err)
 	}
 }
 

--- a/starttls_test.go
+++ b/starttls_test.go
@@ -101,8 +101,8 @@ func TestSTARTTLSDiscardsTheGreeting(t *testing.T) {
 	c.startTLS()
 
 	// No new greeting. The name from before TLS must not carry over.
-	if reply := c.send("MAIL FROM:<s@example.org>"); !strings.HasPrefix(reply, "502") {
-		t.Fatalf("MAIL without a new greeting = %q, want 502", reply)
+	if reply := c.send("MAIL FROM:<s@example.org>"); !strings.HasPrefix(reply, "503") {
+		t.Fatalf("MAIL without a new greeting = %q, want 503", reply)
 	}
 }
 

--- a/xclient.go
+++ b/xclient.go
@@ -12,7 +12,7 @@ func (s *session) handleXCLIENT(ctx context.Context, cmd *command) context.Conte
 
 	fields := cmd.args()
 	if len(fields) < 1 {
-		return s.reply(ctx, 502, "Invalid syntax.")
+		return s.reply(ctx, 501, "Invalid syntax.")
 	}
 
 	if !s.server.EnableXCLIENT {
@@ -33,7 +33,7 @@ func (s *session) handleXCLIENT(ctx context.Context, cmd *command) context.Conte
 		// value.
 		name, value, ok := strings.Cut(item, "=")
 		if !ok {
-			return s.reply(ctx, 502, "Couldn't decode the command.")
+			return s.reply(ctx, 501, "Couldn't decode the command.")
 		}
 
 		value = decodeXtext(value)
@@ -62,7 +62,7 @@ func (s *session) handleXCLIENT(ctx context.Context, cmd *command) context.Conte
 			if !none {
 				port, err := strconv.ParseUint(value, 10, 16)
 				if err != nil {
-					return s.reply(ctx, 502, "Couldn't decode the command.")
+					return s.reply(ctx, 501, "Couldn't decode the command.")
 				}
 				newTCPPort = port
 			}
@@ -81,7 +81,7 @@ func (s *session) handleXCLIENT(ctx context.Context, cmd *command) context.Conte
 			}
 
 		default:
-			return s.reply(ctx, 502, "Couldn't decode the command.")
+			return s.reply(ctx, 501, "Couldn't decode the command.")
 		}
 
 	}

--- a/xclient_test.go
+++ b/xclient_test.go
@@ -18,8 +18,8 @@ func TestXCLIENTNoArgs(t *testing.T) {
 	})
 
 	c := srv.Dial()
-	if err := smtptest.Cmd(c.Text, 502, "XCLIENT"); err != nil {
-		t.Fatalf("XCLIENT with no args didn't 502: %v", err)
+	if err := smtptest.Cmd(c.Text, 501, "XCLIENT"); err != nil {
+		t.Fatalf("XCLIENT with no args didn't 501: %v", err)
 	}
 }
 
@@ -43,8 +43,8 @@ func TestXCLIENTMalformedItem(t *testing.T) {
 	})
 
 	c := srv.Dial()
-	if err := smtptest.Cmd(c.Text, 502, "XCLIENT NAMEwithoutequals"); err != nil {
-		t.Fatalf("XCLIENT with malformed item didn't 502: %v", err)
+	if err := smtptest.Cmd(c.Text, 501, "XCLIENT NAMEwithoutequals"); err != nil {
+		t.Fatalf("XCLIENT with malformed item didn't 501: %v", err)
 	}
 }
 
@@ -57,8 +57,8 @@ func TestXCLIENTBadPort(t *testing.T) {
 	})
 
 	c := srv.Dial()
-	if err := smtptest.Cmd(c.Text, 502, "XCLIENT PORT=notanumber"); err != nil {
-		t.Fatalf("XCLIENT with bad port didn't 502: %v", err)
+	if err := smtptest.Cmd(c.Text, 501, "XCLIENT PORT=notanumber"); err != nil {
+		t.Fatalf("XCLIENT with bad port didn't 501: %v", err)
 	}
 }
 
@@ -71,8 +71,8 @@ func TestXCLIENTUnknownAttribute(t *testing.T) {
 	})
 
 	c := srv.Dial()
-	if err := smtptest.Cmd(c.Text, 502, "XCLIENT BOGUS=value"); err != nil {
-		t.Fatalf("XCLIENT with unknown attribute didn't 502: %v", err)
+	if err := smtptest.Cmd(c.Text, 501, "XCLIENT BOGUS=value"); err != nil {
+		t.Fatalf("XCLIENT with unknown attribute didn't 501: %v", err)
 	}
 }
 


### PR DESCRIPTION
The server used `502` for most faults. That code means the command is not implemented, which says nothing to a client that sent a command in the wrong order, or one with an argument the server could not read. 33 of the 39 replies in the server were `502`.

## What changes

| The client does this | Before | Now |
| --- | --- | --- |
| Sends a command this server does not know | `502` | `500` |
| Sends a line that is not a command | `502` | `500` |
| Leaves out the name on `HELO` or `EHLO` | `502` | `501` |
| Writes `MAIL FROM` or `RCPT TO` wrongly | `502` | `501` |
| Gives an address that does not parse | `502` | `501` |
| Writes `XCLIENT` or `PROXY` wrongly | `502` | `501` |
| Sends `AUTH` with no mechanism | `502` | `501` |
| Sends credentials that do not decode | `502` | `501` |
| Sends `MAIL FROM` before a greeting | `502` | `503` |
| Sends `MAIL FROM` twice | `502` | `503` |
| Sends `RCPT TO` before `MAIL FROM` | `502` | `503` |
| Sends `DATA` before `RCPT TO` | `502` | `503` |
| Sends `AUTH` before a greeting | `502` | `503` |
| Sends `STARTTLS` inside TLS | `502` | `503` |
| Asks for a mechanism this server does not have | `502` | `504` |
| Sends `AUTH` in plain text where STARTTLS is offered | `502` | `530` |

RFC 5321 section 4.2.3 gives `500`, `501`, `503` and `504`. RFC 4954 gives `501` for credentials that do not decode and `504` for a mechanism the server does not have. RFC 3207 gives `530` for a command that needs the TLS layer first, which is the code `middleware.RequireTLS` already returns.

## What stays

`502` stays where the command really is not implemented:

- `AUTH` with no authenticator registered.
- `STARTTLS` with no `TLSConfig`.
- `AUTH` in plain text where STARTTLS is not offered at all. Telling that client to run `STARTTLS` would send it after something the server does not have.
- `XCLIENT` or `PROXY` on a connection that is not TCP.

Codes that were already right are untouched: `452` for too many recipients, `500` for a line too long, `552` for a message over the size, `555` for a parameter of `MAIL FROM` or `RCPT TO`, `550` for `XCLIENT` or `PROXY` that the server does not allow.

## An address that does not parse

This one goes to `501`, not `553`. RFC 5321 gives `553` for a mailbox name that is not allowed, and reads "mailbox syntax incorrect" among its examples, so both fit. Postfix answers `501 5.1.7 Bad sender address syntax` and Exim answers `501`, and a client meets those two far more often than it meets this server.

## Not in this change

`replyError` answers `502` for an error from a hook that is not an `smtpd.Error`. That code is wrong as well, but the right one is a decision about policy rather than about the RFC: `451` holds the mail for a later try, and `550` turns it away for good. It is written into the doc comment of `Error`, so it is worth its own change.

## Tests

15 tests carried the old code and now carry the new one. Each still names the fault it stands for, so the change is visible per fault rather than as one sweep.

`TestAUTHBeforeSTARTTLS` is new. Nothing covered the reply to `AUTH` in plain text on a server that offers STARTTLS, which is the case that now answers `530`. It drives a socket directly, because `Dial` on the test server runs `STARTTLS` for itself.

`go test ./...`, `golangci-lint run ./...`, `gofmt -l .` and `go vet ./...` are all clean.
