### PR TITLE
chore: release v2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.1] - 2026-08-16
+
 ### Fixed
 
 - The credentials of an `AUTH` command stay out of the log when the client
@@ -245,7 +247,8 @@ walkthrough.
 - `Peer.Password` — the password is still passed to the `Authenticate` hook but
   is no longer stored on `Peer`.
 
-[Unreleased]: https://github.com/chrj/smtpd/compare/v2.3.0...main
+[Unreleased]: https://github.com/chrj/smtpd/compare/v2.3.1...main
+[2.3.1]: https://github.com/chrj/smtpd/releases/tag/v2.3.1
 [2.3.0]: https://github.com/chrj/smtpd/releases/tag/v2.3.0
 [2.2.0]: https://github.com/chrj/smtpd/releases/tag/v2.2.0
 [2.1.2]: https://github.com/chrj/smtpd/releases/tag/v2.1.2


### PR DESCRIPTION
## What this does

This pull request prepares the release of v2.3.1. It moves the `Unreleased`
section of the changelog under a `2.3.1` heading with the date 2026-08-16. It
also adds the link reference for the new tag.

There is no code change here. All three fixes are already on `main`.

## What ships in v2.3.1

- The credentials of an `AUTH` command stay out of the log when the client
  writes the command with tabs between the parts (#46). Before, the log carried
  the full line at the `DEBUG` level.

- An address with a quoted local part keeps its quoting in `Envelope.Sender`
  (#47). Before, `MAIL FROM:<" "@example.org>` became ` @example.org`, which is
  not an address.

- An address that carries a line break gets a `501` reply (#47).

## After the merge

The tag and the GitHub release come by hand.
