### PR TITLE
test: run the timeout tests on a fake clock with synctest

### DIFF
--- a/accept_test.go
+++ b/accept_test.go
@@ -1,0 +1,98 @@
+package smtpd_test
+
+import (
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/chrj/smtpd/v2"
+)
+
+// acceptTimeoutErr is a net.Error that reports a timeout, which is what Serve
+// waits out before it calls Accept again.
+type acceptTimeoutErr struct{}
+
+func (acceptTimeoutErr) Error() string   { return "accept: temporary failure" }
+func (acceptTimeoutErr) Timeout() bool   { return true }
+func (acceptTimeoutErr) Temporary() bool { return true }
+
+// flakyListener fails the first failures calls to Accept with a timeout, then
+// blocks until Close.
+type flakyListener struct {
+	remaining atomic.Int32
+	accepts   atomic.Int32
+	closed    chan struct{}
+	once      sync.Once
+}
+
+func newFlakyListener(failures int32) *flakyListener {
+	l := &flakyListener{closed: make(chan struct{})}
+	l.remaining.Store(failures)
+
+	return l
+}
+
+func (l *flakyListener) Accept() (net.Conn, error) {
+	l.accepts.Add(1)
+	if l.remaining.Add(-1) >= 0 {
+		return nil, acceptTimeoutErr{}
+	}
+
+	<-l.closed
+	return nil, net.ErrClosed
+}
+
+func (l *flakyListener) Close() error {
+	l.once.Do(func() { close(l.closed) })
+	return nil
+}
+
+func (l *flakyListener) Addr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 25}
+}
+
+// TestAcceptRetryBackoff verifies that a timeout from Accept does not stop the
+// server. Serve waits one second and accepts again.
+//
+// The test sleeps in its own goroutine, and not in synctest.Wait. Wait returns
+// as soon as the other goroutines block, and it does not move the clock, so
+// the server would stay in its first backoff.
+func TestAcceptRetryBackoff(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		const failures = 3
+
+		l := newFlakyListener(failures)
+		srv := &smtpd.Server{Logger: testLogger(t)}
+
+		served := make(chan error, 1)
+		go func() { served <- srv.Serve(l) }()
+
+		// The backoff is one second, so the server calls Accept at 0s, 1s and
+		// 2s. The call at 3s is still in the future.
+		time.Sleep(2*time.Second + 500*time.Millisecond)
+		synctest.Wait()
+
+		if got, want := l.accepts.Load(), int32(3); got != want {
+			t.Errorf("Accept calls after 2.5s = %d, want %d", got, want)
+		}
+
+		// The last failure is spent, so the call at 3s blocks until Close.
+		time.Sleep(time.Second)
+		synctest.Wait()
+
+		if got, want := l.accepts.Load(), int32(failures+1); got != want {
+			t.Errorf("Accept calls after 3.5s = %d, want %d", got, want)
+		}
+
+		_ = l.Close()
+
+		if err := <-served; err == nil {
+			t.Error("Serve returned nil, want the error of the listener")
+		}
+	})
+}

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -1,0 +1,149 @@
+package smtpd_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/chrj/smtpd/v2"
+)
+
+// The helpers in this file run a server over net.Pipe instead of TCP, so that
+// a test of the read and write timeouts can run inside a synctest bubble.
+//
+// A bubble replaces the clock of the goroutines it holds. net.Pipe applies its
+// deadlines in Go, so the bubble controls them and the test costs no real
+// time. A TCP deadline comes from the operating system, which keeps the real
+// clock. A goroutine that waits for a TCP read is also not durably blocked, so
+// the bubble stops its clock and the test pays the full wait.
+
+// pipeListener is a net.Listener that hands out one end of a net.Pipe for each
+// call to dial. Close makes a waiting Accept return.
+type pipeListener struct {
+	conns  chan net.Conn
+	closed chan struct{}
+	once   sync.Once
+}
+
+func newPipeListener() *pipeListener {
+	return &pipeListener{
+		conns:  make(chan net.Conn),
+		closed: make(chan struct{}),
+	}
+}
+
+func (l *pipeListener) Accept() (net.Conn, error) {
+	select {
+	case c := <-l.conns:
+		return c, nil
+	case <-l.closed:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *pipeListener) Close() error {
+	l.once.Do(func() { close(l.closed) })
+	return nil
+}
+
+// Addr reports a loopback address. The server logs it and the middleware reads
+// it, but no test connects to it.
+func (l *pipeListener) Addr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 25}
+}
+
+// dial gives the server one end of a new pipe and returns the other end.
+func (l *pipeListener) dial(t *testing.T) net.Conn {
+	t.Helper()
+
+	client, server := net.Pipe()
+	select {
+	case l.conns <- server:
+		return client
+	case <-l.closed:
+		t.Fatal("the listener closed before it accepted the connection")
+		return nil
+	}
+}
+
+// runpipeserver starts server on an in-memory listener. The caller runs inside
+// a synctest bubble and closes the listener when the test ends.
+func runpipeserver(t *testing.T, server *smtpd.Server) *pipeListener {
+	t.Helper()
+
+	l := newPipeListener()
+	go func() { _ = server.Serve(l) }()
+
+	return l
+}
+
+// bubbleCert is a self-signed certificate for "localhost". The validity window
+// covers the year 2000, where a synctest bubble starts its clock, and it also
+// covers the real time of a test that runs outside a bubble. A certificate cut
+// for the current time only fails verification inside a bubble.
+var bubbleCert = sync.OnceValue(newBubbleCert)
+
+func newBubbleCert() tls.Certificate {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		panic("smtpd_test: generate the key of the test certificate: " + err.Error())
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		panic("smtpd_test: generate the serial number of the test certificate: " + err.Error())
+	}
+
+	template := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{Organization: []string{"smtpd_test"}, CommonName: "localhost"},
+		NotBefore:             time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC),
+		NotAfter:              time.Date(2100, time.January, 1, 0, 0, 0, 0, time.UTC),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		panic("smtpd_test: create the test certificate: " + err.Error())
+	}
+
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		panic("smtpd_test: parse the test certificate: " + err.Error())
+	}
+
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key, Leaf: leaf}
+}
+
+// pipeServerTLS returns the TLS configuration that a server presents on a pipe.
+func pipeServerTLS() *tls.Config {
+	return &tls.Config{
+		Certificates: []tls.Certificate{bubbleCert()},
+		MinVersion:   tls.VersionTLS12,
+	}
+}
+
+// pipeClientTLS returns a TLS configuration that trusts pipeServerTLS.
+func pipeClientTLS() *tls.Config {
+	pool := x509.NewCertPool()
+	pool.AddCert(bubbleCert().Leaf)
+
+	return &tls.Config{
+		RootCAs:    pool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+	}
+}

