### PR TITLE
fix: keep the quoting of a local part in an address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `AUTH<TAB>PLAIN<TAB><credentials>` as a command, and the log carried that
   line in full at the `DEBUG` level.
 
+- An address with a quoted local part keeps its quoting. Before,
+  `MAIL FROM:<" "@example.org>` put ` @example.org` into `Envelope.Sender`.
+  That value is not an address any more. A relay that sends it on writes a
+  command that the next server cannot read.
+
+- An address that carries a line break gets a `501` reply. Such an address
+  lets the client add a command of its own to the session of a relay.
+
 ## [2.3.0] - 2026-08-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -87,6 +87,20 @@ Architecture
 | `Envelope` | Transaction-scoped state: `Sender`, `Recipients`, `Data io.ReadCloser`. Passed by pointer so Handlers can mutate `Data`. |
 | `Error` | `{Code, Message}` - returned from any hook to produce a specific SMTP reply. Non-`Error` errors are reported as `502`. |
 
+### Address form
+
+`Envelope.Sender` and `Envelope.Recipients` hold an address in the form that
+goes on the wire. An address with a quoted local part keeps its quoting, so a
+relay can write the value into a command of its own.
+
+| The client sends | The value |
+| --- | --- |
+| `MAIL FROM:<user@example.org>` | `user@example.org` |
+| `MAIL FROM:<"a b"@example.org>` | `"a b"@example.org` |
+| `MAIL FROM:<>` | `""` (the null sender) |
+
+The server answers `501` for an address that carries a line break.
+
 ### Delivery handlers
 
 Message delivery is expressed with the `Handler` function type:

