### PR TITLE
fix: redact the credentials of an AUTH command written with tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The credentials of an `AUTH` command stay out of the log when the client
+  writes the command with tabs between the parts. The server reads
+  `AUTH<TAB>PLAIN<TAB><credentials>` as a command, and the log carried that
+  line in full at the `DEBUG` level.
+
 ## [2.3.0] - 2026-08-08
 
 ### Added

--- a/logging.go
+++ b/logging.go
@@ -21,20 +21,23 @@ const redacted = "[redacted]"
 //
 // The other form of AUTH sends the credentials on their own lines, after a 334
 // reply. The session reads those lines directly, and they never reach the log.
+//
+// strings.Fields cuts the line into parts. It breaks on every kind of space,
+// and the command parser breaks the verb on a space or a tab only. The parts
+// here are therefore never fewer than the parts that the parser reads. A line
+// that the parser takes as AUTH is always redacted. A line that it does not
+// take as AUTH is redacted for nothing at worst.
 func redactLine(line string) string {
 	line = strings.TrimSpace(line)
 
-	verb, rest, hasRest := strings.Cut(line, " ")
-	if !hasRest || !strings.EqualFold(verb, "AUTH") {
+	// A line with credentials has three parts: the verb, the mechanism, and
+	// the credentials. With fewer parts, the line carries no credentials.
+	fields := strings.Fields(line)
+	if len(fields) < 3 || !strings.EqualFold(fields[0], "AUTH") {
 		return line
 	}
 
-	mechanism, credentials, hasCredentials := strings.Cut(strings.TrimSpace(rest), " ")
-	if !hasCredentials || strings.TrimSpace(credentials) == "" {
-		return line
-	}
-
-	return verb + " " + mechanism + " " + redacted
+	return fields[0] + " " + fields[1] + " " + redacted
 }
 
 type contextKey string

--- a/redact_test.go
+++ b/redact_test.go
@@ -1,6 +1,9 @@
 package smtpd
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 // TestRedactLine covers the shapes of AUTH that carry the credentials on the
 // command line, and makes sure that every other command reaches the log as it
@@ -29,6 +32,16 @@ func TestRedactLine(t *testing.T) {
 		{
 			name: "extra spaces around the credentials",
 			line: "AUTH  PLAIN   AGZvbwBiYXI=",
+			want: "AUTH PLAIN [redacted]",
+		},
+		{
+			name: "tabs between the parts",
+			line: "AUTH\tPLAIN\tAGZvbwBiYXI=",
+			want: "AUTH PLAIN [redacted]",
+		},
+		{
+			name: "more parts than the mechanism takes",
+			line: "AUTH PLAIN AGZvbwBiYXI= extra",
 			want: "AUTH PLAIN [redacted]",
 		},
 		{
@@ -71,4 +84,48 @@ func TestRedactLine(t *testing.T) {
 			}
 		})
 	}
+}
+
+// FuzzRedactLine holds redaction to the view of the command parser. The
+// parser reads some lines as AUTH with a mechanism and one or more parts
+// after it. Those parts are the credentials. The line that reaches the log
+// must carry the mechanism and the mark, and nothing else.
+//
+// The test compares the parts that the parser reads, not substrings. A
+// credential of one or two characters can also appear inside the name of the
+// mechanism.
+func FuzzRedactLine(f *testing.F) {
+	f.Add("AUTH PLAIN AGZvbwBiYXI=")
+	f.Add("AUTH\tPLAIN\tAGZvbwBiYXI=")
+	f.Add("AUTH  LOGIN   dXNlcm5hbWU=")
+	f.Add("auth plain AGZvbwBiYXI=")
+	f.Add("AUTH PLAIN")
+	f.Add("MAIL FROM:<sender@example.org>")
+
+	f.Fuzz(func(t *testing.T, line string) {
+		cmd, err := parseCommand(line)
+		if err != nil || cmd.action != "AUTH" {
+			return
+		}
+
+		args := cmd.args()
+		if len(args) < 2 {
+			// Nothing comes after the mechanism, so the line carries no
+			// credentials. The other form of AUTH sends the credentials on
+			// their own lines. The session never logs those lines.
+			return
+		}
+
+		redactedLine := redactLine(line)
+
+		out, err := parseCommand(redactedLine)
+		if err != nil {
+			t.Fatalf("redactLine(%q) = %q, which does not parse: %v", line, redactedLine, err)
+		}
+
+		want := []string{args[0], redacted}
+		if got := out.args(); !slices.Equal(got, want) {
+			t.Fatalf("redactLine(%q) = %q, with the parts %q, want %q", line, redactedLine, got, want)
+		}
+	})
 }


### PR DESCRIPTION
## The fault

The command parser breaks the verb of a command on a space or a tab, and it
reads the parts that follow with `strings.Fields`. A client can therefore send
this line and authenticate:

```
AUTH<TAB>PLAIN<TAB>AHVzZXIAcGFzcw==
```

`redactLine` cut the line on a space only. It found no second part in such a
line, so it returned the line as it came. At the `DEBUG` level the session
then wrote the user name and the password to the log in full.

The other form of `AUTH` is not affected. It sends the credentials on their
own lines, after a `334` reply, and the session never logs those lines.

## The correction

Cut the line with `strings.Fields`. It breaks on every kind of space, so its
parts are never fewer than the parts that the command parser reads. A line
that the parser takes as `AUTH` is now always redacted. A line that it does
not take as `AUTH` is redacted for nothing at worst.

## Tests

`TestRedactLine` gets the tab form, and a line with more parts than the
mechanism takes. Both fail before the correction.

`FuzzRedactLine` holds the property in general: when the parser reads a line
as `AUTH` with a mechanism and one or more parts after it, the line that
reaches the log must carry the mechanism and the mark, and nothing else. The
test compares the parts that the parser reads, not substrings, because a
credential of one or two characters can also appear inside the name of the
mechanism. The seed corpus runs with `go test`, and the target found no more
faults in 3.4 million runs.

## Impact

An operator that runs the server at the `DEBUG` level has credentials in the
log for every client that writes `AUTH` with tabs. The log needs a review, and
the accounts in it need new passwords.
