### PR TITLE
test: add fuzz targets for the parsers and the session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A control character in the message of a reply becomes a space. A middleware
+  writes what it knows into the message of a refusal, and some of that comes
+  from the client. The user name of an `AUTH` command is one example: the
+  session decodes it from base64, so it holds any byte at all.
+
+  A line break inside a reply ended that reply and started a line of the
+  client's choosing. The client then read an answer to a command that the
+  server never ran.
+
+  A byte at 0x80 and above stays as it is, so a message in UTF-8 arrives
+  whole.
+
 ### Added
 
 - The server offers `ENHANCEDSTATUSCODES` and writes the status code of

--- a/command_fuzz_test.go
+++ b/command_fuzz_test.go
@@ -1,0 +1,112 @@
+package smtpd
+
+import (
+	"strings"
+	"testing"
+)
+
+// FuzzParseCommand runs the command parser over a line of bytes. It holds
+// the properties that the rest of the session depends on:
+//
+//   - The parser never panics.
+//   - The verb is upper case and carries no space.
+//   - The argument has no space at the front.
+//
+// A verb with a space in it reaches the switch in handle and matches
+// nothing, so the session answers 500 to a command that it must run.
+func FuzzParseCommand(f *testing.F) {
+	f.Add("EHLO relay.example.org")
+	f.Add("mail from:<a@example.org> SIZE=100 BODY=8BITMIME")
+	f.Add("RCPT\tTO:<b@example.net>")
+	f.Add("   MAIL   FROM:   <a@example.org>   ")
+	f.Add("AUTH PLAIN AGZvbwBiYXI=")
+	f.Add("XCLIENT ADDR=192.0.2.2 PORT=2525")
+	f.Add("")
+	f.Add("MAIL FROM:<")
+	f.Add("MAIL FROM:<a@b>trailing")
+
+	f.Fuzz(func(t *testing.T, line string) {
+		cmd, err := parseCommand(line)
+		if err != nil {
+			t.Fatalf("parseCommand(%q) returned an error, which it never does: %v", line, err)
+		}
+		if cmd == nil {
+			t.Fatalf("parseCommand(%q) returned no command", line)
+		}
+
+		if strings.ContainsAny(cmd.action, " \t") {
+			t.Errorf("parseCommand(%q) gave the verb %q, which carries a space", line, cmd.action)
+		}
+
+		if cmd.action != strings.ToUpper(cmd.action) {
+			t.Errorf("parseCommand(%q) gave the verb %q, which is not upper case", line, cmd.action)
+		}
+
+		if strings.HasPrefix(cmd.arg, " ") || strings.HasPrefix(cmd.arg, "\t") {
+			t.Errorf("parseCommand(%q) gave the argument %q, which starts with a space", line, cmd.arg)
+		}
+	})
+}
+
+// FuzzPathArg runs the parser of a MAIL FROM and RCPT TO argument. It holds
+// the properties that handleMAIL and handleRCPT depend on:
+//
+//   - The parser never panics.
+//   - A path that starts with "<" also ends with ">".
+//   - A path without those marks carries no space.
+//   - Every parameter has an upper case name and a value.
+//
+// A path that keeps a space reaches parseAddress, and a parameter name in
+// lower case misses the switch in validateMailParams.
+func FuzzPathArg(f *testing.F) {
+	f.Add("MAIL", "FROM:<a@example.org>")
+	f.Add("MAIL", "FROM:<a@example.org> SIZE=100")
+	f.Add("MAIL", "from:a@example.org body=8bitmime")
+	f.Add("RCPT", "TO:<b@example.net>")
+	f.Add("RCPT", "TO:<b@example.net> NOTIFY=SUCCESS")
+	f.Add("MAIL", "FROM:<>")
+	f.Add("MAIL", "FROM:<a b@example.org> SIZE=1 SIZE=2")
+	f.Add("MAIL", "FROM:")
+
+	f.Fuzz(func(t *testing.T, keyword, arg string) {
+		// The keyword comes from the caller, never from the client. A
+		// fuzzed one only widens the shapes that reach parsePath.
+		if keyword == "" {
+			t.Skip("the callers pass FROM or TO")
+		}
+
+		cmd := &command{line: keyword + " " + arg, action: keyword, arg: arg}
+
+		path, params, err := cmd.pathArg(keyword)
+		if err != nil {
+			return
+		}
+
+		if path == "" {
+			t.Fatalf("pathArg(%q, %q) gave no error and an empty path", keyword, arg)
+		}
+
+		if strings.HasPrefix(path, "<") {
+			if !strings.HasSuffix(path, ">") {
+				t.Errorf("pathArg(%q, %q) gave the path %q, which opens with < and does not close", keyword, arg, path)
+			}
+		} else if strings.ContainsAny(path, " \t") {
+			t.Errorf("pathArg(%q, %q) gave the path %q, which carries a space", keyword, arg, path)
+		}
+
+		for name, value := range params {
+			if name == "" {
+				t.Errorf("pathArg(%q, %q) gave a parameter with an empty name", keyword, arg)
+			}
+			if name != strings.ToUpper(name) {
+				t.Errorf("pathArg(%q, %q) gave the parameter name %q, which is not upper case", keyword, arg, name)
+			}
+			if value == "" {
+				t.Errorf("pathArg(%q, %q) gave the parameter %q an empty value", keyword, arg, name)
+			}
+			if strings.ContainsAny(name+value, " \t") {
+				t.Errorf("pathArg(%q, %q) gave the parameter %q=%q, which carries a space", keyword, arg, name, value)
+			}
+		}
+	})
+}

