### PR TITLE
feat: write the enhanced status codes of RFC 3463

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The server offers `ENHANCEDSTATUSCODES` and writes the status code of
+  RFC 3463 after the reply code, for example `250 2.1.5 Go ahead` and
+  `550 5.7.1 Relay access denied`.
+
+- `EnhancedCode` holds such a status code, and the new `Enhanced` field of
+  `Error` carries it from a middleware to the client. The field is optional.
+  An error that leaves it out takes the generic code for the class of `Code`,
+  which RFC 3463 section 3.1 writes as `x.0.0`.
+
+- The middleware in `middleware` sets a status code for each of its refusals.
+  The SPF checker uses the codes of RFC 7372: `5.7.23` for a check that
+  fails, and `5.7.24` for an error in the check.
+
+### Changed
+
+- A client that sends `EHLO` gets a status code on every reply after that
+  command. A test that asserts on the text of a reply must expect it.
+
+  Three replies stay as they were, because RFC 2034 takes them out of the
+  extension: the greeting, the reply to `HELO` and the reply to `EHLO`. A
+  client that sends `HELO` sees no change at all, because it never saw the
+  server offer the extension.
+
+  The `354` of `DATA` and the `334` of `AUTH` also stay as they were.
+  RFC 3463 defines no status class for those replies.
+
 ## [2.3.1] - 2026-08-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Features
 
 * STARTTLS and implicit TLS
 * PLAIN/LOGIN authentication (after STARTTLS)