--- a/smtpd_test.go
+++ b/smtpd_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/chrj/smtpd/v2"
@@ -782,79 +783,110 @@ func TestInterruptedDATA(t *testing.T) {
 	}
 }
 
+// TestTimeoutClose verifies that the read timeout closes an idle session and
+// that the closed session releases its slot in MaxConnections.
 func TestTimeoutClose(t *testing.T) {
 	t.Parallel()
 
-	srv := runserver(t, &smtpd.Server{
-		MaxConnections: 1,
-		ReadTimeout:    time.Second,
-		WriteTimeout:   time.Second,
-		Logger:         testLogger(t),
+	synctest.Test(t, func(t *testing.T) {
+		l := runpipeserver(t, &smtpd.Server{
+			MaxConnections: 1,
+			ReadTimeout:    time.Second,
+			WriteTimeout:   time.Second,
+			Logger:         testLogger(t),
+		})
+		defer func() { _ = l.Close() }()
+
+		c1, err := smtp.NewClient(l.dial(t), "localhost")
+		if err != nil {
+			t.Fatalf("NewClient failed: %v", err)
+		}
+
+		// Idle past ReadTimeout, so the server closes the first session.
+		time.Sleep(time.Second * 2)
+		synctest.Wait()
+
+		c2, err := smtp.NewClient(l.dial(t), "localhost")
+		if err != nil {
+			t.Fatalf("NewClient failed: %v", err)
+		}
+
+		if err := c1.Mail("sender@example.org"); err == nil {
+			t.Fatal("MAIL succeeded despite being timed out.")
+		}
+
+		if err := c2.Mail("sender@example.org"); err != nil {
+			t.Fatalf("MAIL failed: %v", err)
+		}
+
+		if err := c2.Quit(); err != nil {
+			t.Fatalf("Quit failed: %v", err)
+		}
+
+		_ = c2.Close()
 	})
-
-	c1, err := smtp.Dial(srv.Addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
-
-	time.Sleep(time.Second * 2)
-
-	c2, err := smtp.Dial(srv.Addr)
-	if err != nil {
-		t.Fatalf("Dial failed: %v", err)
-	}
-
-	if err := c1.Mail("sender@example.org"); err == nil {
-		t.Fatal("MAIL succeeded despite being timed out.")
-	}
-
-	if err := c2.Mail("sender@example.org"); err != nil {
-		t.Fatalf("MAIL failed: %v", err)
-	}
-
-	if err := c2.Quit(); err != nil {
-		t.Fatalf("Quit failed: %v", err)
-	}
-
-	_ = c2.Close()
 }
 
+// TestTLSTimeout verifies that every command refreshes the read deadline on a
+// TLS session. The session outlives ReadTimeout because no single gap between
+// two commands reaches it.
 func TestTLSTimeout(t *testing.T) {
 	t.Parallel()
 
-	srv := runsslserver(t, &smtpd.Server{
-		ReadTimeout:  time.Second * 2,
-		WriteTimeout: time.Second * 2,
-		Logger:       testLogger(t),
+	synctest.Test(t, func(t *testing.T) {
+		l := runpipeserver(t, &smtpd.Server{
+			ReadTimeout:  time.Second * 2,
+			WriteTimeout: time.Second * 2,
+			TLSConfig:    pipeServerTLS(),
+			Logger:       testLogger(t),
+		})
+		defer func() { _ = l.Close() }()
+
+		// The deferred close releases the server, which writes a closeNotify
+		// alert of its own when it closes the session on QUIT. A pipe carries
+		// no buffer, so that write waits for a reader that no longer reads.
+		conn := l.dial(t)
+		defer func() { _ = conn.Close() }()
+
+		c, err := smtp.NewClient(conn, "localhost")
+		if err != nil {
+			t.Fatalf("NewClient failed: %v", err)
+		}
+
+		// The session below runs on a TLS connection.
+		if err := c.StartTLS(pipeClientTLS()); err != nil {
+			t.Fatalf("STARTTLS failed: %v", err)
+		}
+
+		time.Sleep(time.Second)
+
+		if err := c.Mail("sender@example.org"); err != nil {
+			t.Fatalf("MAIL failed: %v", err)
+		}
+
+		time.Sleep(time.Second)
+
+		if err := c.Rcpt("recipient@example.net"); err != nil {
+			t.Fatalf("RCPT failed: %v", err)
+		}
+
+		time.Sleep(time.Second)
+
+		if err := c.Rcpt("recipient@example.net"); err != nil {
+			t.Fatalf("RCPT failed: %v", err)
+		}
+
+		time.Sleep(time.Second)
+
+		// QUIT goes through Cmd, not Client.Quit. Quit closes the TLS client
+		// after the reply, and the server closes its own TLS conn on QUIT.
+		// Both closes write a closeNotify alert, and the two writes then wait
+		// for each other. A socket hides this, because the kernel buffers
+		// both alerts.
+		if err := smtptest.Cmd(c.Text, 221, "QUIT"); err != nil {
+			t.Fatalf("QUIT failed: %v", err)
+		}
 	})
-
-	// Dial sends STARTTLS, so the session below runs on a TLS connection.
-	c := srv.Dial()
-
-	time.Sleep(time.Second)
-
-	if err := c.Mail("sender@example.org"); err != nil {
-		t.Fatalf("MAIL failed: %v", err)
-	}
-
-	time.Sleep(time.Second)
-
-	if err := c.Rcpt("recipient@example.net"); err != nil {
-		t.Fatalf("RCPT failed: %v", err)
-	}
-
-	time.Sleep(time.Second)
-
-	if err := c.Rcpt("recipient@example.net"); err != nil {
-		t.Fatalf("RCPT failed: %v", err)
-	}
-
-	time.Sleep(time.Second)
-
-	if err := c.Quit(); err != nil {
-		t.Fatalf("Quit failed: %v", err)
-	}
-
 }
 
 func TestLongLine(t *testing.T) {


### PR DESCRIPTION
`TestTimeoutClose` and `TestTLSTimeout` waited for the read timeout in real
time. Both now run in a `synctest` bubble on a fake clock. A third test covers
the backoff after a failed `Accept`, which no test reached before.

The result is new coverage and tests that do not depend on the wall clock. It
is not a faster package: see the measurements below.

## Why a pipe

A bubble replaces the clock of the goroutines it holds, but only for waits that
Go controls:

- `net.Pipe` applies its deadlines in Go, so the bubble drives them.
- A TCP deadline comes from the operating system, which keeps the real clock. A
  goroutine that waits for a TCP read is also not durably blocked, so the bubble
  stops its clock and the test pays the full wait.

The two tests therefore run the server over `net.Pipe` through the exported
`Serve(net.Listener)`. The library is unchanged, and `smtptest` is unchanged.

## Measurements

Each test loses its real-time wait:

| Test | Before | After |
|---|---|---|
| `TestTLSTimeout` | 4.01s | 0.00s |
| `TestTimeoutClose` | 2.00s | 0.00s |
| `TestAcceptRetryBackoff` | (no test) | 0.00s |

The package total does not change. CI ran both branches with `-race` on the
same hardware:

| Branch | `smtpd/v2` |
|---|---|
| main | 11.396s |
| this branch | 11.179s |

The six seconds above overlapped with other tests that run in parallel, so they
were never the limit. The tests that open loopback sockets set the total.

## The tests still fail when the code breaks

Each test was run against a broken copy of the library:

- No refresh of the read deadline: both timeout tests fail.
- No read deadline at all: `TestTimeoutClose` fails with `421 "Too busy"`,
  because the first session keeps the one slot of `MaxConnections`.
- No backoff after a failed `Accept`: `TestAcceptRetryBackoff` reports 1 call
  instead of 4.
- A backoff of two seconds: `TestAcceptRetryBackoff` reports the wrong count at
  2.5s and at 3.5s.

## Notes for the reader

Two traps are recorded in comments, because a pipe carries no buffer:

- On QUIT the server closes its TLS connection, which writes a closeNotify
  alert. `Client.Quit` writes one at the same time. The two writes wait for each
  other, so the test sends QUIT with `smtptest.Cmd` and closes the client
  connection to release the server. A socket hides this, because the kernel
  buffers both alerts.
- `synctest.Wait` does not move the clock. It returns when the other goroutines
  block. A test that waits for a server in a backoff must sleep in its own
  goroutine.

## Verification

CI passes `go test -v -race -count=1 ./...` and the lint job. Locally `go vet
./...` and `golangci-lint run ./...` pass, and `go mod tidy` leaves `go.mod` and
`go.sum` unchanged.