--- a/address.go
+++ b/address.go
@@ -3,6 +3,7 @@ package smtpd
 import (
 	"fmt"
 	"net/mail"
+	"strings"
 )
 
 func parseAddress(src string) (string, error) {
@@ -18,5 +19,84 @@ func parseAddress(src string) (string, error) {
 		return "", fmt.Errorf("malformed e-mail address: %s", src)
 	}
 
-	return addr.Address, nil
+	address := quoteLocalPart(addr.Address)
+
+	// A line break lets the client write a command of its own into the
+	// session of a relay that sends this address on.
+	if strings.ContainsAny(address, "\r\n") {
+		return "", fmt.Errorf("e-mail address carries a line break: %q", src)
+	}
+
+	return address, nil
+}
+
+// quoteLocalPart puts the quoting back on a local part that needs it. The
+// address parser takes the quoting off, so `"a b"@example.org` comes back as
+// `a b@example.org`. That value is not an address any more. It does not
+// parse, and a relay that writes it into a MAIL FROM command sends a command
+// that the next server cannot read.
+//
+// An address that needs no quoting stays as it is.
+func quoteLocalPart(addr string) string {
+	// The local part is what stands before the last at sign. Quoting can
+	// carry an at sign of its own.
+	at := strings.LastIndexByte(addr, '@')
+	if at < 0 {
+		return addr
+	}
+
+	local, domain := addr[:at], addr[at+1:]
+	if isDotAtom(local) {
+		return addr
+	}
+
+	var out strings.Builder
+	out.Grow(len(addr) + 4)
+
+	out.WriteByte('"')
+	for i := 0; i < len(local); i++ {
+		if local[i] == '"' || local[i] == '\\' {
+			out.WriteByte('\\')
+		}
+		out.WriteByte(local[i])
+	}
+	out.WriteString(`"@`)
+	out.WriteString(domain)
+
+	return out.String()
+}
+
+// isDotAtom reports whether local is a dot-atom, the form of a local part
+// that needs no quoting. RFC 5321 writes it as one or more atoms of atext
+// with a single dot between them.
+func isDotAtom(local string) bool {
+	if local == "" {
+		return false
+	}
+
+	for atom := range strings.SplitSeq(local, ".") {
+		if atom == "" {
+			return false
+		}
+		for i := 0; i < len(atom); i++ {
+			if !isAtext(atom[i]) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// isAtext reports whether c is an atext character. RFC 5321 gives the
+// letters, the digits and a set of signs. RFC 6531 adds every byte above
+// ASCII, so that a UTF-8 local part stays as it is.
+func isAtext(c byte) bool {
+	switch {
+	case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+		return true
+	case c >= 0x80:
+		return true
+	}
+	return strings.IndexByte("!#$%&'*+-/=?^_`{|}~", c) >= 0
 }

--- a/address_test.go
+++ b/address_test.go
@@ -1,0 +1,191 @@
+package smtpd
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+// TestParseAddress covers the forms of an address that reach MAIL FROM and
+// RCPT TO. Each address that parses must come back in a form that goes on the
+// wire again. A relay writes the value of Envelope.Sender and
+// Envelope.Recipients into a command of its own.
+func TestParseAddress(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		src     string
+		want    string
+		wantErr bool
+	}{
+		{name: "bare address", src: "user@example.org", want: "user@example.org"},
+		{name: "angle brackets", src: "<user@example.org>", want: "user@example.org"},
+		{name: "display name", src: `"User" <user@example.org>`, want: "user@example.org"},
+		{name: "address literal", src: "<user@[192.0.2.1]>", want: "user@[192.0.2.1]"},
+		{name: "dots in the local part", src: "<first.last@example.org>", want: "first.last@example.org"},
+		{name: "utf-8 local part stays as it is", src: "<üser@example.org>", want: "üser@example.org"},
+		{
+			name: "a space in the local part keeps its quoting",
+			src:  `<"a b"@example.org>`,
+			want: `"a b"@example.org`,
+		},
+		{
+			name: "an at sign in the local part keeps its quoting",
+			src:  `<"@"@example.org>`,
+			want: `"@"@example.org`,
+		},
+		{
+			name: "a lone space is a local part of its own",
+			src:  `<" "@example.org>`,
+			want: `" "@example.org`,
+		},
+		{
+			name: "a quote in the local part stays escaped",
+			src:  `<"a\"b"@example.org>`,
+			want: `"a\"b"@example.org`,
+		},
+		{
+			name: "a backslash in the local part stays escaped",
+			src:  `<"a\\b"@example.org>`,
+			want: `"a\\b"@example.org`,
+		},
+		{name: "not an address", src: "not an address", wantErr: true},
+		{name: "empty", src: "", wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseAddress(test.src)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("parseAddress(%q) = %q, want an error", test.src, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseAddress(%q): %v", test.src, err)
+			}
+			if got != test.want {
+				t.Fatalf("parseAddress(%q) = %q, want %q", test.src, got, test.want)
+			}
+
+			again, err := parseAddress(got)
+			if err != nil {
+				t.Fatalf("parseAddress(%q) gave %q, which does not parse: %v", test.src, got, err)
+			}
+			if again != got {
+				t.Fatalf("parseAddress(%q) = %q, which parses to %q", got, again, got)
+			}
+		})
+	}
+}
+
+// FuzzParseAddress holds the two properties that a caller depends on. The
+// address that comes back parses to itself, so a relay can write it into a
+// command. It carries no line break, so it cannot add a command of its own to
+// the session of that relay.
+func FuzzParseAddress(f *testing.F) {
+	f.Add("user@example.org")
+	f.Add("<user@example.org>")
+	f.Add(`"User" <user@example.org>`)
+	f.Add(`<"a b"@example.org>`)
+	f.Add(`<"@"@example.org>`)
+	f.Add("<user@[192.0.2.1]>")
+	f.Add("<üser@example.org>")
+
+	f.Fuzz(func(t *testing.T, src string) {
+		addr, err := parseAddress(src)
+		if err != nil {
+			return
+		}
+
+		if strings.ContainsAny(addr, "\r\n") {
+			t.Fatalf("parseAddress(%q) = %q, which carries a line break", src, addr)
+		}
+
+		again, err := parseAddress(addr)
+		if err != nil {
+			t.Fatalf("parseAddress(%q) = %q, which does not parse: %v", src, addr, err)
+		}
+		if again != addr {
+			t.Fatalf("parseAddress(%q) = %q, which parses to %q", src, addr, again)
+		}
+	})
+}
+
+// TestQuoteLocalPart covers the shapes that decide whether the local part
+// needs quoting, without the address parser in front of it.
+func TestQuoteLocalPart(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		addr string
+		want string
+	}{
+		{name: "dot-atom stays as it is", addr: "user@example.org", want: "user@example.org"},
+		{name: "every atext character", addr: "!#$%&'*+-/=?^_`{|}~@example.org", want: "!#$%&'*+-/=?^_`{|}~@example.org"},
+		{name: "utf-8 stays as it is", addr: "üser@example.org", want: "üser@example.org"},
+		{name: "a space is quoted", addr: "a b@example.org", want: `"a b"@example.org`},
+		{name: "a leading dot is quoted", addr: ".user@example.org", want: `".user"@example.org`},
+		{name: "a trailing dot is quoted", addr: "user.@example.org", want: `"user."@example.org`},
+		{name: "two dots are quoted", addr: "a..b@example.org", want: `"a..b"@example.org`},
+		{name: "an empty local part is quoted", addr: "@example.org", want: `""@example.org`},
+		{name: "a quote is escaped", addr: `a"b@example.org`, want: `"a\"b"@example.org`},
+		{name: "a backslash is escaped", addr: `a\b@example.org`, want: `"a\\b"@example.org`},
+		{name: "the last at sign separates the parts", addr: "a@b@example.org", want: `"a@b"@example.org`},
+		{name: "no at sign at all", addr: "example.org", want: "example.org"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := quoteLocalPart(test.addr); got != test.want {
+				t.Fatalf("quoteLocalPart(%q) = %q, want %q", test.addr, got, test.want)
+			}
+		})
+	}
+}
+
+// TestParseAddressRejectsALineBreak makes sure the guard on the result holds,
+// whatever the address parser accepts.
+func TestParseAddressRejectsALineBreak(t *testing.T) {
+	t.Parallel()
+
+	for _, src := range []string{"<a\rb@example.org>", "<a\nb@example.org>", "<\"a\r\nb\"@example.org>"} {
+		if got, err := parseAddress(src); err == nil {
+			t.Errorf("parseAddress(%q) = %q, want an error", src, got)
+		}
+	}
+}
+
+// atextCharacters is the set that isAtext accepts beyond the letters, the
+// digits and the bytes above ASCII. RFC 5321 calls it atext.
+var atextCharacters = []byte("!#$%&'*+-/=?^_`{|}~")
+
+// TestIsAtext pins the set of characters that need no quoting.
+func TestIsAtext(t *testing.T) {
+	t.Parallel()
+
+	for c := range 128 {
+		letter := c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z'
+		digit := c >= '0' && c <= '9'
+		want := letter || digit || slices.Contains(atextCharacters, byte(c))
+
+		if got := isAtext(byte(c)); got != want {
+			t.Errorf("isAtext(%q) = %v, want %v", rune(c), got, want)
+		}
+	}
+
+	// RFC 6531 adds every byte above ASCII, so a UTF-8 local part needs no
+	// quoting.
+	for c := 128; c < 256; c++ {
+		if !isAtext(byte(c)) {
+			t.Errorf("isAtext(%#x) = false, want true", c)
+		}
+	}
+}