+* Enhanced status codes ([RFC 3463](https://www.rfc-editor.org/rfc/rfc3463))
 * [XCLIENT](http://www.postfix.org/XCLIENT_README.html) and the
   [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
 * Per-phase middleware: connection, HELO, MAIL FROM, RCPT TO, AUTH, DATA,
@@ -85,7 +86,8 @@ Architecture
 | `Middleware` | Struct with optional per-phase hook fields. Any combination of fields may be set. |
 | `Peer` | Connection-scoped state, populated progressively (`Addr` at connect, `HeloName` after HELO, `TLS` after handshake, `Username` after AUTH). Passed by value to every hook. |
 | `Envelope` | Transaction-scoped state: `Sender`, `Recipients`, `Data io.ReadCloser`. Passed by pointer so Handlers can mutate `Data`. |
-| `Error` | `{Code, Message}` - returned from any hook to produce a specific SMTP reply. Non-`Error` errors are reported as `502`. |
+| `Error` | `{Code, Enhanced, Message}` - returned from any hook to produce a specific SMTP reply. Non-`Error` errors are reported as `502`. |
+| `EnhancedCode` | `[3]int` - the RFC 3463 status code that goes after the reply code, such as `{5, 7, 1}`. |
 
 ### Address form
 
@@ -301,8 +303,64 @@ Notes:
   protocol in sync.
 * Returning an `smtpd.Error` lets you pick the reply code; any other error
   becomes `502`.
+* Set `Enhanced` on the error to give the client a precise reason. An error
+  that leaves it out takes the generic code for its class, such as `5.0.0`.
+  See [Enhanced status codes](#enhanced-status-codes).
 * The returned context replaces the session context for any subsequent
   commands on the connection.
+
+Enhanced status codes
+---------------------
+
+The server offers `ENHANCEDSTATUSCODES` and writes the status code of
+[RFC 3463](https://www.rfc-editor.org/rfc/rfc3463) after the reply code:
+
+```
+250 2.1.5 Go ahead
+550 5.7.1 Relay access denied
+452 4.5.3 Too many recipients
+```
+
+Set the code on the error that your hook returns:
+
+```go
+return ctx, smtpd.Error{
+    Code:     550,
+    Enhanced: smtpd.EnhancedCode{5, 7, 1},
+    Message:  "Relay access denied",
+}
+```
+
+`Enhanced` is optional. An error that leaves it out takes the generic code
+for the class of `Code`, which RFC 3463 section 3.1 writes as `x.0.0`. The
+example above sends `550 5.0.0 Relay access denied` without the `Enhanced`
+field.
+
+The server leaves the status code out in three places, because
+[RFC 2034](https://www.rfc-editor.org/rfc/rfc2034) does:
+
+* The greeting, which the client reads before it sends a command.
+* The reply to `HELO` and to `EHLO`.
+* Every reply to a client that sent `HELO`. Such a client never saw the
+  server offer the extension, so it gets the replies of RFC 5321.
+
+RFC 3463 defines no status class for a `1yz` or a `3yz` reply, so the `354`
+of `DATA` and the `334` of `AUTH` also stay as they were.
+
+The middleware in `middleware` sets a code for each of its refusals:
+
+| Middleware | Reply |
+| --- | --- |
+| `RequireAuth` | `530 5.7.0 Authentication required` |
+| `RequireTLS` | `530 5.7.0 Must issue STARTTLS first` |
+| `Greylist` | `450 4.7.1 greylisted, try again later` |
+| `IPAddressRateLimit` | `450 4.7.1 rate-limited, try again later` |
+| `RBL` | `554 5.7.1 {list message}` |
+| `SPF` (fail) | `550 5.7.23 SPF check failed` |
+| `SPF` (temporary error) | `451 4.7.24 SPF check temporary error` |
+| `SPF` (permanent error) | `550 5.7.24 SPF check permanent error` |
+
+The SPF codes come from [RFC 7372](https://www.rfc-editor.org/rfc/rfc7372).
 
 Writing middleware
 ------------------
@@ -683,8 +741,12 @@ need in the returned context.
 * A failed STARTTLS handshake now closes the connection (v1 continued the
   session in cleartext). The failure is reported through the `Disconnect`
   hook's `err` argument.
-* `smtpd.Error` renders to `"{Code} {Message}"` - `errors.Is`/`errors.As`
-  work as expected on it.
+* `smtpd.Error` renders to `"{Code} {Message}"`, or to
+  `"{Code} {Enhanced} {Message}"` when you set `Enhanced` -
+  `errors.Is`/`errors.As` work as expected on it.
+* A client that sends `EHLO` now gets the status codes of RFC 3463 on every
+  reply. A test that asserts on the text of a reply must expect them. A
+  client that sends `HELO` sees no change.
 * `Reset` and `Disconnect` middleware hooks are new in v2.
 
 Feedback

--- a/auth.go
+++ b/auth.go
@@ -13,22 +13,22 @@ func (s *session) handleAUTH(ctx context.Context, cmd *command) context.Context 
 
 	args := cmd.args()
 	if len(args) < 1 || len(args) > 2 {
-		return s.reply(ctx, 501, "Invalid syntax.")
+		return s.replyEnhanced(ctx, 501, EnhancedCode{5, 5, 4}, "Invalid syntax.")
 	}
 
 	if !s.server.hasAuthenticator() {
-		return s.reply(ctx, 502, "AUTH not supported.")
+		return s.replyEnhanced(ctx, 502, EnhancedCode{5, 5, 1}, "AUTH not supported.")
 	}
 
 	if s.peer.HeloName == "" {
-		return s.reply(ctx, 503, "Please introduce yourself first.")
+		return s.replyEnhanced(ctx, 503, EnhancedCode{5, 5, 1}, "Please introduce yourself first.")
 	}
 
 	if !s.tls && !s.server.AllowInsecureAuth {
 		if s.server.TLSConfig == nil {
-			return s.reply(ctx, 502, "Cannot AUTH in plain text mode and STARTTLS is not available.")
+			return s.replyEnhanced(ctx, 502, EnhancedCode{5, 5, 1}, "Cannot AUTH in plain text mode and STARTTLS is not available.")
 		}
-		return s.reply(ctx, 530, "Cannot AUTH in plain text mode. Use STARTTLS.")
+		return s.replyEnhanced(ctx, 530, EnhancedCode{5, 7, 0}, "Cannot AUTH in plain text mode. Use STARTTLS.")
 	}
 
 	mechanism := strings.ToUpper(args[0])
@@ -55,13 +55,13 @@ func (s *session) handleAUTH(ctx context.Context, cmd *command) context.Context 
 		data, err := base64.StdEncoding.DecodeString(auth)
 
 		if err != nil {
-			return s.reply(ctx, 501, "Couldn't decode your credentials")
+			return s.replyEnhanced(ctx, 501, EnhancedCode{5, 5, 2}, "Couldn't decode your credentials")
 		}
 
 		parts := bytes.Split(data, []byte{0})
 
 		if len(parts) != 3 {
-			return s.reply(ctx, 501, "Couldn't decode your credentials")
+			return s.replyEnhanced(ctx, 501, EnhancedCode{5, 5, 2}, "Couldn't decode your credentials")
 		}
 
 		username = string(parts[1])
@@ -84,7 +84,7 @@ func (s *session) handleAUTH(ctx context.Context, cmd *command) context.Context 
 		byteUsername, err := base64.StdEncoding.DecodeString(encodedUsername)
 
 		if err != nil {
-			return s.reply(ctx, 501, "Couldn't decode your credentials")
+			return s.replyEnhanced(ctx, 501, EnhancedCode{5, 5, 2}, "Couldn't decode your credentials")
 		}
 
 		ctx = s.reply(ctx, 334, "UGFzc3dvcmQ6")
@@ -96,7 +96,7 @@ func (s *session) handleAUTH(ctx context.Context, cmd *command) context.Context 
 		bytePassword, err := base64.StdEncoding.DecodeString(s.scanner.Text())
 
 		if err != nil {
-			return s.reply(ctx, 501, "Couldn't decode your credentials")
+			return s.replyEnhanced(ctx, 501, EnhancedCode{5, 5, 2}, "Couldn't decode your credentials")
 		}
 
 		username = string(byteUsername)
@@ -105,7 +105,7 @@ func (s *session) handleAUTH(ctx context.Context, cmd *command) context.Context 
 	default:
 
 		logger.WarnContext(ctx, "unknown authentication mechanism", slog.String("mechanism", mechanism))
-		return s.reply(ctx, 504, "Unknown authentication mechanism")
+		return s.replyEnhanced(ctx, 504, EnhancedCode{5, 5, 4}, "Unknown authentication mechanism")
 
 	}
 
@@ -117,6 +117,6 @@ func (s *session) handleAUTH(ctx context.Context, cmd *command) context.Context 
 
 	s.peer.Username = username
 
-	return s.reply(ctx, 235, "OK, you are now authenticated")
+	return s.replyEnhanced(ctx, 235, EnhancedCode{2, 7, 0}, "OK, you are now authenticated")
 
 }

--- a/auth_test.go
+++ b/auth_test.go
@@ -267,7 +267,8 @@ func TestAUTHInsecureDeniedByDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AUTH without TLS didn't 502: %v", err)
 	}
-	if msg != "Cannot AUTH in plain text mode and STARTTLS is not available." {
+	// Hello sent EHLO, so the reply carries the status code of RFC 3463.
+	if msg != "5.5.1 Cannot AUTH in plain text mode and STARTTLS is not available." {
 		t.Errorf("got refusal %q, want the STARTTLS-unavailable message", msg)
 	}
 

--- a/data.go
+++ b/data.go
@@ -13,7 +13,7 @@ func (s *session) handleDATA(ctx context.Context, cmd *command) context.Context 
 	ctx, _ = phasedLoggerFromContext(ctx, "data")
 
 	if s.envelope == nil || len(s.envelope.Recipients) == 0 {
-		return s.reply(ctx, 503, "Missing RCPT TO command.")
+		return s.replyEnhanced(ctx, 503, EnhancedCode{5, 5, 1}, "Missing RCPT TO command.")
 	}
 
 	ctx = s.reply(ctx, 354, "Go ahead. End your data with <CR><LF>.<CR><LF>")
@@ -32,7 +32,7 @@ func (s *session) handleDATA(ctx context.Context, cmd *command) context.Context 
 	_ = body.Close()
 
 	if body.tooBig {
-		ctx = s.reply(ctx, 552, fmt.Sprintf(
+		ctx = s.replyEnhanced(ctx, 552, EnhancedCode{5, 3, 4}, fmt.Sprintf(
 			"Message exceeded max message size of %d bytes",
 			s.server.MaxMessageSize,
 		))

--- a/enhanced.go
+++ b/enhanced.go
@@ -1,0 +1,61 @@
+package smtpd
+
+import "strconv"
+
+// EnhancedCode is the mail system status code of RFC 3463. It holds the
+// class, the subject and the detail of a reply, in that order, and the
+// server writes it after the reply code as "class.subject.detail".
+//
+// RFC 3463 gives three classes: 2 for success, 4 for a temporary fault and
+// 5 for a permanent one. The zero value means that the reply carries no
+// status code.
+//
+// Set it on an Error to give a middleware rejection a precise reason:
+//
+//	smtpd.Error{
+//	    Code:     550,
+//	    Enhanced: smtpd.EnhancedCode{5, 7, 1},
+//	    Message:  "Relay access denied",
+//	}
+//
+// An Error with the zero value gets a code from the class of Code, so a
+// middleware that sets no status code still produces a valid reply.
+type EnhancedCode [3]int
+
+// String writes the code in the form that RFC 3463 gives, for example
+// "5.7.1". The zero value returns an empty string.
+func (c EnhancedCode) String() string {
+	if !c.valid() {
+		return ""
+	}
+	return strconv.Itoa(c[0]) + "." + strconv.Itoa(c[1]) + "." + strconv.Itoa(c[2])
+}
+
+// valid reports whether the code has a class that RFC 3463 defines. The
+// zero value is not valid, which is what makes it mean "no status code".
+func (c EnhancedCode) valid() bool {
+	switch c[0] {
+	case 2, 4, 5:
+		return c[1] >= 0 && c[2] >= 0
+	}
+	return false
+}
+
+// defaultEnhancedCode gives the generic status code for an SMTP reply code.
+// RFC 3463 section 3.1 defines "x.0.0" as the code for a reply with no more
+// precise reason.
+//
+// A reply of class 1 or 3 gets no status code. RFC 3463 defines the classes
+// 2, 4 and 5 only, and a 354 or a 334 reply is part of a command that is
+// still in progress.
+func defaultEnhancedCode(code int) EnhancedCode {
+	switch code / 100 {
+	case 2:
+		return EnhancedCode{2, 0, 0}
+	case 4:
+		return EnhancedCode{4, 0, 0}
+	case 5:
+		return EnhancedCode{5, 0, 0}
+	}
+	return EnhancedCode{}
+}

--- a/enhanced_test.go
+++ b/enhanced_test.go
@@ -1,0 +1,359 @@
+package smtpd_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/chrj/smtpd/v2"
+)
+
+// TestEnhancedStatusCodesAdvertised proves that the server offers the
+// extension of RFC 2034 in the reply to EHLO. A client reads the status
+// codes of the session only after it sees this keyword.
+func TestEnhancedStatusCodesAdvertised(t *testing.T) {
+	t.Parallel()
+
+	srv := runserver(t, &smtpd.Server{Logger: testLogger(t)})
+	c := dialRaw(t, srv.Addr)
+
+	lines := c.replyLines("EHLO localhost")
+
+	found := false
+	for _, line := range lines {
+		if strings.TrimSpace(line[4:]) == "ENHANCEDSTATUSCODES" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("EHLO reply %q, want a line with ENHANCEDSTATUSCODES", lines)
+	}
+}
+
+// TestEnhancedStatusCodeOnReply drives a session to one point and reads the
+// full text of the last reply line, so that the code, the status code and
+// the message are all part of the assertion.
+func TestEnhancedStatusCodeOnReply(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		commands []string
+		want     string
+	}{
+		{
+			name:     "accepted sender",
+			commands: []string{"EHLO localhost", "MAIL FROM:<sender@example.org>"},
+			want:     "250 2.1.0 Go ahead",
+		},
+		{
+			name: "accepted recipient",
+			commands: []string{
+				"EHLO localhost",
+				"MAIL FROM:<sender@example.org>",
+				"RCPT TO:<recipient@example.net>",
+			},
+			want: "250 2.1.5 Go ahead",
+		},
+		{
+			name:     "reset transaction",
+			commands: []string{"EHLO localhost", "RSET"},
+			want:     "250 2.0.0 Go ahead",
+		},
+		{
+			name:     "no operation",
+			commands: []string{"EHLO localhost", "NOOP"},
+			want:     "250 2.0.0 Go ahead",
+		},
+		{
+			name:     "quit",
+			commands: []string{"EHLO localhost", "QUIT"},
+			want:     "221 2.0.0 OK, bye",
+		},
+		{
+			name:     "unknown command",
+			commands: []string{"EHLO localhost", "FROBNICATE"},
+			want:     "500 5.5.1 Unsupported command.",
+		},
+		{
+			name:     "recipient before sender",
+			commands: []string{"EHLO localhost", "RCPT TO:<recipient@example.net>"},
+			want:     "503 5.5.1 Missing MAIL FROM command.",
+		},
+		{
+			name:     "second sender",
+			commands: []string{"EHLO localhost", "MAIL FROM:<a@example.org>", "MAIL FROM:<b@example.org>"},
+			want:     "503 5.5.1 Duplicate MAIL",
+		},
+		{
+			name:     "malformed sender",
+			commands: []string{"EHLO localhost", "MAIL FROM:<not an address>"},
+			want:     "501 5.1.7 Malformed e-mail address",
+		},
+		{
+			name: "malformed recipient",
+			commands: []string{
+				"EHLO localhost",
+				"MAIL FROM:<sender@example.org>",
+				"RCPT TO:<not an address>",
+			},
+			want: "501 5.1.3 Malformed e-mail address",
+		},
+		{
+			name:     "data before recipient",
+			commands: []string{"EHLO localhost", "MAIL FROM:<sender@example.org>", "DATA"},
+			want:     "503 5.5.1 Missing RCPT TO command.",
+		},
+		{
+			name:     "declared size over the limit",
+			commands: []string{"EHLO localhost", "MAIL FROM:<sender@example.org> SIZE=99999999"},
+			want:     "552 5.3.4 Message size exceeds fixed maximum of 10240000 bytes",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := runserver(t, &smtpd.Server{Logger: testLogger(t)})
+			c := dialRaw(t, srv.Addr)
+
+			got := ""
+			for _, command := range test.commands {
+				got = c.send("%s", command)
+			}
+
+			if got != test.want {
+				t.Errorf("got %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+// TestNoEnhancedStatusCodeAfterHELO proves that a client that sent HELO gets
+// the replies of RFC 5321. RFC 2034 puts the status codes behind an
+// extension, and a HELO client never saw the server offer it.
+func TestNoEnhancedStatusCodeAfterHELO(t *testing.T) {
+	t.Parallel()
+
+	srv := runserver(t, &smtpd.Server{Logger: testLogger(t)})
+	c := dialRaw(t, srv.Addr)
+
+	if got, want := c.send("HELO localhost"), "250 Go ahead"; got != want {
+		t.Errorf("HELO: got %q, want %q", got, want)
+	}
+
+	if got, want := c.send("MAIL FROM:<sender@example.org>"), "250 Go ahead"; got != want {
+		t.Errorf("MAIL FROM: got %q, want %q", got, want)
+	}
+
+	if got, want := c.send("FROBNICATE"), "500 Unsupported command."; got != want {
+		t.Errorf("unknown command: got %q, want %q", got, want)
+	}
+}
+
+// TestGreetingCarriesNoEnhancedStatusCode proves that the banner stays as it
+// was. RFC 2034 takes the greeting out of the extension, and the client has
+// sent no command at that point.
+func TestGreetingCarriesNoEnhancedStatusCode(t *testing.T) {
+	t.Parallel()
+
+	srv := runserver(t, &smtpd.Server{
+		Hostname: "mx.example.com",
+		Logger:   testLogger(t),
+	})
+	c := dialRaw(t, srv.Addr)
+
+	if got, want := c.banner, "220 mx.example.com ESMTP ready."; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestEHLOReplyCarriesNoEnhancedStatusCode proves that the reply to EHLO
+// keeps only the hostname and the extension keywords. A status code on those
+// lines makes the client read a keyword that the server does not have.
+func TestEHLOReplyCarriesNoEnhancedStatusCode(t *testing.T) {
+	t.Parallel()
+
+	srv := runserver(t, &smtpd.Server{
+		Hostname: "mx.example.com",
+		Logger:   testLogger(t),
+	})
+	c := dialRaw(t, srv.Addr)
+
+	lines := c.replyLines("EHLO localhost")
+
+	want := []string{
+		"250-mx.example.com",
+		"250-SIZE 10240000",
+		"250-8BITMIME",
+		"250-PIPELINING",
+		"250 ENHANCEDSTATUSCODES",
+	}
+
+	if len(lines) != len(want) {
+		t.Fatalf("got %q, want %q", lines, want)
+	}
+	for i := range want {
+		if lines[i] != want[i] {
+			t.Errorf("line %d: got %q, want %q", i, lines[i], want[i])
+		}
+	}
+}
+
+// TestDataContinuationCarriesNoEnhancedStatusCode proves that the 354 reply
+// stays as it was. RFC 3463 gives no status class for a 3yz reply, because
+// the command is not finished.
+func TestDataContinuationCarriesNoEnhancedStatusCode(t *testing.T) {
+	t.Parallel()
+
+	srv := runserver(t, &smtpd.Server{Logger: testLogger(t)})
+	c := dialRaw(t, srv.Addr)
+
+	c.send("EHLO localhost")
+	c.send("MAIL FROM:<sender@example.org>")
+	c.send("RCPT TO:<recipient@example.net>")
+
+	got := c.send("DATA")
+	want := "354 Go ahead. End your data with <CR><LF>.<CR><LF>"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestMiddlewareErrorCarriesEnhancedStatusCode proves that a status code set
+// on an smtpd.Error reaches the client.
+func TestMiddlewareErrorCarriesEnhancedStatusCode(t *testing.T) {
+	t.Parallel()
+
+	deny := smtpd.Middleware{
+		CheckRecipient: func(ctx context.Context, _ smtpd.Peer, _ string) (context.Context, error) {
+			return ctx, smtpd.Error{
+				Code:     550,
+				Enhanced: smtpd.EnhancedCode{5, 7, 1},
+				Message:  "Relay access denied",
+			}
+		},
+	}
+
+	srv := runserver(t, &smtpd.Server{Logger: testLogger(t)}, deny)
+	c := dialRaw(t, srv.Addr)
+
+	c.send("EHLO localhost")
+	c.send("MAIL FROM:<sender@example.org>")
+
+	got := c.send("RCPT TO:<recipient@example.net>")
+	want := "550 5.7.1 Relay access denied"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestMiddlewareErrorTakesDefaultEnhancedStatusCode proves that an error
+// with no status code still gets a valid one, from the class of the reply
+// code. RFC 3463 section 3.1 gives "x.0.0" for a reply with no more precise
+// reason.
+func TestMiddlewareErrorTakesDefaultEnhancedStatusCode(t *testing.T) {
+	t.Parallel()
+
+	srv := runserver(t, &smtpd.Server{Logger: testLogger(t)}, rejectSender())
+	c := dialRaw(t, srv.Addr)
+
+	c.send("EHLO localhost")
+
+	got := c.send("MAIL FROM:<sender@example.org>")
+	want := "552 5.0.0 Denied"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestPlainErrorTakesEnhancedStatusCode proves that an error which is not an
+// smtpd.Error also reaches the client with a status code. The server reports
+// those as 502, which means that the command is not implemented.
+func TestPlainErrorTakesEnhancedStatusCode(t *testing.T) {
+	t.Parallel()
+
+	srv := runserver(t, &smtpd.Server{Logger: testLogger(t)}, smtpd.Middleware{
+		CheckSender: func(ctx context.Context, _ smtpd.Peer, _ string) (context.Context, error) {
+			return ctx, errors.New("Denied")
+		},
+	})
+	c := dialRaw(t, srv.Addr)
+
+	c.send("EHLO localhost")
+
+	got := c.send("MAIL FROM:<sender@example.org>")
+	want := "502 5.5.1 Denied"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestEnhancedCodeString proves the text form of the status code, and that
+// the zero value produces no text.
+func TestEnhancedCodeString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		code smtpd.EnhancedCode
+		want string
+	}{
+		{"success", smtpd.EnhancedCode{2, 1, 5}, "2.1.5"},
+		{"temporary fault", smtpd.EnhancedCode{4, 7, 1}, "4.7.1"},
+		{"permanent fault", smtpd.EnhancedCode{5, 7, 1}, "5.7.1"},
+		{"two-digit detail", smtpd.EnhancedCode{5, 7, 23}, "5.7.23"},
+		{"zero value", smtpd.EnhancedCode{}, ""},
+		{"class that RFC 3463 does not define", smtpd.EnhancedCode{3, 0, 0}, ""},
+		{"negative part", smtpd.EnhancedCode{5, -1, 0}, ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := test.code.String(); got != test.want {
+				t.Errorf("got %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+// TestErrorString proves that the text of an smtpd.Error names the status
+// code that the caller set, and leaves out one that the caller did not set.
+func TestErrorString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  smtpd.Error
+		want string
+	}{
+		{
+			name: "with a status code",
+			err: smtpd.Error{
+				Code:     550,
+				Enhanced: smtpd.EnhancedCode{5, 7, 1},
+				Message:  "Relay access denied",
+			},
+			want: "550 5.7.1 Relay access denied",
+		},
+		{
+			name: "without a status code",
+			err:  smtpd.Error{Code: 550, Message: "Relay access denied"},
+			want: "550 Relay access denied",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := test.err.Error(); got != test.want {
+				t.Errorf("got %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -83,7 +83,7 @@ func RequireAuthAt(phase AuthPhase) smtpd.Middleware {
 
 func requireAuth(peer smtpd.Peer) error {
 	if peer.Username == "" {
-		return smtpd.Error{Code: 530, Message: "Authentication required"}
+		return smtpd.Error{Code: 530, Enhanced: smtpd.EnhancedCode{5, 7, 0}, Message: "Authentication required"}
 	}
 	return nil
 }

--- a/middleware/greylist.go
+++ b/middleware/greylist.go
@@ -136,10 +136,10 @@ func (g *GreylistChecker) RecipientCheck(ctx context.Context, peer smtpd.Peer, r
 			slog.String("ip", tcpAddr.IP.String()),
 			slog.String("sender", sender),
 			slog.String("recipient", recipient))
-		return smtpd.Error{Code: 450, Message: "greylisted, try again later"}
+		return smtpd.Error{Code: 450, Enhanced: smtpd.EnhancedCode{4, 7, 1}, Message: "greylisted, try again later"}
 	}
 	if now.Sub(first) < g.delay {
-		return smtpd.Error{Code: 450, Message: "greylisted, try again later"}
+		return smtpd.Error{Code: 450, Enhanced: smtpd.EnhancedCode{4, 7, 1}, Message: "greylisted, try again later"}
 	}
 	return nil
 }

--- a/middleware/rate_limit.go
+++ b/middleware/rate_limit.go
@@ -27,7 +27,7 @@ func IPAddressRateLimit(rps float64, burst int) PeerCheck {
 			return nil
 		}
 		if !lims.Allow(tcpAddr.IP.String()) {
-			return smtpd.Error{Code: 450, Message: "rate-limited, try again later"}
+			return smtpd.Error{Code: 450, Enhanced: smtpd.EnhancedCode{4, 7, 1}, Message: "rate-limited, try again later"}
 		}
 		return nil
 	}

--- a/middleware/rbl.go
+++ b/middleware/rbl.go
@@ -85,7 +85,7 @@ func (r *RBLChecker) ConnectionCheck(ctx context.Context, peer smtpd.Peer) error
 				slog.String("list", list),
 				slog.String("msg", msg),
 			)
-			return smtpd.Error{Code: 554, Message: msg}
+			return smtpd.Error{Code: 554, Enhanced: smtpd.EnhancedCode{5, 7, 1}, Message: msg}
 		}
 	}
 

--- a/middleware/spf.go
+++ b/middleware/spf.go
@@ -80,11 +80,11 @@ func (s *SPFChecker) check(ctx context.Context, peer smtpd.Peer, helo, sender st
 	case spf.Fail:
 		logger.WarnContext(ctx, "SPF check failed",
 			slog.String("sender", sender), slog.String("helo", helo))
-		return smtpd.Error{Code: 550, Message: "SPF check failed"}
+		return smtpd.Error{Code: 550, Enhanced: smtpd.EnhancedCode{5, 7, 23}, Message: "SPF check failed"}
 	case spf.TempError:
-		return smtpd.Error{Code: 451, Message: "SPF check temporary error"}
+		return smtpd.Error{Code: 451, Enhanced: smtpd.EnhancedCode{4, 7, 24}, Message: "SPF check temporary error"}
 	case spf.PermError:
-		return smtpd.Error{Code: 550, Message: "SPF check permanent error"}
+		return smtpd.Error{Code: 550, Enhanced: smtpd.EnhancedCode{5, 7, 24}, Message: "SPF check permanent error"}
 	}
 	return nil
 }

--- a/middleware/tls.go
+++ b/middleware/tls.go
@@ -54,7 +54,7 @@ func RequireTLSAt(phase TLSPhase) smtpd.Middleware {
 
 func requireTLS(peer smtpd.Peer) error {
 	if peer.TLS == nil {
-		return smtpd.Error{Code: 530, Message: "Must issue STARTTLS first"}
+		return smtpd.Error{Code: 530, Enhanced: smtpd.EnhancedCode{5, 7, 0}, Message: "Must issue STARTTLS first"}
 	}
 	return nil
 }

--- a/protocol.go
+++ b/protocol.go
@@ -16,7 +16,7 @@ func (s *session) validateMailParams(params map[string]string) error {
 		return nil
 	}
 	if s.peer.Protocol != ESMTP {
-		return Error{Code: 555, Message: "MAIL FROM parameters not recognized or not implemented"}
+		return Error{Code: 555, Enhanced: EnhancedCode{5, 5, 4}, Message: "MAIL FROM parameters not recognized or not implemented"}
 	}
 
 	for name, value := range params {
@@ -24,24 +24,25 @@ func (s *session) validateMailParams(params map[string]string) error {
 		case "SIZE":
 			size, err := strconv.ParseInt(value, 10, 64)
 			if err != nil || size < 0 {
-				return Error{Code: 501, Message: "Invalid SIZE parameter"}
+				return Error{Code: 501, Enhanced: EnhancedCode{5, 5, 4}, Message: "Invalid SIZE parameter"}
 			}
 			if size > int64(s.server.MaxMessageSize) {
 				return Error{
-					Code:    552,
-					Message: fmt.Sprintf("Message size exceeds fixed maximum of %d bytes", s.server.MaxMessageSize),
+					Code:     552,
+					Enhanced: EnhancedCode{5, 3, 4},
+					Message:  fmt.Sprintf("Message size exceeds fixed maximum of %d bytes", s.server.MaxMessageSize),
 				}
 			}
 		case "BODY":
 			switch strings.ToUpper(value) {
 			case "7BIT", "8BITMIME":
 			default:
-				return Error{Code: 501, Message: "Invalid BODY parameter"}
+				return Error{Code: 501, Enhanced: EnhancedCode{5, 5, 4}, Message: "Invalid BODY parameter"}
 			}
 		case "AUTH":
 			// AUTH=<> and xtext-style identities are accepted as opaque values.
 		default:
-			return Error{Code: 555, Message: "MAIL FROM parameters not recognized or not implemented"}
+			return Error{Code: 555, Enhanced: EnhancedCode{5, 5, 4}, Message: "MAIL FROM parameters not recognized or not implemented"}
 		}
 	}
 
@@ -51,7 +52,7 @@ func (s *session) validateMailParams(params map[string]string) error {
 func (s *session) handle(ctx context.Context, line string) context.Context {
 	cmd, err := parseCommand(line)
 	if err != nil {
-		return s.reply(ctx, 500, "Invalid syntax.")
+		return s.replyEnhanced(ctx, 500, EnhancedCode{5, 5, 2}, "Invalid syntax.")
 	}
 
 	// Commands are dispatched to the appropriate handler functions.
@@ -98,7 +99,7 @@ func (s *session) handle(ctx context.Context, line string) context.Context {
 
 	}
 
-	return s.reply(ctx, 500, "Unsupported command.")
+	return s.replyEnhanced(ctx, 500, EnhancedCode{5, 5, 1}, "Unsupported command.")
 
 }
 
@@ -149,17 +150,7 @@ func (s *session) handleEHLO(ctx context.Context, cmd *command) context.Context 
 	s.peer.HeloName = name
 	s.peer.Protocol = ESMTP
 
-	_, _ = fmt.Fprintf(s.writer, "250-%s\r\n", s.server.Hostname)
-
-	extensions := s.extensions()
-
-	if len(extensions) > 1 {
-		for _, ext := range extensions[:len(extensions)-1] {
-			_, _ = fmt.Fprintf(s.writer, "250-%s\r\n", ext)
-		}
-	}
-
-	return s.reply(ctx, 250, extensions[len(extensions)-1])
+	return s.replyMultiline(ctx, 250, s.server.Hostname, s.extensions()...)
 
 }
 
@@ -168,15 +159,15 @@ func (s *session) handleMAIL(ctx context.Context, cmd *command) context.Context 
 
 	addrSpec, params, err := cmd.pathArg("FROM")
 	if err != nil {
-		return s.reply(ctx, 501, "Invalid syntax.")
+		return s.replyEnhanced(ctx, 501, EnhancedCode{5, 5, 4}, "Invalid syntax.")
 	}
 
 	if s.peer.HeloName == "" {
-		return s.reply(ctx, 503, "Please introduce yourself first.")
+		return s.replyEnhanced(ctx, 503, EnhancedCode{5, 5, 1}, "Please introduce yourself first.")
 	}
 
 	if s.envelope != nil {
-		return s.reply(ctx, 503, "Duplicate MAIL")
+		return s.replyEnhanced(ctx, 503, EnhancedCode{5, 5, 1}, "Duplicate MAIL")
 	}
 
 	addr := "" // null sender
@@ -186,7 +177,7 @@ func (s *session) handleMAIL(ctx context.Context, cmd *command) context.Context 
 		addr, err = parseAddress(addrSpec)
 
 		if err != nil {
-			return s.reply(ctx, 501, "Malformed e-mail address")
+			return s.replyEnhanced(ctx, 501, EnhancedCode{5, 1, 7}, "Malformed e-mail address")
 		}
 	}
 
@@ -205,7 +196,7 @@ func (s *session) handleMAIL(ctx context.Context, cmd *command) context.Context 
 		Sender: addr,
 	}
 
-	return s.reply(ctx, 250, "Go ahead")
+	return s.replyEnhanced(ctx, 250, EnhancedCode{2, 1, 0}, "Go ahead")
 
 }
 
@@ -214,25 +205,25 @@ func (s *session) handleRCPT(ctx context.Context, cmd *command) context.Context 
 
 	addrSpec, params, err := cmd.pathArg("TO")
 	if err != nil {
-		return s.reply(ctx, 501, "Invalid syntax.")
+		return s.replyEnhanced(ctx, 501, EnhancedCode{5, 5, 4}, "Invalid syntax.")
 	}
 
 	if s.envelope == nil {
-		return s.reply(ctx, 503, "Missing MAIL FROM command.")
+		return s.replyEnhanced(ctx, 503, EnhancedCode{5, 5, 1}, "Missing MAIL FROM command.")
 	}
 
 	if len(s.envelope.Recipients) >= s.server.MaxRecipients {
-		return s.reply(ctx, 452, "Too many recipients")
+		return s.replyEnhanced(ctx, 452, EnhancedCode{4, 5, 3}, "Too many recipients")
 	}
 
 	if len(params) > 0 {
-		return s.reply(ctx, 555, "RCPT TO parameters not recognized or not implemented")
+		return s.replyEnhanced(ctx, 555, EnhancedCode{5, 5, 4}, "RCPT TO parameters not recognized or not implemented")
 	}
 
 	addr, err := parseAddress(addrSpec)
 
 	if err != nil {
-		return s.reply(ctx, 501, "Malformed e-mail address")
+		return s.replyEnhanced(ctx, 501, EnhancedCode{5, 1, 3}, "Malformed e-mail address")
 	}
 
 	ctx, err = s.server.checkRecipient(ctx, s.peer, addr)
@@ -242,7 +233,7 @@ func (s *session) handleRCPT(ctx context.Context, cmd *command) context.Context 
 
 	s.envelope.Recipients = append(s.envelope.Recipients, addr)
 
-	return s.reply(ctx, 250, "Go ahead")
+	return s.replyEnhanced(ctx, 250, EnhancedCode{2, 1, 5}, "Go ahead")
 
 }
 
@@ -250,11 +241,11 @@ func (s *session) handleSTARTTLS(ctx context.Context, cmd *command) context.Cont
 	ctx, logger := phasedLoggerFromContext(ctx, "starttls")
 
 	if s.tls {
-		return s.reply(ctx, 503, "Already running in TLS")
+		return s.replyEnhanced(ctx, 503, EnhancedCode{5, 5, 1}, "Already running in TLS")
 	}
 
 	if s.server.TLSConfig == nil {
-		return s.reply(ctx, 502, "TLS not supported")
+		return s.replyEnhanced(ctx, 502, EnhancedCode{5, 5, 1}, "TLS not supported")
 	}
 
 	tlsConn := tls.Server(s.conn, s.server.TLSConfig)
@@ -266,7 +257,7 @@ func (s *session) handleSTARTTLS(ctx context.Context, cmd *command) context.Cont
 		// Best-effort 550 over the still-plain conn in case the client
 		// hasn't sent ClientHello yet; then close - continuing from a
 		// half-failed handshake leaves the byte stream unintelligible.
-		ctx = s.reply(ctx, 550, "Handshake error")
+		ctx = s.replyEnhanced(ctx, 550, EnhancedCode{5, 7, 0}, "Handshake error")
 		return s.close(ctx)
 	}
 
@@ -316,6 +307,6 @@ func (s *session) handleNOOP(ctx context.Context, cmd *command) context.Context 
 
 func (s *session) handleQUIT(ctx context.Context, cmd *command) context.Context {
 	ctx, _ = phasedLoggerFromContext(ctx, "quit")
-	ctx = s.reply(ctx, 221, "OK, bye")
+	ctx = s.replyEnhanced(ctx, 221, EnhancedCode{2, 0, 0}, "OK, bye")
 	return s.close(ctx)
 }

--- a/proxy.go
+++ b/proxy.go
@@ -10,11 +10,11 @@ func (s *session) handlePROXY(ctx context.Context, cmd *command) context.Context
 	fields := cmd.args()
 
 	if !s.server.EnableProxyProtocol {
-		return s.reply(ctx, 550, "Proxy Protocol not enabled")
+		return s.replyEnhanced(ctx, 550, EnhancedCode{5, 7, 0}, "Proxy Protocol not enabled")
 	}
 
 	if len(fields) < 5 {
-		return s.reply(ctx, 501, "Couldn't decode the command.")
+		return s.replyEnhanced(ctx, 501, EnhancedCode{5, 5, 4}, "Couldn't decode the command.")
 	}
 
 	var (
@@ -27,12 +27,12 @@ func (s *session) handlePROXY(ctx context.Context, cmd *command) context.Context
 
 	newTCPPort, err = strconv.ParseUint(fields[3], 10, 16)
 	if err != nil {
-		return s.reply(ctx, 501, "Couldn't decode the command.")
+		return s.replyEnhanced(ctx, 501, EnhancedCode{5, 5, 4}, "Couldn't decode the command.")
 	}
 
 	tcpAddr, ok := s.peer.Addr.(*net.TCPAddr)
 	if !ok {
-		return s.reply(ctx, 502, "Unsupported network connection")
+		return s.replyEnhanced(ctx, 502, EnhancedCode{5, 5, 1}, "Unsupported network connection")
 	}
 
 	updated := &net.TCPAddr{IP: tcpAddr.IP, Port: tcpAddr.Port, Zone: tcpAddr.Zone}

--- a/session.go
+++ b/session.go
@@ -126,14 +126,14 @@ func (s *session) serve(ctx context.Context) {
 	if err := s.scanner.Err(); err != nil {
 		s.setErr(err)
 		if errors.Is(err, bufio.ErrTooLong) {
-			ctx = s.reply(ctx, 500, "Line too long")
+			ctx = s.replyEnhanced(ctx, 500, EnhancedCode{5, 5, 2}, "Line too long")
 		}
 	}
 
 }
 
 func (s *session) reject(ctx context.Context) context.Context {
-	ctx = s.reply(ctx, 421, "Too busy. Try again later.")
+	ctx = s.replyEnhanced(ctx, 421, EnhancedCode{4, 3, 2}, "Too busy. Try again later.")
 	return s.close(ctx)
 }
 
@@ -151,18 +151,72 @@ func (s *session) welcome(ctx context.Context) context.Context {
 		return s.close(ctx)
 	}
 
-	return s.reply(ctx, 220, s.server.WelcomeMessage)
+	// The greeting carries no status code. RFC 2034 takes it out of the
+	// extension, and the client has not sent EHLO at this point.
+	return s.replyEnhanced(ctx, 220, EnhancedCode{}, s.server.WelcomeMessage)
 
 }
 
+// reply writes a single reply line with the generic status code for the
+// class of code, such as "5.0.0" for a 550. Use replyEnhanced where a
+// precise reason helps the client.
 func (s *session) reply(ctx context.Context, code int, message string) context.Context {
+	return s.replyEnhanced(ctx, code, defaultEnhancedCode(code), message)
+}
+
+// replyEnhanced writes a single reply line with the given status code. The
+// zero value of enhanced leaves the status code out, which is what the
+// greeting and the reply to HELO and EHLO need.
+func (s *session) replyEnhanced(ctx context.Context, code int, enhanced EnhancedCode, message string) context.Context {
+	status := s.status(enhanced)
+
 	logger := LoggerFromContext(ctx)
 	logger.DebugContext(ctx, "sending",
 		slog.Int("code", code),
+		slog.String("status", status),
 		slog.String("message", message),
 	)
-	_, _ = fmt.Fprintf(s.writer, "%d %s\r\n", code, message)
+
+	if status == "" {
+		_, _ = fmt.Fprintf(s.writer, "%d %s\r\n", code, message)
+		return s.flush(ctx)
+	}
+
+	_, _ = fmt.Fprintf(s.writer, "%d %s %s\r\n", code, status, message)
 	return s.flush(ctx)
+}
+
+// replyMultiline writes first and rest as one reply, with the continuation
+// mark on every line but the last. The lines carry no status code: this is
+// the reply to EHLO, and RFC 2034 takes that reply out of the extension.
+//
+// The first line is a separate argument, so that a reply always has one.
+func (s *session) replyMultiline(ctx context.Context, code int, first string, rest ...string) context.Context {
+	logger := LoggerFromContext(ctx)
+
+	lines := append([]string{first}, rest...)
+	for _, line := range lines[:len(lines)-1] {
+		logger.DebugContext(ctx, "sending",
+			slog.Int("code", code),
+			slog.String("message", line),
+		)
+		_, _ = fmt.Fprintf(s.writer, "%d-%s\r\n", code, line)
+	}
+
+	return s.replyEnhanced(ctx, code, EnhancedCode{}, lines[len(lines)-1])
+}
+
+// status gives the text of the status code to write with a reply. It is
+// empty when the client did not send EHLO.
+//
+// RFC 2034 makes the status code part of an extension, and the server
+// offers that extension in the reply to EHLO. A client that sent HELO never
+// saw the offer, so it gets the replies that it expects from RFC 5321.
+func (s *session) status(enhanced EnhancedCode) string {
+	if s.peer.Protocol != ESMTP {
+		return ""
+	}
+	return enhanced.String()
 }
 
 func (s *session) flush(ctx context.Context) context.Context {
@@ -175,9 +229,9 @@ func (s *session) flush(ctx context.Context) context.Context {
 func (s *session) replyError(ctx context.Context, err error) context.Context {
 	var smtpErr Error
 	if errors.As(err, &smtpErr) {
-		return s.reply(ctx, smtpErr.Code, smtpErr.Message)
+		return s.replyEnhanced(ctx, smtpErr.Code, smtpErr.enhanced(), smtpErr.Message)
 	}
-	return s.reply(ctx, 502, err.Error())
+	return s.replyEnhanced(ctx, 502, EnhancedCode{5, 5, 1}, err.Error())
 }
 
 func (s *session) extensions() []string {
@@ -186,6 +240,7 @@ func (s *session) extensions() []string {
 		fmt.Sprintf("SIZE %d", s.server.MaxMessageSize),
 		"8BITMIME",
 		"PIPELINING",
+		"ENHANCEDSTATUSCODES",
 	}
 
 	if s.server.EnableXCLIENT {
@@ -245,7 +300,7 @@ func (s *session) recovered(ctx context.Context, v any) context.Context {
 		return ctx
 	}
 
-	return s.reply(ctx, 421, "Service not available, closing transmission channel")
+	return s.replyEnhanced(ctx, 421, EnhancedCode{4, 3, 0}, "Service not available, closing transmission channel")
 }
 
 // notifyDisconnect runs the Disconnect hooks. A panic in a hook is contained

--- a/smtpd.go
+++ b/smtpd.go
@@ -48,17 +48,42 @@ type Peer struct {
 // Error is the SMTP protocol error returned by middleware phase hooks
 // (CheckConnection, CheckHelo, CheckSender, CheckRecipient, Authenticate)
 // and by Handler to signal a wire-level rejection. Code is the 3-digit
-// SMTP status code (e.g. 550, 421) and Message is the text after the
-// code in the reply line. The session layer inspects the returned error
+// SMTP status code (for example 550 or 421) and Message is the text after
+// the code in the reply line. The session layer inspects the returned error
 // via errors.As: an Error produces "{Code} {Message}" on the wire, while
 // any other non-nil error is reported as a generic 502.
+//
+// Enhanced holds the RFC 3463 status code. It is optional: the zero value
+// takes the generic code for the class of Code, such as "5.0.0" for a 550.
+// Set it to give the client a precise reason, such as {5, 7, 1} for a
+// refused relay.
+//
+// The server writes the status code only to a client that sent EHLO, and
+// only after that command. See EnhancedCode.
 type Error struct {
-	Code    int
-	Message string
+	Code     int
+	Enhanced EnhancedCode
+	Message  string
 }
 
+// Error writes the code, the status code and the message. It leaves out a
+// status code that the caller did not set, because the server writes one
+// only to a client that sent EHLO. The generic code that such an error
+// takes on the wire is a property of the session, not of the error.
 func (e Error) Error() string {
+	if e.Enhanced.valid() {
+		return fmt.Sprintf("%d %s %s", e.Code, e.Enhanced, e.Message)
+	}
 	return fmt.Sprintf("%d %s", e.Code, e.Message)
+}
+
+// enhanced gives the status code to write for this error. An error that
+// carries none takes the generic code for the class of Code.
+func (e Error) enhanced() EnhancedCode {
+	if e.Enhanced.valid() {
+		return e.Enhanced
+	}
+	return defaultEnhancedCode(e.Code)
 }
 
 // PanicError is the error recorded on a session when a Handler or a

--- a/starttls_test.go
+++ b/starttls_test.go
@@ -21,6 +21,9 @@ type rawClient struct {
 	t    *testing.T
 	conn net.Conn
 	br   *bufio.Reader
+
+	// banner holds the greeting that the server sent on connect.
+	banner string
 }
 
 func dialRaw(t *testing.T, addr string) *rawClient {
@@ -33,7 +36,7 @@ func dialRaw(t *testing.T, addr string) *rawClient {
 	t.Cleanup(func() { _ = conn.Close() })
 
 	c := &rawClient{t: t, conn: conn, br: bufio.NewReader(conn)}
-	c.line() // the banner
+	c.banner = c.line()
 	return c
 }
 
@@ -53,15 +56,26 @@ func (c *rawClient) line() string {
 func (c *rawClient) send(format string, args ...any) string {
 	c.t.Helper()
 
+	lines := c.replyLines(format, args...)
+	return lines[len(lines)-1]
+}
+
+// replyLines writes one command and returns every line of the reply, with
+// the continuation mark still on all lines but the last.
+func (c *rawClient) replyLines(format string, args ...any) []string {
+	c.t.Helper()
+
 	if _, err := fmt.Fprintf(c.conn, format+"\r\n", args...); err != nil {
 		c.t.Fatalf("write failed: %v", err)
 	}
+
+	var lines []string
 	for {
 		l := c.line()
-		if len(l) >= 4 && l[3] == '-' {
-			continue
+		lines = append(lines, l)
+		if len(l) < 4 || l[3] != '-' {
+			return lines
 		}
-		return l
 	}
 }
 

--- a/xclient.go
+++ b/xclient.go
@@ -12,11 +12,11 @@ func (s *session) handleXCLIENT(ctx context.Context, cmd *command) context.Conte
 
 	fields := cmd.args()
 	if len(fields) < 1 {
-		return s.reply(ctx, 501, "Invalid syntax.")
+		return s.replyEnhanced(ctx, 501, EnhancedCode{5, 5, 4}, "Invalid syntax.")
 	}
 
 	if !s.server.EnableXCLIENT {
-		return s.reply(ctx, 550, "XCLIENT not enabled")
+		return s.replyEnhanced(ctx, 550, EnhancedCode{5, 7, 0}, "XCLIENT not enabled")
 	}
 
 	var (
@@ -33,7 +33,7 @@ func (s *session) handleXCLIENT(ctx context.Context, cmd *command) context.Conte
 		// value.
 		name, value, ok := strings.Cut(item, "=")
 		if !ok {
-			return s.reply(ctx, 501, "Couldn't decode the command.")
+			return s.replyEnhanced(ctx, 501, EnhancedCode{5, 5, 4}, "Couldn't decode the command.")
 		}
 
 		value = decodeXtext(value)
@@ -62,7 +62,7 @@ func (s *session) handleXCLIENT(ctx context.Context, cmd *command) context.Conte
 			if !none {
 				port, err := strconv.ParseUint(value, 10, 16)
 				if err != nil {
-					return s.reply(ctx, 501, "Couldn't decode the command.")
+					return s.replyEnhanced(ctx, 501, EnhancedCode{5, 5, 4}, "Couldn't decode the command.")
 				}
 				newTCPPort = port
 			}
@@ -81,14 +81,14 @@ func (s *session) handleXCLIENT(ctx context.Context, cmd *command) context.Conte
 			}
 
 		default:
-			return s.reply(ctx, 501, "Couldn't decode the command.")
+			return s.replyEnhanced(ctx, 501, EnhancedCode{5, 5, 4}, "Couldn't decode the command.")
 		}
 
 	}
 
 	tcpAddr, ok := s.peer.Addr.(*net.TCPAddr)
 	if !ok {
-		return s.reply(ctx, 502, "Unsupported network connection")
+		return s.replyEnhanced(ctx, 502, EnhancedCode{5, 5, 1}, "Unsupported network connection")
 	}
 
 	if newHeloName != "" {


### PR DESCRIPTION
## What this does

The server offers `ENHANCEDSTATUSCODES` and writes the status code of
[RFC 3463](https://www.rfc-editor.org/rfc/rfc3463) after the reply code:

```
250 2.1.5 Go ahead
550 5.7.1 Relay access denied
452 4.5.3 Too many recipients
```

## Why

A bounce processor reads the status code to find the reason that a message
did not arrive. Without it, the reason is free text that only a person can
read. Postfix, aiosmtpd, nodemailer and `emersion/go-smtp` all send these
codes, so a peer expects them.

## The API

`EnhancedCode` is a `[3]int` that holds the class, the subject and the
detail. The new `Enhanced` field of `Error` carries it from a middleware to
the client:

```go
return ctx, smtpd.Error{
    Code:     550,
    Enhanced: smtpd.EnhancedCode{5, 7, 1},
    Message:  "Relay access denied",
}
```

The field is optional. An error that leaves it out takes the generic code
for the class of `Code`, which RFC 3463 section 3.1 writes as `x.0.0`. A
middleware that sets no code still produces a valid reply.

## Where the server writes no status code

RFC 2034 takes three replies out of the extension:

* The greeting. The client reads it before it sends a command.
* The reply to `HELO`.
* The reply to `EHLO`. A status code on those lines makes the client read a
  keyword that the server does not have.

A client that sends `HELO` gets no status code on any reply. It never saw
the server offer the extension, so it gets the replies of RFC 5321.

The `354` of `DATA` and the `334` of `AUTH` also stay as they were. RFC 3463
defines the classes 2, 4 and 5 only.

## Middleware

Each refusal now carries a code:

| Middleware | Reply |
| --- | --- |
| `RequireAuth` | `530 5.7.0 Authentication required` |
| `RequireTLS` | `530 5.7.0 Must issue STARTTLS first` |
| `Greylist` | `450 4.7.1 greylisted, try again later` |
| `IPAddressRateLimit` | `450 4.7.1 rate-limited, try again later` |
| `RBL` | `554 5.7.1 {list message}` |
| `SPF` (fail) | `550 5.7.23 SPF check failed` |
| `SPF` (temporary error) | `451 4.7.24 SPF check temporary error` |
| `SPF` (permanent error) | `550 5.7.24 SPF check permanent error` |

The SPF codes come from [RFC 7372](https://www.rfc-editor.org/rfc/rfc7372).

## Decisions to review

* **No configuration field.** RFC 2034 says that a server can send the codes
  once it offers the keyword, and the server offers it. A `Server` flag adds
  configuration for a wire format that every other server already sends.
* **Nothing for a HELO client.** This is stricter than Postfix, which sends
  the codes to a HELO client too. An old client that never asked for the
  extension keeps the exact replies it had before.
* **`Error.Error()` is unchanged for an error with no `Enhanced` field.**
  The text names a status code only when the caller set one. The generic
  code that an error takes on the wire depends on the session, not on the
  error, so the text would claim a code that the server did not send.

## Compatibility

A client that sends `EHLO` sees new text on every reply after that command.
This is visible to any test that asserts on the text of a reply.
`TestAUTHInsecureDeniedByDefault` in this repository needed that update.

The migration section of the README and the changelog both name the change.

## Tests

`enhanced_test.go` reads the full text of a reply line, so the code, the
status code and the message are all part of the assertion. It covers the
`EHLO` keyword line, the greeting, a `HELO` session, the `354` of `DATA`, a
middleware error with and without a code, and the text form of
`EnhancedCode`.

`go test ./...` and `golangci-lint run ./...` are both clean.