--- a/reply_test.go
+++ b/reply_test.go
@@ -1,0 +1,81 @@
+package smtpd_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/chrj/smtpd/v2"
+)
+
+// TestReplyTextStaysInsideItsReply drives a server whose middleware puts a
+// control character into the message of a refusal. The client must read one
+// reply, with the control character replaced.
+//
+// A middleware writes what it knows into the message, and some of that comes
+// from the client. The user name of an AUTH command is one example: the
+// session decodes it from base64, so it holds any byte at all.
+func TestReplyTextStaysInsideItsReply(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		message string
+		want    string
+	}{
+		{
+			name:    "a plain message stays as it is",
+			message: "No such user",
+			want:    "550 5.0.0 No such user",
+		},
+		{
+			name:    "a line break becomes a space",
+			message: "No such user\r\n250 injected",
+			want:    "550 5.0.0 No such user  250 injected",
+		},
+		{
+			name:    "a line feed on its own becomes a space",
+			message: "No such user\n250 injected",
+			want:    "550 5.0.0 No such user 250 injected",
+		},
+		{
+			name:    "a carriage return on its own becomes a space",
+			message: "No such user\rmore",
+			want:    "550 5.0.0 No such user more",
+		},
+		{
+			name:    "a tab becomes a space",
+			message: "No\tsuch\tuser",
+			want:    "550 5.0.0 No such user",
+		},
+		{
+			name:    "utf-8 arrives whole",
+			message: "Ingen sådan brugér",
+			want:    "550 5.0.0 Ingen sådan brugér",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			deny := smtpd.Middleware{
+				CheckSender: func(ctx context.Context, _ smtpd.Peer, _ string) (context.Context, error) {
+					return ctx, smtpd.Error{Code: 550, Message: test.message}
+				},
+			}
+
+			srv := runserver(t, &smtpd.Server{Logger: testLogger(t)}, deny)
+			c := dialRaw(t, srv.Addr)
+
+			c.send("EHLO localhost")
+
+			lines := c.replyLines("MAIL FROM:<sender@example.org>")
+			if len(lines) != 1 {
+				t.Fatalf("the server wrote %d lines, want 1: %q", len(lines), lines)
+			}
+			if lines[0] != test.want {
+				t.Errorf("got %q, want %q", lines[0], test.want)
+			}
+		})
+	}
+}