--- a/data_test.go
+++ b/data_test.go
@@ -352,3 +352,83 @@ func TestHandleDATAHandlerError(t *testing.T) {
 		t.Fatalf("codes = %v, want [354 554]", codes)
 	}
 }
+
+// chunkReader hands out the body in the sizes it is given, so a fuzz target
+// decides where the reads of dataReader fall.
+type chunkReader struct {
+	data   []byte
+	chunks []byte
+
+	pos  int
+	next int
+}
+
+func (r *chunkReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+
+	want := len(p)
+	if len(r.chunks) > 0 {
+		size := int(r.chunks[r.next%len(r.chunks)]) + 1
+		r.next++
+		want = min(want, size)
+	}
+
+	n := copy(p[:want], r.data[r.pos:])
+	r.pos += n
+	return n, nil
+}
+
+// FuzzDataReader holds the accounting of the DATA body:
+//
+//   - The handler never sees more than the limit.
+//   - What the handler sees is the start of the message.
+//   - The marks that handleDATA reads afterwards say what happened.
+//
+// The limit is at least one byte, as configureDefaults gives the server.
+func FuzzDataReader(f *testing.F) {
+	f.Add([]byte("hello world"), []byte{4}, uint16(1024), uint16(512))
+	f.Add([]byte("hello world"), []byte{1}, uint16(5), uint16(1))
+	f.Add(bytes.Repeat([]byte("a"), 300), []byte{7, 1, 64}, uint16(100), uint16(16))
+
+	f.Fuzz(func(t *testing.T, body, chunks []byte, limit, readSize uint16) {
+		max := int(limit)%4096 + 1
+		buf := make([]byte, int(readSize)%64+1)
+
+		d := &dataReader{r: &chunkReader{data: body, chunks: chunks}, max: max}
+
+		var got bytes.Buffer
+		for {
+			n, err := d.Read(buf)
+			if n < 0 || n > len(buf) {
+				t.Fatalf("Read gave n = %d for a buffer of %d", n, len(buf))
+			}
+			got.Write(buf[:n])
+			if err != nil {
+				if !errors.Is(err, io.EOF) && !errors.Is(err, errMessageTooLarge) {
+					t.Fatalf("Read: %v", err)
+				}
+				break
+			}
+		}
+
+		if got.Len() > max {
+			t.Fatalf("the handler saw %d bytes, over the limit of %d", got.Len(), max)
+		}
+		if !bytes.HasPrefix(body, got.Bytes()) {
+			t.Fatalf("the handler saw %q, which is not the start of the body %q", got.Bytes(), body)
+		}
+
+		if err := d.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+
+		if want := len(body) > max; d.tooBig != want {
+			t.Fatalf("tooBig = %v for a body of %d and a limit of %d, want %v", d.tooBig, len(body), max, want)
+		}
+		if d.abandoned && len(body) <= 2*max {
+			t.Fatalf("gave up on a body of %d bytes with a limit of %d, which ends inside the budget", len(body), max)
+		}
+	})
+}