--- a/session.go
+++ b/session.go
@@ -169,6 +169,7 @@ func (s *session) reply(ctx context.Context, code int, message string) context.C
 // greeting and the reply to HELO and EHLO need.
 func (s *session) replyEnhanced(ctx context.Context, code int, enhanced EnhancedCode, message string) context.Context {
 	status := s.status(enhanced)
+	message = sanitizeReplyText(message)
 
 	logger := LoggerFromContext(ctx)
 	logger.DebugContext(ctx, "sending",
@@ -196,6 +197,7 @@ func (s *session) replyMultiline(ctx context.Context, code int, first string, re
 
 	lines := append([]string{first}, rest...)
 	for _, line := range lines[:len(lines)-1] {
+		line = sanitizeReplyText(line)
 		logger.DebugContext(ctx, "sending",
 			slog.Int("code", code),
 			slog.String("message", line),
@@ -204,6 +206,48 @@ func (s *session) replyMultiline(ctx context.Context, code int, first string, re
 	}
 
 	return s.replyEnhanced(ctx, code, EnhancedCode{}, lines[len(lines)-1])
+}
+
+// sanitizeReplyText makes text safe to write inside a reply line. Every
+// control character becomes a space.
+//
+// The message of a middleware refusal often carries something that the client
+// sent. The user name of an AUTH command is one example: the session decodes
+// it from base64, so it holds any byte at all. A line break inside a reply
+// ends that reply and starts a line of the client's choosing. The client then
+// reads an answer to a command that the server never ran.
+//
+// A byte at 0x80 and above stays as it is, so a message in UTF-8 arrives
+// whole.
+func sanitizeReplyText(text string) string {
+	if !hasControl(text) {
+		return text
+	}
+
+	out := []byte(text)
+	for i, c := range out {
+		if isControl(c) {
+			out[i] = ' '
+		}
+	}
+	return string(out)
+}
+
+// hasControl reports whether text carries a control character, so that a
+// text without one goes on the wire as it is.
+func hasControl(text string) bool {
+	for i := 0; i < len(text); i++ {
+		if isControl(text[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+// isControl reports whether c is a control character. RFC 5321 gives the text
+// of a reply as printable characters.
+func isControl(c byte) bool {
+	return c < 0x20 || c == 0x7f
 }
 
 // status gives the text of the status code to write with a reply. It is

--- a/session_fuzz_test.go
+++ b/session_fuzz_test.go
@@ -107,13 +107,175 @@ func FuzzSession(f *testing.F) {
 			t.Fatalf("the session did not end for the script %q", script)
 		}
 
-		written := conn.out.String()
-		for line := range strings.SplitSeq(strings.TrimSuffix(written, "\r\n"), "\r\n") {
-			if line == "" {
-				continue
-			}
-			if !replyLine.MatchString(line) {
-				t.Fatalf("the server wrote %q, which is not a reply\nscript: %q\nwritten: %q", line, script, written)
+		replyLines(t, conn.out.String())
+	})
+}
+
+// runScript drives one session over script and returns the session and every
+// byte that the server wrote. It fails the test if the session does not end,
+// which is how a target reports a loop that never leaves.
+func runScript(t *testing.T, srv *Server, script string) (*session, string) {
+	t.Helper()
+
+	if err := srv.configureDefaults(); err != nil {
+		t.Fatalf("configureDefaults: %v", err)
+	}
+
+	conn := &scriptConn{in: bytes.NewReader([]byte(script))}
+	ctx, session := srv.newSession(context.Background(), conn)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		session.serve(ctx)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatalf("the session did not end for the script %q", script)
+	}
+
+	return session, conn.out.String()
+}
+
+// replyLines cuts what the server wrote into lines and holds the shape of
+// each one. A line that carries a control character means that the server let
+// something from the client past the end of a reply.
+func replyLines(t *testing.T, written string) []string {
+	t.Helper()
+
+	var lines []string
+	for line := range strings.SplitSeq(strings.TrimSuffix(written, "\r\n"), "\r\n") {
+		if line == "" {
+			continue
+		}
+		if !replyLine.MatchString(line) {
+			t.Fatalf("the server wrote %q, which is not a reply\nwritten: %q", line, written)
+		}
+		if strings.ContainsAny(line, "\r\n") {
+			t.Fatalf("the server wrote %q, which carries a line break\nwritten: %q", line, written)
+		}
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+// FuzzReplyText puts the message of a middleware refusal on the wire. It
+// holds one property: the message stays inside its reply.
+//
+// A middleware writes what it knows into the message, and some of that comes
+// from the client. The user name of an AUTH command is one example: the
+// session decodes it from base64, so it carries any byte at all. A message
+// with a line break in it would end the reply and start a line of the
+// client's choosing, which the client uses to answer a command that the
+// server never ran.
+//
+// The script uses HELO, so the count of the lines does not move with the list
+// of extensions that EHLO reports.
+func FuzzReplyText(f *testing.F) {
+	f.Add("Denied")
+	f.Add("no such user\r\n250 injected")
+	f.Add("no such user\n250 injected")
+	f.Add("no such user\rmore")
+	f.Add("")
+	f.Add("\x00\x07denied")
+	f.Add(strings.Repeat("x", 600))
+
+	f.Fuzz(func(t *testing.T, message string) {
+		srv := &Server{}
+		srv.Use(Middleware{
+			CheckSender: func(ctx context.Context, _ Peer, _ string) (context.Context, error) {
+				return ctx, Error{Code: 550, Message: message}
+			},
+		})
+
+		_, written := runScript(t, srv,
+			"HELO relay.example.org\r\nMAIL FROM:<a@example.org>\r\nQUIT\r\n")
+
+		// The greeting, the reply to HELO, the refusal of MAIL FROM and the
+		// reply to QUIT. One line each.
+		if got := replyLines(t, written); len(got) != 4 {
+			t.Fatalf("the server wrote %d lines for the message %q, want 4\nwritten: %q",
+				len(got), message, written)
+		}
+	})
+}
+
+// FuzzXCLIENT runs the XCLIENT command of Postfix over a fuzzed argument. It
+// holds two properties:
+//
+//   - The address of the peer stays a TCP address.
+//   - Every line that the server writes is a reply.
+//
+// The first property is what handleXCLIENT and handlePROXY both read. A peer
+// with an address of another type, or with none, makes the next command that
+// reads it fail.
+func FuzzXCLIENT(f *testing.F) {
+	f.Add("ADDR=192.0.2.2 PORT=2525 LOGIN=user PROTO=ESMTP")
+	f.Add("ADDR=[UNAVAILABLE] PORT=[TEMPUNAVAIL]")
+	f.Add("HELO=+2Brelay.example.org NAME=proxy.example.net")
+	f.Add("LOGIN=user+0D+0A250+20injected")
+	f.Add("ADDR=2001:db8::1 PORT=65535")
+	f.Add("PORT=99999999")
+	f.Add("ADDR=")
+	f.Add("=")
+	f.Add("")
+
+	f.Fuzz(func(t *testing.T, arg string) {
+		srv := &Server{EnableXCLIENT: true}
+
+		session, written := runScript(t, srv,
+			"XCLIENT "+arg+"\r\nEHLO relay.example.org\r\nQUIT\r\n")
+
+		if session.peer.Addr == nil {
+			t.Fatalf("the peer lost its address for the argument %q", arg)
+		}
+		if _, ok := session.peer.Addr.(*net.TCPAddr); !ok {
+			t.Fatalf("the peer holds a %T for the argument %q, want a *net.TCPAddr", session.peer.Addr, arg)
+		}
+
+		replyLines(t, written)
+	})
+}
+
+// FuzzAuthExchange runs the AUTH command over a fuzzed argument, and answers
+// every continuation with a fuzzed line. It holds one property: the server
+// reports success only after it asked the authenticator.
+//
+// A 235 reply without that call is an authentication bypass. The two
+// mechanisms read a different number of lines, and both of them decode base64
+// from the client, so the paths that reach the reply are many.
+func FuzzAuthExchange(f *testing.F) {
+	f.Add("PLAIN AGZvbwBiYXI=", "")
+	f.Add("PLAIN", "AGZvbwBiYXI=")
+	f.Add("LOGIN", "dXNlcg==")
+	f.Add("LOGIN dXNlcg==", "cGFzcw==")
+	f.Add("PLAIN =", "")
+	f.Add("PLAIN *", "*")
+	f.Add("CRAM-MD5", "")
+	f.Add("", "")
+
+	f.Fuzz(func(t *testing.T, arg, response string) {
+		calls := 0
+
+		srv := &Server{AllowInsecureAuth: true}
+		srv.Use(Middleware{
+			Authenticate: func(ctx context.Context, _ Peer, _, _ string) (context.Context, error) {
+				calls++
+				return ctx, nil
+			},
+		})
+
+		// Two responses, because AUTH LOGIN asks twice.
+		_, written := runScript(t, srv,
+			"EHLO relay.example.org\r\nAUTH "+arg+"\r\n"+response+"\r\n"+response+"\r\nQUIT\r\n")
+
+		lines := replyLines(t, written)
+
+		for _, line := range lines {
+			if strings.HasPrefix(line, "235 ") && calls == 0 {
+				t.Fatalf("the server wrote %q without asking the authenticator\nwritten: %q", line, written)
 			}
 		}
 	})

--- a/xtext_fuzz_test.go
+++ b/xtext_fuzz_test.go
@@ -1,0 +1,41 @@
+package smtpd
+
+import (
+	"strings"
+	"testing"
+)
+
+// FuzzDecodeXtext runs the xtext decoder over an XCLIENT attribute value. It
+// holds three properties:
+//
+//   - The decoder never panics.
+//   - The result is never longer than the value.
+//   - A value without a plus sign comes back as it was.
+//
+// The second property bounds the memory that one command can take. The third
+// keeps the decoder away from a value that carries no encoding, which is what
+// a proxy that does not encode its values sends.
+func FuzzDecodeXtext(f *testing.F) {
+	f.Add("192.0.2.2")
+	f.Add("user+2Bname")
+	f.Add("+2B+2B+2B")
+	f.Add("+")
+	f.Add("++")
+	f.Add("+2")
+	f.Add("+zz")
+	f.Add("+0D+0A250+20injected")
+	f.Add("[UNAVAILABLE]")
+	f.Add("")
+
+	f.Fuzz(func(t *testing.T, value string) {
+		got := decodeXtext(value)
+
+		if len(got) > len(value) {
+			t.Fatalf("decodeXtext(%q) gave %q, which is longer than the value", value, got)
+		}
+
+		if !strings.Contains(value, "+") && got != value {
+			t.Fatalf("decodeXtext(%q) gave %q, and the value carries no plus sign", value, got)
+		}
+	})
+}


### PR DESCRIPTION
## What this does

Adds five fuzz targets over the command parser and the session, and fixes the
one defect that they found.

## The defect

`FuzzReplyText` puts the message of a middleware refusal on the wire and
counts the lines that the server writes. A message with a line break in it
made two lines:

```
550 no such user
250 injected
```

A middleware writes what it knows into the message of a refusal, and some of
that comes from the client. The user name of an `AUTH` command is one
example: the session decodes it from base64, so it holds any byte at all. The
`LOGIN` attribute of `XCLIENT` is another, because the xtext decoder turns
`+0D+0A` into a line break.

The client reads the second line as the answer to the next command that it
sends. It then acts on a reply that the server never wrote.

`session.replyEnhanced` and `session.replyMultiline` now put a space in the
place of every control character. A byte at 0x80 and above stays as it is, so
a message in UTF-8 arrives whole. `TestReplyTextStaysInsideItsReply` covers
the shapes by name.

## The targets

| Target | Properties |
| --- | --- |
| `FuzzParseCommand` | The verb is upper case and carries no space. The argument has no space at the front. |
| `FuzzPathArg` | A path that opens with `<` also closes with `>`. A path without those marks carries no space. Every parameter has an upper case name and a value. |
| `FuzzDecodeXtext` | The result is never longer than the value. A value without a plus sign comes back as it was. |
| `FuzzReplyText` | The message of a refusal stays inside its reply. |
| `FuzzXCLIENT` | The address of the peer stays a TCP address, which is what `handleXCLIENT` and `handlePROXY` both read. |
| `FuzzAuthExchange` | A `235` reply comes only after the authenticator ran. |

Each target ran for 45 to 60 seconds after the fix, from 300,000 to 2,000,000
executions each, with no further failure.

`runScript` and `replyLines` take the work that the session targets share.
`FuzzSession` now reads its lines through `replyLines`, which adds the test
for a control character to that target as well.

## What this does not cover

* **STARTTLS.** A target would have to drive a TLS handshake from fuzzed
  bytes. `FuzzSession` still answers 502 to `STARTTLS`, because the server in
  that target holds no certificate.
* **The peer fields themselves.** `Peer.Username` still holds any byte that
  base64 decodes to, and `Peer.HeloName` holds a bare carriage return. The
  fix above stops those bytes at the wire, so the server is safe. A middleware
  that writes them to a file or a database is not, and refusing them at the
  `AUTH` and `EHLO` phases is a separate change.

## Tests

`go test ./...` and `golangci-lint run ./...` are both clean.