--- a/session_fuzz_test.go
+++ b/session_fuzz_test.go
@@ -1,0 +1,120 @@
+package smtpd
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+// scriptConn is a net.Conn that reads a session written in advance and keeps
+// what the server writes. The deadlines do nothing, so a fuzz target runs at
+// the speed of memory.
+type scriptConn struct {
+	in  *bytes.Reader
+	out bytes.Buffer
+}
+
+func (c *scriptConn) Read(p []byte) (int, error)  { return c.in.Read(p) }
+func (c *scriptConn) Write(p []byte) (int, error) { return c.out.Write(p) }
+func (c *scriptConn) Close() error                { return nil }
+
+func (c *scriptConn) LocalAddr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 25}
+}
+
+func (c *scriptConn) RemoteAddr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4(192, 0, 2, 1), Port: 12345}
+}
+
+func (c *scriptConn) SetDeadline(time.Time) error      { return nil }
+func (c *scriptConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *scriptConn) SetWriteDeadline(time.Time) error { return nil }
+
+var _ net.Conn = (*scriptConn)(nil)
+
+// replyLine is the shape of every line that an SMTP server writes. It carries
+// three digits, then a space for the last line of a reply, or a hyphen for a
+// line that continues. A line without that shape means the server let
+// something from the client into a reply.
+var replyLine = regexp.MustCompile(`^[2-5][0-9][0-9][ -]`)
+
+// FuzzSession runs a whole session against a script of bytes. It holds three
+// properties:
+//
+//   - The session never panics.
+//   - The session always ends.
+//   - Every line that the server writes is a reply.
+//
+// The last property catches a reply that a client splits in two. A client
+// does that with a line break in a value that reaches a message.
+//
+// STARTTLS is outside the target. The server has no certificate here, so it
+// answers 502 and stays in plain text.
+func FuzzSession(f *testing.F) {
+	f.Add("EHLO relay.example.org\r\nMAIL FROM:<a@example.org>\r\nRCPT TO:<b@example.net>\r\nDATA\r\nhello\r\n.\r\nQUIT\r\n", uint8(0))
+	f.Add("HELO relay.example.org\r\nMAIL FROM:<>\r\nRCPT TO:<b@example.net>\r\nDATA\r\n.\r\nQUIT\r\n", uint8(0))
+	f.Add("XCLIENT ADDR=192.0.2.2 PORT=2525 LOGIN=user\r\nEHLO x\r\nQUIT\r\n", uint8(1))
+	f.Add("PROXY TCP4 192.0.2.2 192.0.2.1 2525 25\r\nEHLO x\r\nQUIT\r\n", uint8(2))
+	f.Add("EHLO x\r\nAUTH PLAIN AGZvbwBiYXI=\r\nQUIT\r\n", uint8(4))
+	f.Add("EHLO x\r\nAUTH LOGIN\r\ndXNlcg==\r\ncGFzcw==\r\nQUIT\r\n", uint8(4))
+	f.Add("MAIL FROM:<\r\nRCPT TO:>>>\r\nDATA\r\n", uint8(7))
+	f.Add("MAIL FROM:<\" \"@0> SIZE=1 SIZE=2\r\n", uint8(7))
+
+	f.Fuzz(func(t *testing.T, script string, options uint8) {
+		srv := &Server{
+			EnableXCLIENT:       options&1 != 0,
+			EnableProxyProtocol: options&2 != 0,
+			AllowInsecureAuth:   options&4 != 0,
+
+			// Small enough that a short script reaches the limit and the
+			// drain that follows it.
+			MaxMessageSize: 4096,
+			MaxRecipients:  4,
+
+			Handler: func(ctx context.Context, _ Peer, env *Envelope) (context.Context, error) {
+				_, _ = io.Copy(io.Discard, env.Data)
+				return ctx, nil
+			},
+		}
+
+		srv.Use(Middleware{
+			Authenticate: func(ctx context.Context, _ Peer, _, _ string) (context.Context, error) {
+				return ctx, nil
+			},
+		})
+
+		if err := srv.configureDefaults(); err != nil {
+			t.Fatalf("configureDefaults: %v", err)
+		}
+
+		conn := &scriptConn{in: bytes.NewReader([]byte(script))}
+		ctx, session := srv.newSession(context.Background(), conn)
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			session.serve(ctx)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(30 * time.Second):
+			t.Fatalf("the session did not end for the script %q", script)
+		}
+
+		written := conn.out.String()
+		for line := range strings.SplitSeq(strings.TrimSuffix(written, "\r\n"), "\r\n") {
+			if line == "" {
+				continue
+			}
+			if !replyLine.MatchString(line) {
+				t.Fatalf("the server wrote %q, which is not a reply\nscript: %q\nwritten: %q", line, script, written)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Follows #46, which is merged. This branch is rebased on `main`.

## The fault

RFC 5321 lets a local part carry a space, an at sign, or a quote, if quotes
enclose the local part. The address parser of `net/mail` takes that quoting
off, so the value that reaches a hook is not an address any more:

| The client sends | `Envelope.Sender` before | Parses again? |
| --- | --- | --- |
| `MAIL FROM:<" "@example.org>` | ` @example.org` | no |
| `MAIL FROM:<"a b"@example.org>` | `a b@example.org` | no |
| `MAIL FROM:<"@"@example.org>` | `@@example.org` | no |

A relay that writes such a value into a command of its own sends a command
that the next server cannot read. The relay example in `_examples` does that
through `net/smtp`, which refuses a line break but accepts a space.

## The correction

Put the quoting back on a local part that is not a dot-atom, and escape a
quote or a backslash inside it. RFC 6531 counts every byte above ASCII as
atext, so a UTF-8 local part stays as it is.

Refuse an address that carries a line break as well. `net/mail` rejects one
today. The guard holds because the value goes on the wire in the session of a
relay, where a line break lets the client add a command of its own.

## Tests

`TestParseAddress` covers the forms that reach `MAIL FROM` and `RCPT TO`, and
every address that parses must parse again to itself. `TestQuoteLocalPart` and
`TestIsAtext` pin the two decisions that stand behind it.

`FuzzParseAddress` holds the same two properties for any input. It found no
faults in 3.1 million runs.

This branch also adds two fuzz targets that found no faults, as a net for
later changes:

- `FuzzDataReader` holds the accounting of the DATA body. The handler never
  sees more than the limit, what it sees is the start of the message, and the
  marks that `handleDATA` reads afterwards say what happened.
- `FuzzSession` runs a whole session against a script of bytes, over a
  connection that reads from memory. The session never panics, it always ends,
  and every line the server writes is a reply. The last property catches a
  reply that a client splits in two with a line break.

Each target carries a seed corpus, so `go test` runs the seeds and CI keeps
them green.


