### PR TITLE
feat: take a message in chunks with BDAT (RFC 3030)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The server offers `CHUNKING` and takes a message in chunks with the `BDAT`
+  command of RFC 3030. There is nothing to turn on, in the same way as for
+  `PIPELINING` and `8BITMIME`.
+
+  `Envelope.Data` streams the chunks as they arrive: the handler starts with
+  the first chunk and reads the message through the rest of the transfer, so a
+  chunked message is never held in memory as a whole. The server runs the
+  handler on a goroutine of its own and waits for it at `BDAT LAST`.
+
+  A transfer that ends before the last chunk gives the handler an error in the
+  place of the rest of the message, so half a message never looks whole to it.
+  `RSET` does that, and so does a connection that closes in the middle.
+
+  A chunk that the server refuses still comes off the wire, which is what
+  RFC 3030 asks for: a chunk that stays there is read as commands.
+
+- The server offers `BINARYMIME` and takes `BODY=BINARYMIME` on `MAIL FROM`.
+  Such a message needs `BDAT`, so `DATA` answers `503` for one.
+
+- `Envelope.BodyType` holds the `BODY` parameter of `MAIL FROM`, as one of the
+  new `Body7Bit`, `Body8BitMIME` and `BodyBinaryMIME` values. It is empty when
+  the client sent no such parameter.
+
 - The server offers the `DSN` extension of RFC 3461 when `Server.EnableDSN` is
   set. It reads `RET` and `ENVID` on `MAIL FROM`, and `NOTIFY` and `ORCPT` on
   `RCPT TO`, and puts them on the new `Envelope.DSN` field.
@@ -53,6 +76,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fails, and `5.7.24` for an error in the check.
 
 ### Changed
+
+- The session reads its command lines from the reader of the connection, where
+  it read them through a `bufio.Scanner` before. A scanner reads ahead, and the
+  octets of a `BDAT` chunk follow the command line on the same stream.
+
+  A message that a client sends in the same write as its `DATA` command now
+  arrives whole. The scanner took those octets into a buffer of its own, where
+  the reader of the body could not reach them. RFC 2920 tells a client to wait
+  for the `354` reply, so this reached only a client that does not.
 
 - A client that sends `EHLO` gets a status code on every reply after that
   command. A test that asserts on the text of a reply must expect it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The session reads its command lines from the reader of the connection, where
-  it read them through a `bufio.Scanner` before. A scanner reads ahead, and the
+  it read them through a `bufio.Scanner` before. A read that fails once fails
+  from then on, in the way that a scanner stops for good. A scanner reads ahead, and the
   octets of a `BDAT` chunk follow the command line on the same stream.
 
   A message that a client sends in the same write as its `DATA` command now

--- a/README.md
+++ b/README.md
@@ -208,9 +208,11 @@ Blue boxes are SMTP phases; amber boxes are middleware hooks. The `Envelope`
 is created at `MAIL FROM`, grows across `RCPT TO`, gets `Data` at `DATA` or at
 the first `BDAT`, and is cleared after delivery or `RSET`.
 
-The handlers of a `DATA` message run once the whole message arrived. The
-handlers of a `BDAT` message start with the first chunk and read the rest as
-it comes.
+The handlers start as soon as the message does, and `Data` streams the rest to
+them, both for `DATA` and for `BDAT`. The two differ in where they run: the
+handlers of a `DATA` message hold the session while they read, and the
+handlers of a `BDAT` message run on a goroutine of their own while the session
+reads the commands that carry the chunks.
 
 `Disconnect` always runs exactly once per session. `err` is nil on clean
 shutdown (QUIT or server `Shutdown`); non-nil if a TLS/read/DATA error

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Features
 * STARTTLS and implicit TLS
 * PLAIN/LOGIN authentication (after STARTTLS)
 * Enhanced status codes ([RFC 3463](https://www.rfc-editor.org/rfc/rfc3463))
+* `CHUNKING` with `BDAT`, and `BINARYMIME`
+  ([RFC 3030](https://www.rfc-editor.org/rfc/rfc3030))
 * DSN parameters ([RFC 3461](https://www.rfc-editor.org/rfc/rfc3461)), off by
   default
 * [XCLIENT](http://www.postfix.org/XCLIENT_README.html) and the
@@ -87,7 +89,7 @@ Architecture
 | `Handler` | `func(ctx, peer, *Envelope) (ctx, error)` - the terminal delivery stage. |
 | `Middleware` | Struct with optional per-phase hook fields. Any combination of fields may be set. |
 | `Peer` | Connection-scoped state, populated progressively (`Addr` at connect, `HeloName` after HELO, `TLS` after handshake, `Username` after AUTH). Passed by value to every hook. |
-| `Envelope` | Transaction-scoped state: `Sender`, `Recipients`, `Data io.ReadCloser`, `DSN`. Passed by pointer so Handlers can mutate `Data`. |
+| `Envelope` | Transaction-scoped state: `Sender`, `Recipients`, `Data io.ReadCloser`, `BodyType`, `DSN`. Passed by pointer so Handlers can mutate `Data`. |
 | `Error` | `{Code, Enhanced, Message}` - returned from any hook to produce a specific SMTP reply. Non-`Error` errors are reported as `502`. |
 | `EnhancedCode` | `[3]int` - the RFC 3463 status code that goes after the reply code, such as `{5, 7, 1}`. |
 
@@ -187,7 +189,9 @@ flowchart TD
     checkSender --> rcptTo["RCPT TO (0..n)"]
     rcptTo --> checkRecipient["CheckRecipient"]
     checkRecipient --> data["DATA"]
+    checkRecipient --> bdat["BDAT (1..n)"]
     data --> middlewareHandler["middleware Handler"]
+    bdat --> middlewareHandler
     middlewareHandler --> serverHandler["Server.Handler"]
     serverHandler --> rset["RSET"]
     rset --> resetHook["Reset"]
@@ -196,16 +200,20 @@ flowchart TD
     classDef phase fill:#1d4ed8,stroke:#1e3a8a,color:#ffffff;
     classDef hook fill:#f59e0b,stroke:#92400e,color:#111827;
 
-    class accept,helo,starttls,auth,mailFrom,rcptTo,data,rset phase;
+    class accept,helo,starttls,auth,mailFrom,rcptTo,data,bdat,rset phase;
     class checkConnection,checkHelo,authenticate,checkSender,checkRecipient,middlewareHandler,serverHandler,resetHook hook;
 ```
 
 Blue boxes are SMTP phases; amber boxes are middleware hooks. The `Envelope`
-is created at `MAIL FROM`, grows across `RCPT TO`, gets `Data` at `DATA`, and
-is cleared after delivery or `RSET`.
+is created at `MAIL FROM`, grows across `RCPT TO`, gets `Data` at `DATA` or at
+the first `BDAT`, and is cleared after delivery or `RSET`.
+
+The handlers of a `DATA` message run once the whole message arrived. The
+handlers of a `BDAT` message start with the first chunk and read the rest as
+it comes.
 
 `Disconnect` always runs exactly once per session. `err` is nil on clean
-shutdown (QUIT or server `Shutdown`); non-nil if a TLS/scanner/DATA error
+shutdown (QUIT or server `Shutdown`); non-nil if a TLS/read/DATA error
 terminated the session, or a `PanicError` if a hook panicked.
 
 ### STARTTLS
@@ -242,6 +250,54 @@ encoding still arrives whole.
 
 The values `[UNAVAILABLE]` and `[TEMPUNAVAIL]` say that the proxy has no
 information for that attribute, and leave it as it was.
+
+### CHUNKING and BDAT
+
+The server takes a message in chunks with the `BDAT` command of
+[RFC 3030](https://www.rfc-editor.org/rfc/rfc3030). It offers `CHUNKING` and
+`BINARYMIME` in the reply to `EHLO`, and there is nothing to turn on.
+
+```
+C: BDAT 24
+S: 250 2.0.0 24 octets received
+C: BDAT 12 LAST
+S: 250 2.0.0 Message OK, 36 octets received
+```
+
+The octets of a chunk follow the command line on the same stream. They carry
+no dot stuffing and no line structure, so the body reaches the handler as the
+client sent it. A line with one dot on it is part of the message, where the
+same line ends a `DATA` message.
+
+`Envelope.Data` streams the chunks as they arrive. The handler starts with the
+first chunk and reads the message through the rest of the transfer, in the same
+way as for a `DATA` message, so a chunked message is never held in memory as a
+whole. The server runs it on a goroutine of its own and waits for it at
+`BDAT LAST`.
+
+A transfer that ends before the last chunk gives the handler an error in the
+place of the rest of the message. `RSET` does that, and so does a connection
+that closes in the middle. Half a message therefore never looks whole to a
+handler.
+
+| The client sends | The server answers |
+| --- | --- |
+| `BDAT` before `RCPT TO` | `503`, after it read the chunk off the wire |
+| a chunk that takes the message past `MaxMessageSize` | `552`, and every chunk after it gets the same answer |
+| `DATA` after `BDAT` in one transaction | `503` |
+| `DATA` for a `BODY=BINARYMIME` message | `503` |
+| `RCPT TO` after the first chunk | `503` |
+| `BDAT` with a chunk size that is not a number | `501`, and the connection closes |
+
+A refused chunk still comes off the wire, which is what RFC 3030 asks for: a
+chunk that stays there is read as commands. The one command that closes the
+connection is a `BDAT` whose size cannot be read, because nothing then says
+where the chunk ends.
+
+`Envelope.BodyType` holds the `BODY` parameter of `MAIL FROM`: `7BIT`,
+`8BITMIME` or `BINARYMIME`. It is empty when the client sent no such
+parameter. A `BINARYMIME` message needs `BDAT`, so `DATA` answers `503` for
+one.
 
 ### DSN
 

--- a/auth.go
+++ b/auth.go
@@ -44,10 +44,11 @@ func (s *session) handleAUTH(ctx context.Context, cmd *command) context.Context 
 
 		if len(args) < 2 {
 			ctx = s.reply(ctx, 334, "Give me your credentials")
-			if !s.scanner.Scan() {
+			line, err := s.readLine()
+			if err != nil {
 				return ctx
 			}
-			auth = s.scanner.Text()
+			auth = line
 		} else {
 			auth = args[1]
 		}
@@ -73,10 +74,11 @@ func (s *session) handleAUTH(ctx context.Context, cmd *command) context.Context 
 
 		if len(args) < 2 {
 			ctx = s.reply(ctx, 334, "VXNlcm5hbWU6")
-			if !s.scanner.Scan() {
+			line, err := s.readLine()
+			if err != nil {
 				return ctx
 			}
-			encodedUsername = s.scanner.Text()
+			encodedUsername = line
 		} else {
 			encodedUsername = args[1]
 		}
@@ -89,11 +91,12 @@ func (s *session) handleAUTH(ctx context.Context, cmd *command) context.Context 
 
 		ctx = s.reply(ctx, 334, "UGFzc3dvcmQ6")
 
-		if !s.scanner.Scan() {
+		encodedPassword, err := s.readLine()
+		if err != nil {
 			return ctx
 		}
 
-		bytePassword, err := base64.StdEncoding.DecodeString(s.scanner.Text())
+		bytePassword, err := base64.StdEncoding.DecodeString(encodedPassword)
 
 		if err != nil {
 			return s.replyEnhanced(ctx, 501, EnhancedCode{5, 5, 2}, "Couldn't decode your credentials")

--- a/auth_test.go
+++ b/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"net/smtp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/chrj/smtpd/v2"
 	"github.com/chrj/smtpd/v2/smtptest"
@@ -290,5 +291,42 @@ func TestAUTHBeforeSTARTTLS(t *testing.T) {
 
 	if reply := c.send("AUTH PLAIN Zm9vAGJhcgBxdXV4"); !strings.HasPrefix(reply, "530") {
 		t.Fatalf("AUTH in plain text = %q, want 530", reply)
+	}
+}
+
+// TestAUTHContinuationTooLongEndsTheSession covers the credentials line of an
+// AUTH command that is longer than the server reads.
+//
+// The rest of that line stays in the reader. A session that goes on would read
+// it as commands, so the client could put a command of its own behind its
+// credentials and the server would run it. The read is terminal instead: the
+// server answers 500 and the session ends.
+func TestAUTHContinuationTooLongEndsTheSession(t *testing.T) {
+	t.Parallel()
+
+	srv := runserver(t, &smtpd.Server{
+		Logger:            testLogger(t),
+		AllowInsecureAuth: true,
+	}, acceptAuth())
+
+	c := dialRaw(t, srv.Addr)
+	c.send("EHLO localhost")
+
+	if reply := c.send("AUTH PLAIN"); !strings.HasPrefix(reply, "334") {
+		t.Fatalf("AUTH PLAIN = %q, want 334", reply)
+	}
+
+	// One line of credentials that is longer than the server reads, with a
+	// command written behind it.
+	c.write([]byte(strings.Repeat("A", 70*1024) + "\r\nNOOP\r\n"))
+
+	if reply := c.line(); !strings.Contains(reply, "500") {
+		t.Fatalf("the reply to the credentials = %q, want 500", reply)
+	}
+
+	// Nothing that followed the credentials runs, and the session is over.
+	_ = c.conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	if line, err := c.br.ReadString('\n'); err == nil {
+		t.Errorf("the session wrote %q after the refusal, and it must be over", line)
 	}
 }

--- a/bdat_test.go
+++ b/bdat_test.go
@@ -602,3 +602,124 @@ func TestBDATPanicReachesTheHookAfterRSET(t *testing.T) {
 		t.Errorf("the panic value is %v, want %q", panicErr.Value, "boom after the chunk")
 	}
 }
+
+// TestBDATRefusedFirstChunkClosesTheTransaction covers a transaction whose
+// first chunk the server refused. The transaction saw a BDAT command, so it
+// takes no recipient and no DATA after that.
+func TestBDATRefusedFirstChunkClosesTheTransaction(t *testing.T) {
+	t.Parallel()
+
+	srv := runserver(t, &smtpd.Server{
+		Logger:         testLogger(t),
+		MaxMessageSize: 32,
+	})
+
+	c := dialRaw(t, srv.Addr)
+	openTransaction(t, c, "MAIL FROM:<sender@example.org>")
+
+	if reply := bdat(t, c, strings.Repeat("x", 64), false); !strings.HasPrefix(reply, "552") {
+		t.Fatalf("the chunk that is too large = %q, want 552", reply)
+	}
+
+	if reply := c.send("RCPT TO:<late@example.net>"); !strings.HasPrefix(reply, "503") {
+		t.Errorf("RCPT TO after the refused chunk = %q, want 503", reply)
+	}
+
+	if reply := c.send("DATA"); !strings.HasPrefix(reply, "503") {
+		t.Errorf("DATA after the refused chunk = %q, want 503", reply)
+	}
+}
+
+// TestBDATPanicSkipsTheResetHook covers the order of the hooks when a handler
+// panics on its way out of a transfer that RSET ended. The Disconnect hooks
+// run last, so a Reset hook must not run after them.
+//
+// The handler waits for the end of the body, which is what RSET gives it, and
+// panics there. The session is inside its own reset at that moment, which is
+// the order that this test holds.
+func TestBDATPanicSkipsTheResetHook(t *testing.T) {
+	t.Parallel()
+
+	var resets resetRecord
+	var rec disconnectRecord
+
+	boom := panicOnce("boom on the way out")
+
+	srv := runserver(t, &smtpd.Server{
+		Logger: testLogger(t),
+		Handler: func(ctx context.Context, _ smtpd.Peer, env *smtpd.Envelope) (context.Context, error) {
+			if _, err := io.ReadAll(env.Data); err != nil {
+				boom()
+			}
+			return ctx, nil
+		},
+	}, resetCounter(&resets), disconnectCounter(&rec))
+
+	c := dialRaw(t, srv.Addr)
+	openTransaction(t, c, "MAIL FROM:<sender@example.org>")
+
+	if reply := bdat(t, c, "half", false); !strings.HasPrefix(reply, "250") {
+		t.Fatalf("BDAT = %q, want 250", reply)
+	}
+
+	if reply := c.send("RSET"); !strings.HasPrefix(reply, "421") {
+		t.Fatalf("RSET = %q, want 421", reply)
+	}
+
+	if count, _ := waitDisconnect(&rec, 2*time.Second); count != 1 {
+		t.Fatalf("Disconnect ran %d times, want 1", count)
+	}
+
+	if got := resets.Count(); got != 0 {
+		t.Errorf("the Reset hook ran %d times after the panic, want 0", got)
+	}
+}
+
+// TestBDATHandlerContextReachesLaterCommands covers the contract of Handler:
+// the context that it gives back holds for the commands that follow. A
+// handler of a chunked message can end before the last chunk, and the
+// commands after it must run in its context.
+func TestBDATHandlerContextReachesLaterCommands(t *testing.T) {
+	t.Parallel()
+
+	type ctxKey struct{}
+
+	finished := make(chan struct{})
+	seen := make(chan bool, 1)
+
+	srv := runserver(t, &smtpd.Server{
+		Logger: testLogger(t),
+		Handler: func(ctx context.Context, _ smtpd.Peer, env *smtpd.Envelope) (context.Context, error) {
+			// End before the last chunk, with a context of its own.
+			buf := make([]byte, 4)
+			if _, err := io.ReadFull(env.Data, buf); err != nil {
+				return ctx, err
+			}
+
+			defer close(finished)
+			return context.WithValue(ctx, ctxKey{}, "from the handler"), nil
+		},
+	}, smtpd.Middleware{
+		Reset: func(ctx context.Context, _ smtpd.Peer) context.Context {
+			seen <- ctx.Value(ctxKey{}) == "from the handler"
+			return ctx
+		},
+	})
+
+	c := dialRaw(t, srv.Addr)
+	openTransaction(t, c, "MAIL FROM:<sender@example.org>")
+
+	if reply := bdat(t, c, "half", false); !strings.HasPrefix(reply, "250") {
+		t.Fatalf("BDAT = %q, want 250", reply)
+	}
+
+	<-finished
+
+	if reply := c.send("RSET"); !strings.HasPrefix(reply, "250") {
+		t.Fatalf("RSET = %q, want 250", reply)
+	}
+
+	if !<-seen {
+		t.Error("the Reset hook ran without the context of the handler")
+	}
+}

--- a/bdat_test.go
+++ b/bdat_test.go
@@ -509,3 +509,96 @@ func TestBDATLeavesNoGoroutine(t *testing.T) {
 		t.Errorf("the server holds %d goroutines, and it held %d before the 20 sessions", after, before)
 	}
 }
+
+// TestBDATSyntaxErrorKeepsTheSession covers a BDAT command whose length reads
+// but whose rest does not. The server can still take the chunk off the wire,
+// so the session goes on.
+func TestBDATSyntaxErrorKeepsTheSession(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		command string
+	}{
+		{name: "a mark of another kind", command: "BDAT 5 FIRST"},
+		{name: "three arguments", command: "BDAT 5 LAST LAST"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := runserver(t, &smtpd.Server{Logger: testLogger(t)})
+
+			c := dialRaw(t, srv.Addr)
+			openTransaction(t, c, "MAIL FROM:<sender@example.org>")
+
+			c.write([]byte(test.command + "\r\nhello"))
+			if reply := c.line(); !strings.HasPrefix(reply, "501") {
+				t.Fatalf("%s = %q, want 501", test.command, reply)
+			}
+
+			// The five octets of the chunk are gone from the stream, so the
+			// server reads the next line as a command.
+			if reply := c.send("NOOP"); !strings.HasPrefix(reply, "250") {
+				t.Errorf("NOOP after the refusal = %q, want 250", reply)
+			}
+		})
+	}
+}
+
+// TestBDATPanicReachesTheHookAfterRSET covers a handler that panics while the
+// session reads the next command. RSET drops the transfer, and the panic must
+// not go with it: it ends the session and reaches the Disconnect hooks.
+func TestBDATPanicReachesTheHookAfterRSET(t *testing.T) {
+	t.Parallel()
+
+	var rec disconnectRecord
+
+	// release holds the handler until the client has the reply to its chunk,
+	// so the panic lands on the command that follows and not on the chunk.
+	release := make(chan struct{})
+	boom := panicOnce("boom after the chunk")
+
+	srv := runserver(t, &smtpd.Server{
+		Logger: testLogger(t),
+		Handler: func(ctx context.Context, _ smtpd.Peer, env *smtpd.Envelope) (context.Context, error) {
+			buf := make([]byte, 4)
+			if _, err := io.ReadFull(env.Data, buf); err != nil {
+				return ctx, err
+			}
+
+			<-release
+			boom()
+
+			return ctx, nil
+		},
+	}, disconnectCounter(&rec))
+
+	c := dialRaw(t, srv.Addr)
+	openTransaction(t, c, "MAIL FROM:<sender@example.org>")
+
+	if reply := bdat(t, c, "half", false); !strings.HasPrefix(reply, "250") {
+		t.Fatalf("BDAT = %q, want 250", reply)
+	}
+
+	close(release)
+
+	// The panic answers the command that follows, whichever one it is.
+	if reply := c.send("RSET"); !strings.HasPrefix(reply, "421") {
+		t.Fatalf("RSET = %q, want 421", reply)
+	}
+
+	count, lastErr := waitDisconnect(&rec, 2*time.Second)
+	if count != 1 {
+		t.Fatalf("Disconnect ran %d times, want 1", count)
+	}
+
+	var panicErr smtpd.PanicError
+	if !errors.As(lastErr, &panicErr) {
+		t.Fatalf("the Disconnect hook read %v, want a smtpd.PanicError", lastErr)
+	}
+	if panicErr.Value != "boom after the chunk" {
+		t.Errorf("the panic value is %v, want %q", panicErr.Value, "boom after the chunk")
+	}
+}

--- a/bdat_test.go
+++ b/bdat_test.go
@@ -1,0 +1,511 @@
+package smtpd_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chrj/smtpd/v2"
+)
+
+// bdat writes one BDAT command with its chunk in a single write, in the way
+// that a client sends them, and returns the reply.
+//
+// The chunk follows the command line on the same stream with nothing between
+// them, so this is also the test that the server reads its command lines
+// without taking the octets of the chunk with them.
+func bdat(t *testing.T, c *rawClient, payload string, last bool) string {
+	t.Helper()
+
+	command := fmt.Sprintf("BDAT %d", len(payload))
+	if last {
+		command += " LAST"
+	}
+
+	c.write([]byte(command + "\r\n" + payload))
+	return c.line()
+}
+
+// openTransaction greets the server and sends MAIL FROM and RCPT TO, so that
+// the next command is a BDAT that the server takes.
+func openTransaction(t *testing.T, c *rawClient, mail string) {
+	t.Helper()
+
+	if reply := c.send("EHLO localhost"); !strings.HasPrefix(reply, "250") {
+		t.Fatalf("EHLO reply = %q, want 250", reply)
+	}
+	if reply := c.send("%s", mail); !strings.HasPrefix(reply, "250") {
+		t.Fatalf("MAIL reply = %q, want 250", reply)
+	}
+	if reply := c.send("RCPT TO:<recipient@example.net>"); !strings.HasPrefix(reply, "250") {
+		t.Fatalf("RCPT reply = %q, want 250", reply)
+	}
+}
+
+// TestChunkingOffered covers the EHLO keywords of RFC 3030.
+func TestChunkingOffered(t *testing.T) {
+	t.Parallel()
+
+	srv := runserver(t, &smtpd.Server{Logger: testLogger(t)})
+
+	c := srv.Dial()
+	if err := c.Hello("localhost"); err != nil {
+		t.Fatalf("EHLO failed: %v", err)
+	}
+
+	for _, keyword := range []string{"CHUNKING", "BINARYMIME"} {
+		if ok, _ := c.Extension(keyword); !ok {
+			t.Errorf("the server does not offer %s", keyword)
+		}
+	}
+
+	if err := c.Quit(); err != nil {
+		t.Errorf("QUIT failed: %v", err)
+	}
+}
+
+// TestBDATDelivers drives whole messages through BDAT and reads them back off
+// the envelope.
+func TestBDATDelivers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mail   string
+		chunks []string
+		want   message
+	}{
+		{
+			name:   "one chunk",
+			mail:   "MAIL FROM:<sender@example.org>",
+			chunks: []string{"Subject: one\r\n\r\nA short body.\r\n"},
+			want:   message{body: "Subject: one\r\n\r\nA short body.\r\n"},
+		},
+		{
+			name:   "three chunks in order",
+			mail:   "MAIL FROM:<sender@example.org>",
+			chunks: []string{"Subject: three\r\n", "\r\nfirst half ", "second half\r\n"},
+			want:   message{body: "Subject: three\r\n\r\nfirst half second half\r\n"},
+		},
+		{
+			name:   "an empty last chunk ends the message",
+			mail:   "MAIL FROM:<sender@example.org>",
+			chunks: []string{"Subject: empty end\r\n\r\nbody\r\n", ""},
+			want:   message{body: "Subject: empty end\r\n\r\nbody\r\n"},
+		},
+		{
+			name:   "an empty message",
+			mail:   "MAIL FROM:<sender@example.org>",
+			chunks: []string{""},
+			want:   message{body: ""},
+		},
+		{
+			// A dot on a line of its own ends a DATA message. BDAT counts
+			// octets, so the body carries it like any other content.
+			name:   "a line with one dot on it",
+			mail:   "MAIL FROM:<sender@example.org>",
+			chunks: []string{"Subject: dot\r\n\r\n.\r\nstill the body\r\n"},
+			want:   message{body: "Subject: dot\r\n\r\n.\r\nstill the body\r\n"},
+		},
+		{
+			name:   "octets that carry no line structure",
+			mail:   "MAIL FROM:<sender@example.org> BODY=BINARYMIME",
+			chunks: []string{"\x00\x01\x02\r\n\xff\xfe no line break at the end"},
+			want: message{
+				bodyType: smtpd.BodyBinaryMIME,
+				body:     "\x00\x01\x02\r\n\xff\xfe no line break at the end",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := make(chan message, 1)
+			srv := runserver(t, &smtpd.Server{
+				Logger:  testLogger(t),
+				Handler: captureMessage(got),
+			})
+
+			c := dialRaw(t, srv.Addr)
+			openTransaction(t, c, test.mail)
+
+			for i, chunk := range test.chunks {
+				last := i == len(test.chunks)-1
+
+				reply := bdat(t, c, chunk, last)
+				if !strings.HasPrefix(reply, "250") {
+					t.Fatalf("chunk %d: reply = %q, want 250", i, reply)
+				}
+			}
+
+			msg := <-got
+			if msg.readErr != nil {
+				t.Fatalf("the handler read the body with the error %v", msg.readErr)
+			}
+			if msg.body != test.want.body {
+				t.Errorf("body = %q, want %q", msg.body, test.want.body)
+			}
+			if msg.bodyType != test.want.bodyType {
+				t.Errorf("body type = %q, want %q", msg.bodyType, test.want.bodyType)
+			}
+			if msg.sender != "sender@example.org" {
+				t.Errorf("sender = %q, want %q", msg.sender, "sender@example.org")
+			}
+
+			// The transaction is over, so the next one starts from MAIL FROM.
+			if reply := c.send("MAIL FROM:<second@example.org>"); !strings.HasPrefix(reply, "250") {
+				t.Errorf("MAIL FROM after the message = %q, want 250", reply)
+			}
+		})
+	}
+}
+
+// TestBDATKeepsTheStreamInSync covers the rule of RFC 3030 that a server which
+// refuses a chunk still takes its octets off the wire. A chunk that stays
+// there is read as commands.
+func TestBDATKeepsTheStreamInSync(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// setup runs before the chunk that the server refuses.
+		setup   func(t *testing.T, c *rawClient)
+		payload string
+		want    string
+	}{
+		{
+			name:    "before MAIL FROM",
+			setup:   func(t *testing.T, c *rawClient) { c.send("EHLO localhost") },
+			payload: "NOOP\r\nNOOP\r\n",
+			want:    "503",
+		},
+		{
+			name: "before RCPT TO",
+			setup: func(t *testing.T, c *rawClient) {
+				c.send("EHLO localhost")
+				c.send("MAIL FROM:<sender@example.org>")
+			},
+			payload: "RSET\r\n",
+			want:    "503",
+		},
+		{
+			name: "a message that is too large",
+			setup: func(t *testing.T, c *rawClient) {
+				openTransaction(t, c, "MAIL FROM:<sender@example.org>")
+			},
+			payload: strings.Repeat("x", 2048),
+			want:    "552",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := runserver(t, &smtpd.Server{
+				Logger:         testLogger(t),
+				MaxMessageSize: 1024,
+			})
+
+			c := dialRaw(t, srv.Addr)
+			test.setup(t, c)
+
+			if reply := bdat(t, c, test.payload, false); !strings.HasPrefix(reply, test.want) {
+				t.Fatalf("reply = %q, want %s", reply, test.want)
+			}
+
+			// The octets of the chunk are gone from the stream, so the
+			// server reads the next line as a command.
+			if reply := c.send("NOOP"); !strings.HasPrefix(reply, "250") {
+				t.Errorf("NOOP after the refusal = %q, want 250", reply)
+			}
+		})
+	}
+}
+
+// TestBDATRefusesEveryChunkAfterAFailure covers the rule of RFC 3030 that the
+// chunks a client already sent through a pipeline get an answer of their own.
+// RSET starts a transaction that works again.
+func TestBDATRefusesEveryChunkAfterAFailure(t *testing.T) {
+	t.Parallel()
+
+	got := make(chan message, 1)
+	srv := runserver(t, &smtpd.Server{
+		Logger:         testLogger(t),
+		MaxMessageSize: 32,
+		Handler:        captureMessage(got),
+	})
+
+	c := dialRaw(t, srv.Addr)
+	openTransaction(t, c, "MAIL FROM:<sender@example.org>")
+
+	if reply := bdat(t, c, strings.Repeat("x", 64), false); !strings.HasPrefix(reply, "552") {
+		t.Fatalf("the chunk that is too large = %q, want 552", reply)
+	}
+
+	// A chunk that would fit on its own still gets the answer of the
+	// transaction that failed.
+	if reply := bdat(t, c, "small", true); !strings.HasPrefix(reply, "552") {
+		t.Errorf("the chunk after the failure = %q, want 552", reply)
+	}
+
+	if reply := c.send("RSET"); !strings.HasPrefix(reply, "250") {
+		t.Fatalf("RSET = %q, want 250", reply)
+	}
+
+	openTransaction(t, c, "MAIL FROM:<sender@example.org>")
+	if reply := bdat(t, c, "short body", true); !strings.HasPrefix(reply, "250") {
+		t.Fatalf("the message after RSET = %q, want 250", reply)
+	}
+
+	if msg := <-got; msg.body != "short body" {
+		t.Errorf("body = %q, want %q", msg.body, "short body")
+	}
+}
+
+// TestBDATAndDATADoNotMix covers the commands that RFC 3030 keeps apart.
+func TestBDATAndDATADoNotMix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mail string
+		bdat bool
+		want string
+	}{
+		{
+			name: "DATA after BDAT",
+			mail: "MAIL FROM:<sender@example.org>",
+			bdat: true,
+			want: "503",
+		},
+		{
+			name: "DATA for a BINARYMIME message",
+			mail: "MAIL FROM:<sender@example.org> BODY=BINARYMIME",
+			want: "503",
+		},
+		{
+			name: "DATA for a message of text",
+			mail: "MAIL FROM:<sender@example.org> BODY=8BITMIME",
+			want: "354",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := runserver(t, &smtpd.Server{Logger: testLogger(t)})
+
+			c := dialRaw(t, srv.Addr)
+			openTransaction(t, c, test.mail)
+
+			if test.bdat {
+				if reply := bdat(t, c, "part of a message\r\n", false); !strings.HasPrefix(reply, "250") {
+					t.Fatalf("BDAT = %q, want 250", reply)
+				}
+			}
+
+			if reply := c.send("DATA"); !strings.HasPrefix(reply, test.want) {
+				t.Errorf("DATA = %q, want %s", reply, test.want)
+			}
+		})
+	}
+}
+
+// TestBDATStopsTheHandlerOnRSET covers a transfer that ends before the last
+// chunk. The handler must read an error in the place of the rest of the
+// message, so that half a message never looks whole to it.
+func TestBDATStopsTheHandlerOnRSET(t *testing.T) {
+	t.Parallel()
+
+	got := make(chan message, 1)
+	srv := runserver(t, &smtpd.Server{
+		Logger:  testLogger(t),
+		Handler: captureMessage(got),
+	})
+
+	c := dialRaw(t, srv.Addr)
+	openTransaction(t, c, "MAIL FROM:<sender@example.org>")
+
+	if reply := bdat(t, c, "Subject: half a message\r\n", false); !strings.HasPrefix(reply, "250") {
+		t.Fatalf("BDAT = %q, want 250", reply)
+	}
+
+	if reply := c.send("RSET"); !strings.HasPrefix(reply, "250") {
+		t.Fatalf("RSET = %q, want 250", reply)
+	}
+
+	msg := <-got
+	if msg.readErr == nil {
+		t.Fatalf("the handler read the body without an error, and it got %q", msg.body)
+	}
+
+	// The session carries on.
+	openTransaction(t, c, "MAIL FROM:<second@example.org>")
+	if reply := bdat(t, c, "a whole message", true); !strings.HasPrefix(reply, "250") {
+		t.Errorf("the message after RSET = %q, want 250", reply)
+	}
+}
+
+// TestBDATReportsTheHandlerError covers a handler that refuses the message.
+// The client hears about it at the last chunk.
+func TestBDATReportsTheHandlerError(t *testing.T) {
+	t.Parallel()
+
+	srv := runserver(t, &smtpd.Server{
+		Logger: testLogger(t),
+		Handler: func(ctx context.Context, _ smtpd.Peer, env *smtpd.Envelope) (context.Context, error) {
+			_ = env.Data.Close()
+			return ctx, smtpd.Error{Code: 554, Enhanced: smtpd.EnhancedCode{5, 7, 1}, Message: "Not today"}
+		},
+	})
+
+	c := dialRaw(t, srv.Addr)
+	openTransaction(t, c, "MAIL FROM:<sender@example.org>")
+
+	if reply := bdat(t, c, "a whole message", true); reply != "554 5.7.1 Not today" {
+		t.Errorf("BDAT LAST = %q, want %q", reply, "554 5.7.1 Not today")
+	}
+
+	// The transaction is over, so the next one starts from MAIL FROM.
+	if reply := c.send("MAIL FROM:<second@example.org>"); !strings.HasPrefix(reply, "250") {
+		t.Errorf("MAIL FROM after the refusal = %q, want 250", reply)
+	}
+}
+
+// TestBDATSyntaxErrorEndsTheSession covers a command whose chunk size cannot
+// be read. Nothing says where the chunk ends, so the session cannot go on.
+func TestBDATSyntaxErrorEndsTheSession(t *testing.T) {
+	t.Parallel()
+
+	srv := runserver(t, &smtpd.Server{Logger: testLogger(t)})
+
+	c := dialRaw(t, srv.Addr)
+	openTransaction(t, c, "MAIL FROM:<sender@example.org>")
+
+	if reply := c.send("BDAT plenty"); !strings.HasPrefix(reply, "501") {
+		t.Fatalf("BDAT with a bad size = %q, want 501", reply)
+	}
+
+	if _, err := c.conn.Write([]byte("NOOP\r\n")); err == nil {
+		if _, err := c.br.ReadString('\n'); err == nil {
+			t.Error("the session stayed open after a BDAT that could not be read")
+		}
+	}
+}
+
+// TestRCPTAfterBDAT covers a recipient that arrives after the message started.
+// The handler reads the envelope while the chunks arrive, so the list of
+// recipients is closed by then.
+func TestRCPTAfterBDAT(t *testing.T) {
+	t.Parallel()
+
+	srv := runserver(t, &smtpd.Server{Logger: testLogger(t)})
+
+	c := dialRaw(t, srv.Addr)
+	openTransaction(t, c, "MAIL FROM:<sender@example.org>")
+
+	if reply := bdat(t, c, "part of a message\r\n", false); !strings.HasPrefix(reply, "250") {
+		t.Fatalf("BDAT = %q, want 250", reply)
+	}
+
+	if reply := c.send("RCPT TO:<late@example.net>"); !strings.HasPrefix(reply, "503") {
+		t.Errorf("RCPT TO after BDAT = %q, want 503", reply)
+	}
+}
+
+// TestBDATHandlerPanicClosesTheSession covers a handler that panics while a
+// chunked message arrives. The handler runs on a goroutine of its own, so its
+// panic reaches the session as a value and not through recover. The client
+// must see the same 421 as for a panic in a DATA handler, and the Disconnect
+// hooks must read the PanicError.
+func TestBDATHandlerPanicClosesTheSession(t *testing.T) {
+	t.Parallel()
+
+	var rec disconnectRecord
+	boom := panicOnce("boom in a chunk")
+
+	srv := runserver(t, &smtpd.Server{
+		Logger: testLogger(t),
+		Handler: func(ctx context.Context, _ smtpd.Peer, env *smtpd.Envelope) (context.Context, error) {
+			_, _ = io.ReadAll(env.Data)
+			boom()
+			return ctx, nil
+		},
+	}, disconnectCounter(&rec))
+
+	c := dialRaw(t, srv.Addr)
+	openTransaction(t, c, "MAIL FROM:<sender@example.org>")
+
+	if reply := bdat(t, c, "a whole message", true); !strings.HasPrefix(reply, "421") {
+		t.Fatalf("BDAT LAST = %q, want 421", reply)
+	}
+
+	count, lastErr := waitDisconnect(&rec, time.Second)
+	if count != 1 {
+		t.Fatalf("Disconnect ran %d times, want 1", count)
+	}
+
+	var panicErr smtpd.PanicError
+	if !errors.As(lastErr, &panicErr) {
+		t.Fatalf("the Disconnect hook read %v, want a smtpd.PanicError", lastErr)
+	}
+	if panicErr.Value != "boom in a chunk" {
+		t.Errorf("the panic value is %v, want %q", panicErr.Value, "boom in a chunk")
+	}
+
+	// The stack must reach the frame that panicked, and not only the frame
+	// that recovered, or it gives an operator nothing to debug with.
+	if !strings.Contains(string(panicErr.Stack), "TestBDATHandlerPanicClosesTheSession") {
+		t.Errorf("the stack does not reach the handler that panicked:\n%s", panicErr.Stack)
+	}
+}
+
+// TestBDATLeavesNoGoroutine covers the goroutine that runs the handler of a
+// chunked message. A session that ends in the middle of a transfer must not
+// leave it behind.
+func TestBDATLeavesNoGoroutine(t *testing.T) {
+	t.Parallel()
+
+	// The handler blocks on a body that never ends, which is the goroutine
+	// that a session must stop before it goes away.
+	srv := runserver(t, &smtpd.Server{
+		Logger: testLogger(t),
+		Handler: func(ctx context.Context, _ smtpd.Peer, env *smtpd.Envelope) (context.Context, error) {
+			_, _ = io.ReadAll(env.Data)
+			return ctx, nil
+		},
+	})
+
+	before := runtime.NumGoroutine()
+
+	for range 20 {
+		c := dialRaw(t, srv.Addr)
+		openTransaction(t, c, "MAIL FROM:<sender@example.org>")
+
+		if reply := bdat(t, c, "half of a message\r\n", false); !strings.HasPrefix(reply, "250") {
+			t.Fatalf("BDAT = %q, want 250", reply)
+		}
+
+		// The client goes away in the middle of the message.
+		_ = c.conn.Close()
+	}
+
+	// The sessions end on their own, so give them a moment to.
+	deadline := time.Now().Add(2 * time.Second)
+	for runtime.NumGoroutine() > before+5 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if after := runtime.NumGoroutine(); after > before+5 {
+		t.Errorf("the server holds %d goroutines, and it held %d before the 20 sessions", after, before)
+	}
+}

--- a/chunk.go
+++ b/chunk.go
@@ -171,37 +171,50 @@ func (s *session) finishChunk(ctx context.Context) (context.Context, int64, erro
 	return ctx, t.received, result.err
 }
 
-// abort ends the handler of a transfer that will not finish and keeps the
-// cause on the transfer, so that every chunk that follows gets the same
-// answer.
-func (t *chunkTransfer) abort(cause error) {
-	t.failure = cause
-
+// end stops the handler and gives back what it left. The handler reads cause
+// in the place of the rest of the message, so a message that is not whole
+// never looks complete to it.
+//
+// The goroutine writes one result before it ends, so a handler that returned
+// after the last poll is still here to answer for. A panic that nothing reads
+// would leave no trace at all.
+func (t *chunkTransfer) end(cause error) *deliverResult {
 	if !t.started() {
-		return
+		return nil
 	}
 
 	_ = t.pw.CloseWithError(cause)
 	<-t.exited
 	t.pw = nil
+
+	if result, ok := t.poll(); ok {
+		return &result
+	}
+
+	return nil
 }
 
-// stopChunk ends a transfer that did not reach BDAT LAST. The handler reads
-// cause in the place of the rest of the message, so a message that is not
-// whole never looks complete to it.
+// abort ends the handler of a transfer that will not finish and keeps the
+// cause on the transfer, so that every chunk that follows gets the same
+// answer.
+func (t *chunkTransfer) abort(cause error) *deliverResult {
+	t.failure = cause
+	return t.end(cause)
+}
+
+// stopChunk ends a transfer that did not reach BDAT LAST and drops it.
 //
 // It waits for the goroutine of the handler, so that no handler of a message
 // that the client gave up on runs into the session that follows.
-func (s *session) stopChunk(cause error) {
+func (s *session) stopChunk(cause error) *deliverResult {
 	t := s.chunk
 	s.chunk = nil
 
-	if !t.started() {
-		return
+	if t == nil {
+		return nil
 	}
 
-	_ = t.pw.CloseWithError(cause)
-	<-t.exited
+	return t.end(cause)
 }
 
 // handleBDAT runs the BDAT command of RFC 3030. The octets of the chunk
@@ -211,8 +224,8 @@ func (s *session) stopChunk(cause error) {
 func (s *session) handleBDAT(ctx context.Context, cmd *command) context.Context {
 	ctx, _ = phasedLoggerFromContext(ctx, "bdat")
 
-	size, last, err := cmd.bdatArg()
-	if err != nil {
+	size, last, sized, err := cmd.bdatArg()
+	if err != nil && !sized {
 		// The length of the chunk is the only thing that says where it ends.
 		// Without it, nothing that follows can be read as a command.
 		ctx = s.replyEnhanced(ctx, 501, EnhancedCode{5, 5, 4}, "Invalid BDAT syntax.")
@@ -221,6 +234,17 @@ func (s *session) handleBDAT(ctx context.Context, cmd *command) context.Context 
 
 	// A chunk arrives at the speed of a message, not of a command.
 	_ = s.conn.SetDeadline(time.Now().Add(s.server.DataTimeout))
+
+	if err != nil {
+		// The length reads, so the chunk comes off the wire and the session
+		// goes on. The transaction does not: a command that the server
+		// cannot read leaves the message in a state it cannot trust.
+		return s.refuseChunk(ctx, size, false, Error{
+			Code:     501,
+			Enhanced: EnhancedCode{5, 5, 4},
+			Message:  "Invalid BDAT syntax.",
+		})
+	}
 
 	if s.envelope == nil || len(s.envelope.Recipients) == 0 {
 		return s.refuseChunk(ctx, size, last, Error{
@@ -309,7 +333,9 @@ func (s *session) chunkRefusal(size int64) error {
 // command with refusal.
 func (s *session) refuseChunk(ctx context.Context, size int64, last bool, refusal error) context.Context {
 	if s.chunk != nil {
-		s.chunk.abort(refusal)
+		if ctx, done := s.reportChunkPanic(ctx, s.chunk.abort(refusal)); done {
+			return ctx
+		}
 	}
 
 	read, err := s.discardChunk(size)
@@ -348,6 +374,27 @@ func (s *session) discardChunk(size int64) (read bool, err error) {
 	}
 
 	return true, nil
+}
+
+// reportChunkPanic answers a handler that ended in a panic while the session
+// was busy with something else. The panic goes to the log and to the
+// Disconnect hooks, and to the client as the 421 that a panic in a DATA
+// handler also gives. done says that the session is over.
+//
+// An error that is not a panic goes no further here. A message that the
+// client gave up on has nobody left to answer to.
+func (s *session) reportChunkPanic(ctx context.Context, result *deliverResult) (context.Context, bool) {
+	if result == nil {
+		return ctx, false
+	}
+
+	var panicErr PanicError
+	if !errors.As(result.err, &panicErr) {
+		return ctx, false
+	}
+
+	ctx = s.reportPanic(ctx, panicErr)
+	return s.close(ctx), true
 }
 
 // replyChunkError answers a handler that ended with an error. A panic ends the

--- a/chunk.go
+++ b/chunk.go
@@ -246,15 +246,19 @@ func (s *session) handleBDAT(ctx context.Context, cmd *command) context.Context 
 		})
 	}
 
-	if s.envelope == nil || len(s.envelope.Recipients) == 0 {
-		return s.refuseChunk(ctx, size, last, Error{
-			Code:     503,
-			Enhanced: EnhancedCode{5, 5, 1},
-			Message:  "Missing RCPT TO command.",
-		})
-	}
-
+	// The envelope is read once, where the transfer begins. From the first
+	// chunk on, the handler runs on a goroutine of its own and can write to
+	// the envelope, and the command that opened the transfer already showed
+	// that a recipient is there.
 	if s.chunk == nil {
+		if s.envelope == nil || len(s.envelope.Recipients) == 0 {
+			return s.refuseChunk(ctx, size, last, Error{
+				Code:     503,
+				Enhanced: EnhancedCode{5, 5, 1},
+				Message:  "Missing RCPT TO command.",
+			})
+		}
+
 		s.chunk = &chunkTransfer{}
 	}
 

--- a/chunk.go
+++ b/chunk.go
@@ -40,6 +40,11 @@ type chunkTransfer struct {
 	// received counts the octets of the message so far.
 	received int64
 
+	// buf carries the octets from the connection into the pipe. It stays
+	// with the transfer, so that a message of many chunks takes one buffer
+	// and not one for every chunk.
+	buf []byte
+
 	// failure is the answer that every chunk after a refusal gets. RFC 3030
 	// asks the server to take the chunks that the client already sent and to
 	// answer each one of them.
@@ -49,6 +54,14 @@ type chunkTransfer struct {
 	// can return before the last chunk, and the client hears about it at the
 	// next command.
 	result *deliverResult
+}
+
+// copyBuf gives the buffer that carries the octets of a chunk into the pipe.
+func (t *chunkTransfer) copyBuf() []byte {
+	if t.buf == nil {
+		t.buf = make([]byte, 32*1024)
+	}
+	return t.buf
 }
 
 // started reports whether the handler is running.
@@ -229,7 +242,13 @@ func (s *session) handleBDAT(ctx context.Context, cmd *command) context.Context 
 		s.startChunk(ctx)
 	}
 
-	if _, err := io.CopyN(s.chunk.pw, s.reader, size); err != nil {
+	n, err := io.CopyBuffer(s.chunk.pw, io.LimitReader(s.reader, size), s.chunk.copyBuf())
+	if err == nil && n != size {
+		// A reader that stops early gives no error of its own, and a chunk
+		// that is not whole is not a chunk.
+		err = io.ErrUnexpectedEOF
+	}
+	if err != nil {
 		// The session cannot know how much of the chunk it read, so the line
 		// that follows is not a command.
 		s.setErr(err)

--- a/chunk.go
+++ b/chunk.go
@@ -1,0 +1,344 @@
+package smtpd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"runtime/debug"
+	"time"
+)
+
+// errChunkAborted is what the handler reads in the place of the rest of the
+// message when a transfer ends before BDAT LAST. RSET does that, and so does
+// a connection that closes in the middle of a message.
+var errChunkAborted = errors.New("smtpd: the chunked transfer ended before the last chunk")
+
+// deliverResult carries what the handler of a chunked message gave back. The
+// context replaces the one of the session, in the same way as it does for a
+// message that arrives through DATA.
+type deliverResult struct {
+	ctx context.Context
+	err error
+}
+
+// chunkTransfer holds the state of one BDAT transfer.
+//
+// The handler runs on a goroutine of its own and reads the chunks through a
+// pipe as they arrive, so a message that arrives in chunks streams in the
+// same way as a message that arrives through DATA. The session writes each
+// chunk into the pipe and closes it at BDAT LAST.
+//
+// The transfer exists from the first BDAT command of a transaction. The
+// goroutine starts with the first chunk that the server takes, so a chunk
+// that the server refuses starts nothing.
+type chunkTransfer struct {
+	pw     *io.PipeWriter
+	done   chan deliverResult
+	exited chan struct{}
+
+	// received counts the octets of the message so far.
+	received int64
+
+	// failure is the answer that every chunk after a refusal gets. RFC 3030
+	// asks the server to take the chunks that the client already sent and to
+	// answer each one of them.
+	failure error
+
+	// result holds what the handler gave back, once it arrived. The handler
+	// can return before the last chunk, and the client hears about it at the
+	// next command.
+	result *deliverResult
+}
+
+// started reports whether the handler is running.
+func (t *chunkTransfer) started() bool {
+	return t != nil && t.pw != nil
+}
+
+// poll asks for the result of the handler without waiting for it.
+func (t *chunkTransfer) poll() (deliverResult, bool) {
+	if t.result != nil {
+		return *t.result, true
+	}
+
+	select {
+	case result := <-t.done:
+		t.result = &result
+		return result, true
+	default:
+		return deliverResult{}, false
+	}
+}
+
+// wait asks for the result of the handler and waits for it. The caller closes
+// the write end of the pipe first, which is what makes the handler read the
+// end of the message.
+func (t *chunkTransfer) wait() deliverResult {
+	if t.result != nil {
+		return *t.result
+	}
+
+	result := <-t.done
+	t.result = &result
+	return result
+}
+
+// chunkBody hands the chunks of a message to the handler. Close does
+// nothing: the session owns the pipe, and it closes the write end at the last
+// chunk. A handler that closes the body early would otherwise take the rest
+// of the message away from the session, which still has to read it off the
+// wire.
+type chunkBody struct {
+	r *io.PipeReader
+}
+
+func (c *chunkBody) Read(p []byte) (int, error) { return c.r.Read(p) }
+func (c *chunkBody) Close() error               { return nil }
+
+// startChunk puts the handler on a goroutine of its own and gives it the read
+// end of the pipe as the body of the message.
+//
+// The goroutine always ends: the drain that follows the handler reads until
+// the session closes the write end of the pipe, which finishChunk and
+// stopChunk both do.
+func (s *session) startChunk(ctx context.Context) {
+	pr, pw := io.Pipe()
+
+	t := s.chunk
+	t.pw = pw
+	t.done = make(chan deliverResult, 1)
+	t.exited = make(chan struct{})
+
+	s.envelope.Data = &chunkBody{r: pr}
+
+	// The peer of the session is a snapshot, because a command that arrives
+	// while the handler runs can write to the one of the session.
+	peer := s.peer
+	env := s.envelope
+
+	go func() {
+		defer close(t.exited)
+
+		defer func() {
+			if v := recover(); v != nil {
+				// The session turns this into the 421 that a panic in a DATA
+				// handler gives, and into the error that the Disconnect
+				// hooks read.
+				t.done <- deliverResult{ctx: ctx, err: PanicError{Value: v, Stack: debug.Stack()}}
+			}
+
+			// Read what the handler left, so that the session can write the
+			// chunks that follow. The server drains the body of a DATA
+			// message in the same way.
+			_, _ = io.Copy(io.Discard, pr)
+			_ = pr.Close()
+		}()
+
+		dctx, err := s.server.deliver(ctx, peer, env)
+		t.done <- deliverResult{ctx: dctx, err: err}
+	}()
+}
+
+// finishChunk closes the message at BDAT LAST and waits for the handler. It
+// gives the context of the handler, the length of the message and the error
+// that the handler gave back.
+func (s *session) finishChunk(ctx context.Context) (context.Context, int64, error) {
+	t := s.chunk
+	s.chunk = nil
+
+	_ = t.pw.Close()
+	result := t.wait()
+	<-t.exited
+
+	if result.ctx != nil {
+		ctx = result.ctx
+	}
+
+	return ctx, t.received, result.err
+}
+
+// abort ends the handler of a transfer that will not finish and keeps the
+// cause on the transfer, so that every chunk that follows gets the same
+// answer.
+func (t *chunkTransfer) abort(cause error) {
+	t.failure = cause
+
+	if !t.started() {
+		return
+	}
+
+	_ = t.pw.CloseWithError(cause)
+	<-t.exited
+	t.pw = nil
+}
+
+// stopChunk ends a transfer that did not reach BDAT LAST. The handler reads
+// cause in the place of the rest of the message, so a message that is not
+// whole never looks complete to it.
+//
+// It waits for the goroutine of the handler, so that no handler of a message
+// that the client gave up on runs into the session that follows.
+func (s *session) stopChunk(cause error) {
+	t := s.chunk
+	s.chunk = nil
+
+	if !t.started() {
+		return
+	}
+
+	_ = t.pw.CloseWithError(cause)
+	<-t.exited
+}
+
+// handleBDAT runs the BDAT command of RFC 3030. The octets of the chunk
+// follow the command line on the same stream, so every path here takes the
+// whole chunk off the wire before it writes a reply. A reply that leaves the
+// octets there makes the server read the message as commands.
+func (s *session) handleBDAT(ctx context.Context, cmd *command) context.Context {
+	ctx, _ = phasedLoggerFromContext(ctx, "bdat")
+
+	size, last, err := cmd.bdatArg()
+	if err != nil {
+		// The length of the chunk is the only thing that says where it ends.
+		// Without it, nothing that follows can be read as a command.
+		ctx = s.replyEnhanced(ctx, 501, EnhancedCode{5, 5, 4}, "Invalid BDAT syntax.")
+		return s.close(ctx)
+	}
+
+	// A chunk arrives at the speed of a message, not of a command.
+	_ = s.conn.SetDeadline(time.Now().Add(s.server.DataTimeout))
+
+	if s.envelope == nil || len(s.envelope.Recipients) == 0 {
+		return s.refuseChunk(ctx, size, last, Error{
+			Code:     503,
+			Enhanced: EnhancedCode{5, 5, 1},
+			Message:  "Missing RCPT TO command.",
+		})
+	}
+
+	if s.chunk == nil {
+		s.chunk = &chunkTransfer{}
+	}
+
+	if refusal := s.chunkRefusal(size); refusal != nil {
+		return s.refuseChunk(ctx, size, last, refusal)
+	}
+
+	if !s.chunk.started() {
+		s.startChunk(ctx)
+	}
+
+	if _, err := io.CopyN(s.chunk.pw, s.reader, size); err != nil {
+		// The session cannot know how much of the chunk it read, so the line
+		// that follows is not a command.
+		s.setErr(err)
+		s.stopChunk(err)
+		ctx = s.replyEnhanced(ctx, 451, EnhancedCode{4, 3, 0}, "The chunk could not be read")
+		return s.close(ctx)
+	}
+
+	s.chunk.received += size
+
+	if !last {
+		// A handler that returned before the last chunk has an answer that
+		// the client needs now. The chunks that follow get the same one.
+		if result, ok := s.chunk.poll(); ok && result.err != nil {
+			if result.ctx != nil {
+				ctx = result.ctx
+			}
+			s.chunk.failure = result.err
+			return s.replyChunkError(ctx, result.err)
+		}
+
+		return s.reply(ctx, 250, fmt.Sprintf("%d octets received", size))
+	}
+
+	ctx, received, err := s.finishChunk(ctx)
+	if err != nil {
+		ctx = s.replyChunkError(ctx, err)
+		if s.closed {
+			// A panic in the handler ended the session, and there is no
+			// transaction left to reset.
+			return ctx
+		}
+		return s.reset(ctx)
+	}
+
+	return s.reset(s.reply(ctx, 250, fmt.Sprintf("Message OK, %d octets received", received)))
+}
+
+// chunkRefusal gives the answer for a chunk that the server does not take, or
+// nil for a chunk that it takes.
+func (s *session) chunkRefusal(size int64) error {
+	if s.chunk.failure != nil {
+		return s.chunk.failure
+	}
+
+	if size > int64(s.server.MaxMessageSize)-s.chunk.received {
+		return Error{
+			Code:     552,
+			Enhanced: EnhancedCode{5, 3, 4},
+			Message:  fmt.Sprintf("Message exceeded max message size of %d bytes", s.server.MaxMessageSize),
+		}
+	}
+
+	return nil
+}
+
+// refuseChunk takes the octets of a chunk off the wire and answers the
+// command with refusal.
+func (s *session) refuseChunk(ctx context.Context, size int64, last bool, refusal error) context.Context {
+	if s.chunk != nil {
+		s.chunk.abort(refusal)
+	}
+
+	read, err := s.discardChunk(size)
+	if err != nil {
+		// The connection is gone, and the read loop sees the same error.
+		s.setErr(err)
+		return ctx
+	}
+
+	ctx = s.replyError(ctx, refusal)
+
+	if !read {
+		return s.close(ctx)
+	}
+
+	if last {
+		return s.reset(ctx)
+	}
+
+	return ctx
+}
+
+// discardChunk reads the octets of a chunk that the server does not take, and
+// throws them away.
+//
+// read is false for a chunk that is longer than twice the largest message
+// that the server takes. Reading that costs without bound, so the caller
+// closes the session in the place of reading it.
+func (s *session) discardChunk(size int64) (read bool, err error) {
+	if size > int64(s.server.MaxMessageSize)*2 {
+		return false, nil
+	}
+
+	if _, err := io.CopyN(io.Discard, s.reader, size); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// replyChunkError answers a handler that ended with an error. A panic ends the
+// session, in the same way as a panic in the handler of a DATA message.
+func (s *session) replyChunkError(ctx context.Context, err error) context.Context {
+	var panicErr PanicError
+	if errors.As(err, &panicErr) {
+		ctx = s.reportPanic(ctx, panicErr)
+		return s.close(ctx)
+	}
+
+	return s.replyError(ctx, err)
+}

--- a/command.go
+++ b/command.go
@@ -162,29 +162,39 @@ func (cmd *command) syntaxError(message string) error {
 // bdatArg reads the arguments of a BDAT command: the length of the chunk that
 // follows the command line, and the mark that says it is the last one. RFC
 // 3030 writes the command as "BDAT" SP chunk-size [ SP end-marker ].
-func (cmd *command) bdatArg() (size int64, last bool, err error) {
+//
+// sized reports whether the length of the chunk is known. A command with a
+// length that reads gets an answer and keeps the session, because the server
+// can still take the chunk off the wire. A command without one ends the
+// session: nothing says where the chunk stops.
+func (cmd *command) bdatArg() (size int64, last, sized bool, err error) {
 	if cmd == nil {
-		return 0, false, SyntaxError{Message: "nil command"}
+		return 0, false, false, SyntaxError{Message: "nil command"}
 	}
 
 	args := cmd.args()
-	if len(args) < 1 || len(args) > 2 {
-		return 0, false, cmd.syntaxError("BDAT takes a chunk size and an optional LAST")
+	if len(args) < 1 {
+		return 0, false, false, cmd.syntaxError("BDAT takes a chunk size and an optional LAST")
 	}
 
 	// The length is a count of octets, so a sign has no place in it.
 	// ParseUint takes none, and 63 bits keep the value inside an int64.
 	value, err := strconv.ParseUint(args[0], 10, 63)
 	if err != nil {
-		return 0, false, cmd.syntaxError("invalid chunk size")
+		return 0, false, false, cmd.syntaxError("invalid chunk size")
+	}
+	size = int64(value)
+
+	if len(args) > 2 {
+		return size, false, true, cmd.syntaxError("BDAT takes a chunk size and an optional LAST")
 	}
 
 	if len(args) == 2 {
 		if !strings.EqualFold(args[1], "LAST") {
-			return 0, false, cmd.syntaxError("invalid end marker")
+			return size, false, true, cmd.syntaxError("invalid end marker")
 		}
 		last = true
 	}
 
-	return int64(value), last, nil
+	return size, last, true, nil
 }

--- a/command.go
+++ b/command.go
@@ -2,6 +2,7 @@ package smtpd
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -156,4 +157,34 @@ func (cmd *command) syntaxError(message string) error {
 		}
 	}
 	return SyntaxError{Line: line, Message: message}
+}
+
+// bdatArg reads the arguments of a BDAT command: the length of the chunk that
+// follows the command line, and the mark that says it is the last one. RFC
+// 3030 writes the command as "BDAT" SP chunk-size [ SP end-marker ].
+func (cmd *command) bdatArg() (size int64, last bool, err error) {
+	if cmd == nil {
+		return 0, false, SyntaxError{Message: "nil command"}
+	}
+
+	args := cmd.args()
+	if len(args) < 1 || len(args) > 2 {
+		return 0, false, cmd.syntaxError("BDAT takes a chunk size and an optional LAST")
+	}
+
+	// The length is a count of octets, so a sign has no place in it.
+	// ParseUint takes none, and 63 bits keep the value inside an int64.
+	value, err := strconv.ParseUint(args[0], 10, 63)
+	if err != nil {
+		return 0, false, cmd.syntaxError("invalid chunk size")
+	}
+
+	if len(args) == 2 {
+		if !strings.EqualFold(args[1], "LAST") {
+			return 0, false, cmd.syntaxError("invalid end marker")
+		}
+		last = true
+	}
+
+	return int64(value), last, nil
 }

--- a/command_test.go
+++ b/command_test.go
@@ -177,35 +177,39 @@ func TestCommandSingleArg(t *testing.T) {
 // TestBdatArg covers the arguments of the BDAT command of RFC 3030.
 func TestBdatArg(t *testing.T) {
 	tests := []struct {
-		name     string
-		arg      string
-		wantSize int64
-		wantLast bool
-		wantErr  bool
+		name      string
+		arg       string
+		wantSize  int64
+		wantLast  bool
+		wantSized bool
+		wantErr   bool
 	}{
-		{name: "a chunk", arg: "1024", wantSize: 1024},
-		{name: "the last chunk", arg: "1024 LAST", wantSize: 1024, wantLast: true},
-		{name: "the mark in lower case", arg: "7 last", wantSize: 7, wantLast: true},
-		{name: "an empty last chunk", arg: "0 LAST", wantSize: 0, wantLast: true},
+		{name: "a chunk", arg: "1024", wantSize: 1024, wantSized: true},
+		{name: "the last chunk", arg: "1024 LAST", wantSize: 1024, wantLast: true, wantSized: true},
+		{name: "the mark in lower case", arg: "7 last", wantSize: 7, wantLast: true, wantSized: true},
+		{name: "an empty last chunk", arg: "0 LAST", wantSize: 0, wantLast: true, wantSized: true},
 		{name: "no argument", arg: "", wantErr: true},
 		{name: "a size that is not a number", arg: "big", wantErr: true},
 		{name: "a negative size", arg: "-1", wantErr: true},
 		{name: "a size with a sign", arg: "+1", wantErr: true},
 		{name: "a size that does not fit", arg: "99999999999999999999", wantErr: true},
-		{name: "a mark of another kind", arg: "10 FIRST", wantErr: true},
-		{name: "three arguments", arg: "10 LAST LAST", wantErr: true},
+
+		// The length reads in these two, so the server can still take the
+		// chunk off the wire and keep the session.
+		{name: "a mark of another kind", arg: "10 FIRST", wantSize: 10, wantSized: true, wantErr: true},
+		{name: "three arguments", arg: "10 LAST LAST", wantSize: 10, wantSized: true, wantErr: true},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			cmd := &command{action: "BDAT", arg: test.arg}
 
-			size, last, err := cmd.bdatArg()
+			size, last, sized, err := cmd.bdatArg()
 			if (err != nil) != test.wantErr {
 				t.Fatalf("bdatArg() error = %v, wantErr %v", err, test.wantErr)
 			}
-			if err != nil {
-				return
+			if sized != test.wantSized {
+				t.Errorf("bdatArg() sized = %v, want %v", sized, test.wantSized)
 			}
 			if size != test.wantSize || last != test.wantLast {
 				t.Errorf("bdatArg() = %d, %v, want %d, %v", size, last, test.wantSize, test.wantLast)

--- a/command_test.go
+++ b/command_test.go
@@ -173,3 +173,43 @@ func TestCommandSingleArg(t *testing.T) {
 		})
 	}
 }
+
+// TestBdatArg covers the arguments of the BDAT command of RFC 3030.
+func TestBdatArg(t *testing.T) {
+	tests := []struct {
+		name     string
+		arg      string
+		wantSize int64
+		wantLast bool
+		wantErr  bool
+	}{
+		{name: "a chunk", arg: "1024", wantSize: 1024},
+		{name: "the last chunk", arg: "1024 LAST", wantSize: 1024, wantLast: true},
+		{name: "the mark in lower case", arg: "7 last", wantSize: 7, wantLast: true},
+		{name: "an empty last chunk", arg: "0 LAST", wantSize: 0, wantLast: true},
+		{name: "no argument", arg: "", wantErr: true},
+		{name: "a size that is not a number", arg: "big", wantErr: true},
+		{name: "a negative size", arg: "-1", wantErr: true},
+		{name: "a size with a sign", arg: "+1", wantErr: true},
+		{name: "a size that does not fit", arg: "99999999999999999999", wantErr: true},
+		{name: "a mark of another kind", arg: "10 FIRST", wantErr: true},
+		{name: "three arguments", arg: "10 LAST LAST", wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := &command{action: "BDAT", arg: test.arg}
+
+			size, last, err := cmd.bdatArg()
+			if (err != nil) != test.wantErr {
+				t.Fatalf("bdatArg() error = %v, wantErr %v", err, test.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if size != test.wantSize || last != test.wantLast {
+				t.Errorf("bdatArg() = %d, %v, want %d, %v", size, last, test.wantSize, test.wantLast)
+			}
+		})
+	}
+}

--- a/data.go
+++ b/data.go
@@ -12,15 +12,19 @@ import (
 func (s *session) handleDATA(ctx context.Context, cmd *command) context.Context {
 	ctx, _ = phasedLoggerFromContext(ctx, "data")
 
-	if s.envelope == nil || len(s.envelope.Recipients) == 0 {
-		return s.replyEnhanced(ctx, 503, EnhancedCode{5, 5, 1}, "Missing RCPT TO command.")
-	}
-
 	// RFC 3030 keeps the two ways of sending a message apart. The dot that
 	// ends a DATA message has no meaning in the octets of a chunk, and a
 	// message that already arrived in chunks is not a DATA message.
+	//
+	// This stands before the envelope, and not after it: the handler of a
+	// chunked message runs on a goroutine of its own and can write to the
+	// envelope, so the session reads nothing out of it while that lasts.
 	if s.chunk != nil {
 		return s.replyEnhanced(ctx, 503, EnhancedCode{5, 5, 1}, "DATA cannot follow BDAT in the same transaction")
+	}
+
+	if s.envelope == nil || len(s.envelope.Recipients) == 0 {
+		return s.replyEnhanced(ctx, 503, EnhancedCode{5, 5, 1}, "Missing RCPT TO command.")
 	}
 
 	if s.envelope.BodyType == BodyBinaryMIME {

--- a/data.go
+++ b/data.go
@@ -16,6 +16,17 @@ func (s *session) handleDATA(ctx context.Context, cmd *command) context.Context 
 		return s.replyEnhanced(ctx, 503, EnhancedCode{5, 5, 1}, "Missing RCPT TO command.")
 	}
 
+	// RFC 3030 keeps the two ways of sending a message apart. The dot that
+	// ends a DATA message has no meaning in the octets of a chunk, and a
+	// message that already arrived in chunks is not a DATA message.
+	if s.chunk != nil {
+		return s.replyEnhanced(ctx, 503, EnhancedCode{5, 5, 1}, "DATA cannot follow BDAT in the same transaction")
+	}
+
+	if s.envelope.BodyType == BodyBinaryMIME {
+		return s.replyEnhanced(ctx, 503, EnhancedCode{5, 5, 1}, "A BINARYMIME message needs BDAT")
+	}
+
 	ctx = s.reply(ctx, 354, "Go ahead. End your data with <CR><LF>.<CR><LF>")
 	_ = s.conn.SetDeadline(time.Now().Add(s.server.DataTimeout))
 

--- a/data_drain_test.go
+++ b/data_drain_test.go
@@ -77,7 +77,6 @@ func runDATAFrom(t *testing.T, srv *Server, env *Envelope, r io.Reader) ([]int, 
 		conn:     fakeConn{},
 		reader:   reader,
 		writer:   bufio.NewWriter(serverWrite),
-		scanner:  bufio.NewScanner(reader),
 		envelope: env,
 		peer:     Peer{ServerName: "localhost"},
 	}

--- a/data_test.go
+++ b/data_test.go
@@ -229,7 +229,6 @@ func runDATA(t *testing.T, srv *Server, env *Envelope, payload string) []int {
 		conn:     fakeConn{},
 		reader:   reader,
 		writer:   bufio.NewWriter(serverWrite),
-		scanner:  bufio.NewScanner(reader),
 		envelope: env,
 		peer:     Peer{ServerName: "localhost"},
 	}

--- a/enhanced_test.go
+++ b/enhanced_test.go
@@ -188,6 +188,8 @@ func TestEHLOReplyCarriesNoEnhancedStatusCode(t *testing.T) {
 		"250-mx.example.com",
 		"250-SIZE 10240000",
 		"250-8BITMIME",
+		"250-BINARYMIME",
+		"250-CHUNKING",
 		"250-PIPELINING",
 		"250 ENHANCEDSTATUSCODES",
 	}

--- a/envelope.go
+++ b/envelope.go
@@ -2,13 +2,46 @@ package smtpd
 
 import "io"
 
+// BodyType is the value of the BODY parameter of MAIL FROM. RFC 1652 gives
+// the first two values, and RFC 3030 adds the third.
+type BodyType string
+
+const (
+	// Body7Bit is a message of 7-bit text, which is what a client that sends
+	// no BODY parameter means.
+	Body7Bit BodyType = "7BIT"
+
+	// Body8BitMIME is a message of 8-bit text with lines.
+	Body8BitMIME BodyType = "8BITMIME"
+
+	// BodyBinaryMIME is a message of octets without a line structure. RFC
+	// 3030 gives it to BDAT alone: the server answers 503 to a DATA command
+	// for such a message, because the dot that ends a DATA message has no
+	// meaning in binary content.
+	BodyBinaryMIME BodyType = "BINARYMIME"
+)
+
 // Envelope holds a message. Data is a streaming body that the handler
 // must fully read and Close. The server drains and closes it on return
 // from the handler regardless, to keep the SMTP protocol in sync.
+//
+// A message that arrives in BDAT chunks gives Data the chunks as they come,
+// so a handler that reads it to the end waits for the last chunk. Close on
+// such a body does nothing: the session owns the stream, because it still has
+// to read the rest of the message off the wire.
 type Envelope struct {
 	Sender     string
 	Recipients []string
 	Data       io.ReadCloser
+
+	// BodyType is the value of the BODY parameter of MAIL FROM. The empty
+	// string means that the client sent no BODY parameter, which RFC 1652
+	// reads as a message of 7-bit text.
+	//
+	// A message of BodyBinaryMIME arrives through BDAT, and Data gives its
+	// octets as they came. Such a message carries no line structure, so a
+	// handler that writes it on must keep it whole.
+	BodyType BodyType
 
 	// DSN holds the delivery status notification parameters of RFC 3461
 	// that came with the transaction. It is nil when the server runs

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -195,3 +195,42 @@ func dsnCapture(got chan<- *smtpd.DSN) smtpd.Handler {
 		return ctx, nil
 	}
 }
+
+// write puts bytes on the connection and reads nothing back. A BDAT command
+// and its chunk go out in one write, in the way that a client sends them.
+func (c *rawClient) write(b []byte) {
+	c.t.Helper()
+
+	if _, err := c.conn.Write(b); err != nil {
+		c.t.Fatalf("write failed: %v", err)
+	}
+}
+
+// message is what a handler read off an envelope.
+type message struct {
+	sender     string
+	recipients []string
+	bodyType   smtpd.BodyType
+	body       string
+	readErr    error
+}
+
+// captureMessage returns a Handler that reads the whole body and hands the
+// message to the test. The channel is buffered, so the handler returns and the
+// client gets its reply before the test reads the value.
+func captureMessage(got chan<- message) smtpd.Handler {
+	return func(ctx context.Context, _ smtpd.Peer, env *smtpd.Envelope) (context.Context, error) {
+		body, err := io.ReadAll(env.Data)
+		_ = env.Data.Close()
+
+		got <- message{
+			sender:     env.Sender,
+			recipients: env.Recipients,
+			bodyType:   env.BodyType,
+			body:       string(body),
+			readErr:    err,
+		}
+
+		return ctx, nil
+	}
+}

--- a/protocol.go
+++ b/protocol.go
@@ -134,8 +134,15 @@ func (s *session) handle(ctx context.Context, line string) context.Context {
 	// command. A panic in it ends the session, whatever that command is.
 	if s.chunk.started() {
 		if result, ok := s.chunk.poll(); ok {
-			if ctx, done := s.reportChunkPanic(ctx, &result); done {
+			var done bool
+			if ctx, done = s.reportChunkPanic(ctx, &result); done {
 				return ctx
+			}
+
+			// A handler that ended gives back a context, and the commands
+			// after it run in that one.
+			if result.ctx != nil {
+				ctx = result.ctx
 			}
 		}
 	}
@@ -308,7 +315,10 @@ func (s *session) handleRCPT(ctx context.Context, cmd *command) context.Context 
 		return s.replyEnhanced(ctx, 503, EnhancedCode{5, 5, 1}, "Missing MAIL FROM command.")
 	}
 
-	if s.chunk.started() {
+	// A transaction that saw a BDAT command takes no more recipients, whether
+	// the server took that chunk or not. It also keeps the session away from
+	// an envelope that the handler of a chunked message can write to.
+	if s.chunk != nil {
 		return s.replyEnhanced(ctx, 503, EnhancedCode{5, 5, 1}, "Cannot add a recipient after BDAT")
 	}
 

--- a/protocol.go
+++ b/protocol.go
@@ -20,71 +20,77 @@ var errMailParams = Error{Code: 555, Enhanced: EnhancedCode{5, 5, 4}, Message: "
 // errRcptParams answers a RCPT TO parameter that the server does not know.
 var errRcptParams = Error{Code: 555, Enhanced: EnhancedCode{5, 5, 4}, Message: "RCPT TO parameters not recognized or not implemented"}
 
-// parseMailParams reads the parameters of a MAIL FROM command. It returns the
-// delivery status notification parameters of RFC 3461, or nil when the client
-// sent none of them.
-func (s *session) parseMailParams(params map[string]string) (*DSN, error) {
+// mailParams holds what the parameters of a MAIL FROM command say about the
+// message that follows.
+type mailParams struct {
+	body BodyType
+	dsn  *DSN
+}
+
+// parseMailParams reads the parameters of a MAIL FROM command.
+func (s *session) parseMailParams(params map[string]string) (mailParams, error) {
+	var out mailParams
+
 	if len(params) == 0 {
-		return nil, nil
+		return out, nil
 	}
 	if s.peer.Protocol != ESMTP {
-		return nil, errMailParams
+		return mailParams{}, errMailParams
 	}
-
-	var dsn *DSN
 
 	for name, value := range params {
 		switch name {
 		case "SIZE":
 			size, err := strconv.ParseInt(value, 10, 64)
 			if err != nil || size < 0 {
-				return nil, Error{Code: 501, Enhanced: EnhancedCode{5, 5, 4}, Message: "Invalid SIZE parameter"}
+				return mailParams{}, Error{Code: 501, Enhanced: EnhancedCode{5, 5, 4}, Message: "Invalid SIZE parameter"}
 			}
 			if size > int64(s.server.MaxMessageSize) {
-				return nil, Error{
+				return mailParams{}, Error{
 					Code:     552,
 					Enhanced: EnhancedCode{5, 3, 4},
 					Message:  fmt.Sprintf("Message size exceeds fixed maximum of %d bytes", s.server.MaxMessageSize),
 				}
 			}
 		case "BODY":
-			switch strings.ToUpper(value) {
-			case "7BIT", "8BITMIME":
+			switch body := BodyType(strings.ToUpper(value)); body {
+			case Body7Bit, Body8BitMIME, BodyBinaryMIME:
+				out.body = body
 			default:
-				return nil, Error{Code: 501, Enhanced: EnhancedCode{5, 5, 4}, Message: "Invalid BODY parameter"}
+				return mailParams{}, Error{Code: 501, Enhanced: EnhancedCode{5, 5, 4}, Message: "Invalid BODY parameter"}
 			}
 		case "AUTH":
 			// AUTH=<> and xtext-style identities are accepted as opaque values.
 		case "RET":
 			if !s.server.EnableDSN {
-				return nil, errMailParams
+				return mailParams{}, errMailParams
 			}
 			ret, ok := parseDSNReturn(value)
 			if !ok {
-				return nil, Error{Code: 501, Enhanced: EnhancedCode{5, 5, 4}, Message: "Invalid RET parameter"}
+				return mailParams{}, Error{Code: 501, Enhanced: EnhancedCode{5, 5, 4}, Message: "Invalid RET parameter"}
 			}
-			if dsn == nil {
-				dsn = &DSN{}
+			if out.dsn == nil {
+				out.dsn = &DSN{}
 			}
-			dsn.Return = ret
+			out.dsn.Return = ret
 		case "ENVID":
 			if !s.server.EnableDSN {
-				return nil, errMailParams
+				return mailParams{}, errMailParams
 			}
 			envID, ok := parseEnvID(value)
 			if !ok {
-				return nil, Error{Code: 501, Enhanced: EnhancedCode{5, 5, 4}, Message: "Invalid ENVID parameter"}
+				return mailParams{}, Error{Code: 501, Enhanced: EnhancedCode{5, 5, 4}, Message: "Invalid ENVID parameter"}
 			}
-			if dsn == nil {
-				dsn = &DSN{}
+			if out.dsn == nil {
+				out.dsn = &DSN{}
 			}
-			dsn.EnvID = envID
+			out.dsn.EnvID = envID
 		default:
-			return nil, errMailParams
+			return mailParams{}, errMailParams
 		}
 	}
 
-	return dsn, nil
+	return out, nil
 }
 
 // parseRcptParams reads the parameters of a RCPT TO command. It returns the
@@ -155,6 +161,9 @@ func (s *session) handle(ctx context.Context, line string) context.Context {
 
 	case "DATA":
 		return s.handleDATA(ctx, cmd)
+
+	case "BDAT":
+		return s.handleBDAT(ctx, cmd)
 
 	case "RSET":
 		return s.handleRSET(ctx, cmd)
@@ -255,7 +264,7 @@ func (s *session) handleMAIL(ctx context.Context, cmd *command) context.Context 
 		}
 	}
 
-	dsn, err := s.parseMailParams(params)
+	mail, err := s.parseMailParams(params)
 	if err != nil {
 		return s.replyError(ctx, err)
 	}
@@ -268,8 +277,9 @@ func (s *session) handleMAIL(ctx context.Context, cmd *command) context.Context 
 	ctx = ContextWithSender(ctx, addr)
 
 	s.envelope = &Envelope{
-		Sender: addr,
-		DSN:    dsn,
+		Sender:   addr,
+		BodyType: mail.body,
+		DSN:      mail.dsn,
 	}
 
 	return s.replyEnhanced(ctx, 250, EnhancedCode{2, 1, 0}, "Go ahead")
@@ -286,6 +296,10 @@ func (s *session) handleRCPT(ctx context.Context, cmd *command) context.Context 
 
 	if s.envelope == nil {
 		return s.replyEnhanced(ctx, 503, EnhancedCode{5, 5, 1}, "Missing MAIL FROM command.")
+	}
+
+	if s.chunk.started() {
+		return s.replyEnhanced(ctx, 503, EnhancedCode{5, 5, 1}, "Cannot add a recipient after BDAT")
 	}
 
 	if len(s.envelope.Recipients) >= s.server.MaxRecipients {

--- a/protocol.go
+++ b/protocol.go
@@ -360,7 +360,6 @@ func (s *session) handleSTARTTLS(ctx context.Context, cmd *command) context.Cont
 	s.conn = tlsConn
 	s.reader = bufio.NewReader(tlsConn)
 	s.writer = bufio.NewWriter(tlsConn)
-	s.scanner = bufio.NewScanner(s.reader)
 	s.tls = true
 
 	// Save connection state on peer

--- a/protocol.go
+++ b/protocol.go
@@ -130,6 +130,16 @@ func (s *session) parseRcptParams(params map[string]string) (RecipientDSN, error
 }
 
 func (s *session) handle(ctx context.Context, line string) context.Context {
+	// The handler of a chunked message runs while the session reads the next
+	// command. A panic in it ends the session, whatever that command is.
+	if s.chunk.started() {
+		if result, ok := s.chunk.poll(); ok {
+			if ctx, done := s.reportChunkPanic(ctx, &result); done {
+				return ctx
+			}
+		}
+	}
+
 	cmd, err := parseCommand(line)
 	if err != nil {
 		return s.replyEnhanced(ctx, 500, EnhancedCode{5, 5, 2}, "Invalid syntax.")

--- a/read_test.go
+++ b/read_test.go
@@ -1,0 +1,103 @@
+package smtpd
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// TestReadLine covers the reader that took the place of a bufio.Scanner. The
+// session reads its command lines and the chunks of BDAT from one reader, so
+// a line must leave the octets that follow it where they are.
+func TestReadLine(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    string
+		want  []string
+		rest  string
+		final error
+	}{
+		{
+			name:  "two lines",
+			in:    "EHLO one\r\nNOOP\r\n",
+			want:  []string{"EHLO one", "NOOP"},
+			final: io.EOF,
+		},
+		{
+			name:  "a line feed without a carriage return",
+			in:    "EHLO one\nNOOP\n",
+			want:  []string{"EHLO one", "NOOP"},
+			final: io.EOF,
+		},
+		{
+			name:  "an empty line",
+			in:    "\r\nNOOP\r\n",
+			want:  []string{"", "NOOP"},
+			final: io.EOF,
+		},
+		{
+			name:  "a last line without a line break",
+			in:    "EHLO one\r\nQUIT",
+			want:  []string{"EHLO one", "QUIT"},
+			final: io.EOF,
+		},
+		{
+			name: "the octets after the line stay where they are",
+			in:   "BDAT 5\r\nhelloNOOP\r\n",
+			want: []string{"BDAT 5"},
+			rest: "helloNOOP\r\n",
+		},
+		{
+			// The line break counts toward the bound, so the longest line
+			// that gets through is two octets shorter than it.
+			name:  "a line of the greatest length",
+			in:    strings.Repeat("b", maxLineLength-2) + "\r\n",
+			want:  []string{strings.Repeat("b", maxLineLength-2)},
+			final: io.EOF,
+		},
+		{
+			name:  "a line that is too long",
+			in:    strings.Repeat("b", maxLineLength) + "\r\n",
+			final: bufio.ErrTooLong,
+		},
+		{
+			name:  "a line without an end",
+			in:    strings.Repeat("b", 10),
+			want:  []string{strings.Repeat("b", 10)},
+			final: io.EOF,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := &session{reader: bufio.NewReader(strings.NewReader(test.in))}
+
+			for i, want := range test.want {
+				got, err := s.readLine()
+				if err != nil {
+					t.Fatalf("line %d: readLine() gave the error %v", i, err)
+				}
+				if got != want {
+					t.Fatalf("line %d: readLine() = %q, want %q", i, got, want)
+				}
+			}
+
+			if test.rest != "" {
+				rest, err := io.ReadAll(s.reader)
+				if err != nil {
+					t.Fatalf("read the rest: %v", err)
+				}
+				if string(rest) != test.rest {
+					t.Errorf("the reader holds %q, want %q", rest, test.rest)
+				}
+				return
+			}
+
+			if _, err := s.readLine(); !errors.Is(err, test.final) {
+				t.Errorf("the last readLine() gave %v, want %v", err, test.final)
+			}
+		})
+	}
+}

--- a/session.go
+++ b/session.go
@@ -2,10 +2,12 @@ package smtpd
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"runtime/debug"
@@ -21,15 +23,14 @@ type session struct {
 
 	conn net.Conn
 
-	reader  *bufio.Reader
-	writer  *bufio.Writer
-	scanner *bufio.Scanner
+	reader *bufio.Reader
+	writer *bufio.Writer
 
 	tls    bool
 	closed bool
 
 	// closeErr records the first non-nil I/O error that ended the session
-	// - TLS handshake failure, a terminal scanner error, or a DATA read
+	// - TLS handshake failure, a terminal read error, or a DATA read
 	// error. Middleware-level rejection errors are not recorded here;
 	// they already produced an SMTP reply. Surfaced to Disconnect hooks.
 	closeErr error
@@ -77,10 +78,65 @@ func (srv *Server) newSession(ctx context.Context, c net.Conn) (context.Context,
 		}
 	}
 
-	s.scanner = bufio.NewScanner(s.reader)
-
 	return ctx, s
 
+}
+
+// maxLineLength bounds one line from the client. RFC 5321 section 4.5.3.1
+// gives 512 octets for a command line and 1000 for a line of a message, and
+// the bound here is far above both, so that a long AUTH line or a long
+// address still gets through.
+//
+// Without a bound, a client that never writes a line break makes the server
+// hold the memory of a line without end.
+const maxLineLength = 64 * 1024
+
+// readLine reads one line from the client. It gives the line without the
+// line break at the end, in the way that bufio.ScanLines does: a "\n" ends
+// the line, and a "\r" before it belongs to the break.
+//
+// A line longer than maxLineLength ends with bufio.ErrTooLong. The line break
+// counts toward that length, because the bound is on what the server holds in
+// memory for one line.
+//
+// The session reads its lines here and not through a bufio.Scanner, because
+// a scanner reads ahead: it takes the octets that follow a line into a buffer
+// of its own, where nothing can read them again.
+func (s *session) readLine() (string, error) {
+	var line []byte
+
+	for {
+		part, err := s.reader.ReadSlice('\n')
+
+		if len(line)+len(part) > maxLineLength {
+			return "", bufio.ErrTooLong
+		}
+
+		// ReadSlice gives a window into the buffer of the reader, and the
+		// next read writes over it.
+		line = append(line, part...)
+
+		if errors.Is(err, bufio.ErrBufferFull) {
+			continue
+		}
+
+		if err != nil {
+			// A last line without a line break is still a command, which is
+			// how the scanner of the standard library reads it.
+			if errors.Is(err, io.EOF) && len(line) > 0 {
+				return string(trimLineBreak(line)), nil
+			}
+			return "", err
+		}
+
+		return string(trimLineBreak(line)), nil
+	}
+}
+
+// trimLineBreak takes the line break off the end of a line.
+func trimLineBreak(line []byte) []byte {
+	line = bytes.TrimSuffix(line, []byte("\n"))
+	return bytes.TrimSuffix(line, []byte("\r"))
 }
 
 func (s *session) serve(ctx context.Context) {
@@ -110,23 +166,28 @@ func (s *session) serve(ctx context.Context) {
 		ctx = s.welcome(ctx)
 	}
 
-	for s.scanner.Scan() {
-		line := s.scanner.Text()
+	for {
+		line, err := s.readLine()
+		if err != nil {
+			// A session that already finished through QUIT, or through a
+			// close from a handler, reads from a closed connection here.
+			// That error is not the one that ended the session.
+			if s.closed || errors.Is(err, io.EOF) {
+				return
+			}
+
+			s.setErr(err)
+			if errors.Is(err, bufio.ErrTooLong) {
+				ctx = s.replyEnhanced(ctx, 500, EnhancedCode{5, 5, 2}, "Line too long")
+			}
+			return
+		}
+
 		logger.DebugContext(ctx, "received", slog.String("line", redactLine(line)))
 		ctx = s.handle(ctx, line)
-	}
 
-	// Only inspect scanner.Err() if we didn't already finish via QUIT or
-	// a handler-initiated close - reading from an already-closed conn
-	// would otherwise clobber closeErr with a use-of-closed error.
-	if s.closed {
-		return
-	}
-
-	if err := s.scanner.Err(); err != nil {
-		s.setErr(err)
-		if errors.Is(err, bufio.ErrTooLong) {
-			ctx = s.replyEnhanced(ctx, 500, EnhancedCode{5, 5, 2}, "Line too long")
+		if s.closed {
+			return
 		}
 	}
 

--- a/session.go
+++ b/session.go
@@ -26,12 +26,16 @@ type session struct {
 	reader *bufio.Reader
 	writer *bufio.Writer
 
+	// chunk carries the message of a BDAT transfer while it arrives. It is
+	// nil outside such a transfer.
+	chunk *chunkTransfer
+
 	tls    bool
 	closed bool
 
 	// closeErr records the first non-nil I/O error that ended the session
-	// - TLS handshake failure, a terminal read error, or a DATA read
-	// error. Middleware-level rejection errors are not recorded here;
+	// - TLS handshake failure, a terminal read error, or an error while the
+	// message arrived. Middleware-level rejection errors are not recorded here;
 	// they already produced an SMTP reply. Surfaced to Disconnect hooks.
 	closeErr error
 }
@@ -87,8 +91,9 @@ func (srv *Server) newSession(ctx context.Context, c net.Conn) (context.Context,
 // the bound here is far above both, so that a long AUTH line or a long
 // address still gets through.
 //
-// Without a bound, a client that never writes a line break makes the server
-// hold the memory of a line without end.
+// The session reads the command lines and the chunks of BDAT from one
+// reader. Without a bound, a client that never writes a line break makes the
+// server hold the memory of a line without end.
 const maxLineLength = 64 * 1024
 
 // readLine reads one line from the client. It gives the line without the
@@ -100,8 +105,9 @@ const maxLineLength = 64 * 1024
 // memory for one line.
 //
 // The session reads its lines here and not through a bufio.Scanner, because
-// a scanner reads ahead: it takes the octets that follow a line into a buffer
-// of its own, where nothing can read them again.
+// a scanner reads ahead. The octets of a BDAT chunk follow the command line
+// on the same stream, and a scanner takes them into a buffer of its own,
+// where nothing can read them again.
 func (s *session) readLine() (string, error) {
 	var line []byte
 
@@ -199,6 +205,7 @@ func (s *session) reject(ctx context.Context) context.Context {
 }
 
 func (s *session) reset(ctx context.Context) context.Context {
+	s.stopChunk(errChunkAborted)
 	s.envelope = nil
 	ctx = s.server.reset(ctx, s.peer)
 	return contextWithoutSender(ctx)
@@ -344,6 +351,8 @@ func (s *session) extensions() []string {
 	extensions := []string{
 		fmt.Sprintf("SIZE %d", s.server.MaxMessageSize),
 		"8BITMIME",
+		"BINARYMIME",
+		"CHUNKING",
 		"PIPELINING",
 		"ENHANCEDSTATUSCODES",
 	}
@@ -369,17 +378,7 @@ func (s *session) extensions() []string {
 }
 
 func (s *session) deliver(ctx context.Context) (context.Context, error) {
-	var err error
-	for _, h := range s.server.handlers {
-		ctx, err = h(ctx, s.peer, s.envelope)
-		if err != nil {
-			return ctx, err
-		}
-	}
-	if s.server.Handler != nil {
-		return s.server.Handler(ctx, s.peer, s.envelope)
-	}
-	return ctx, nil
+	return s.server.deliver(ctx, s.peer, s.envelope)
 }
 
 func (s *session) close(ctx context.Context) context.Context {
@@ -387,6 +386,7 @@ func (s *session) close(ctx context.Context) context.Context {
 		return ctx
 	}
 	s.closed = true
+	s.stopChunk(errChunkAborted)
 	_ = s.writer.Flush()
 	s.notifyDisconnect(ctx)
 	_ = s.conn.Close()
@@ -397,11 +397,17 @@ func (s *session) close(ctx context.Context) context.Context {
 // the session and a 421 reply. The connection closes afterwards, so the
 // client does not continue on a session whose state is unknown.
 func (s *session) recovered(ctx context.Context, v any) context.Context {
-	err := PanicError{Value: v, Stack: debug.Stack()}
+	return s.reportPanic(ctx, PanicError{Value: v, Stack: debug.Stack()})
+}
+
+// reportPanic writes a panic to the log and tells the client. The handler of
+// a chunked message runs on a goroutine of its own and recovers its own
+// panic, so it arrives here as a value and not through recover.
+func (s *session) reportPanic(ctx context.Context, err PanicError) context.Context {
 	s.setErr(err)
 
 	LoggerFromContext(ctx).ErrorContext(ctx, "recovered a panic",
-		slog.Any("panic", v),
+		slog.Any("panic", err.Value),
 		slog.String("stack", string(err.Stack)),
 	)
 

--- a/session.go
+++ b/session.go
@@ -222,8 +222,23 @@ func (s *session) reject(ctx context.Context) context.Context {
 }
 
 func (s *session) reset(ctx context.Context) context.Context {
-	ctx, _ = s.reportChunkPanic(ctx, s.stopChunk(errChunkAborted))
+	result := s.stopChunk(errChunkAborted)
+
+	ctx, done := s.reportChunkPanic(ctx, result)
 	s.envelope = nil
+
+	if done {
+		// The panic closed the session, and the Disconnect hooks ran with
+		// it. A Reset hook after them would come out of order.
+		return contextWithoutSender(ctx)
+	}
+
+	// A handler that ended gives back a context, and what follows runs in
+	// that one.
+	if result != nil && result.ctx != nil {
+		ctx = result.ctx
+	}
+
 	ctx = s.server.reset(ctx, s.peer)
 	return contextWithoutSender(ctx)
 }
@@ -253,6 +268,13 @@ func (s *session) reply(ctx context.Context, code int, message string) context.C
 // zero value of enhanced leaves the status code out, which is what the
 // greeting and the reply to HELO and EHLO need.
 func (s *session) replyEnhanced(ctx context.Context, code int, enhanced EnhancedCode, message string) context.Context {
+	// A closed session has no reader on the other end. The write would go
+	// into a buffer that nothing flushes, and the reply that the client did
+	// read was the last one.
+	if s.closed {
+		return ctx
+	}
+
 	status := s.status(enhanced)
 	message = sanitizeReplyText(message)
 
@@ -278,6 +300,10 @@ func (s *session) replyEnhanced(ctx context.Context, code int, enhanced Enhanced
 //
 // The first line is a separate argument, so that a reply always has one.
 func (s *session) replyMultiline(ctx context.Context, code int, first string, rest ...string) context.Context {
+	if s.closed {
+		return ctx
+	}
+
 	logger := LoggerFromContext(ctx)
 
 	lines := append([]string{first}, rest...)

--- a/session.go
+++ b/session.go
@@ -33,6 +33,14 @@ type session struct {
 	tls    bool
 	closed bool
 
+	// readErr holds the error that ended the reading of the connection. A
+	// read that failed once fails from then on, in the way that a
+	// bufio.Scanner stops for good. Without that, an AUTH command whose
+	// continuation line is too long would leave the rest of that line in the
+	// reader, and the session would read the credentials of the client as
+	// commands.
+	readErr error
+
 	// closeErr records the first non-nil I/O error that ended the session
 	// - TLS handshake failure, a terminal read error, or an error while the
 	// message arrived. Middleware-level rejection errors are not recorded here;
@@ -104,18 +112,26 @@ const maxLineLength = 64 * 1024
 // counts toward that length, because the bound is on what the server holds in
 // memory for one line.
 //
+// A read that failed once fails from then on. The rest of a line that was too
+// long is still in the reader, and the session must not read it as commands.
+//
 // The session reads its lines here and not through a bufio.Scanner, because
 // a scanner reads ahead. The octets of a BDAT chunk follow the command line
 // on the same stream, and a scanner takes them into a buffer of its own,
 // where nothing can read them again.
 func (s *session) readLine() (string, error) {
+	if s.readErr != nil {
+		return "", s.readErr
+	}
+
 	var line []byte
 
 	for {
 		part, err := s.reader.ReadSlice('\n')
 
 		if len(line)+len(part) > maxLineLength {
-			return "", bufio.ErrTooLong
+			s.readErr = bufio.ErrTooLong
+			return "", s.readErr
 		}
 
 		// ReadSlice gives a window into the buffer of the reader, and the
@@ -132,6 +148,7 @@ func (s *session) readLine() (string, error) {
 			if errors.Is(err, io.EOF) && len(line) > 0 {
 				return string(trimLineBreak(line)), nil
 			}
+			s.readErr = err
 			return "", err
 		}
 
@@ -205,7 +222,7 @@ func (s *session) reject(ctx context.Context) context.Context {
 }
 
 func (s *session) reset(ctx context.Context) context.Context {
-	s.stopChunk(errChunkAborted)
+	ctx, _ = s.reportChunkPanic(ctx, s.stopChunk(errChunkAborted))
 	s.envelope = nil
 	ctx = s.server.reset(ctx, s.peer)
 	return contextWithoutSender(ctx)
@@ -386,7 +403,12 @@ func (s *session) close(ctx context.Context) context.Context {
 		return ctx
 	}
 	s.closed = true
-	s.stopChunk(errChunkAborted)
+
+	// The session is closed already, so reportChunkPanic writes no reply and
+	// the close inside it returns at once. The panic still reaches the log
+	// and the Disconnect hooks below.
+	ctx, _ = s.reportChunkPanic(ctx, s.stopChunk(errChunkAborted))
+
 	_ = s.writer.Flush()
 	s.notifyDisconnect(ctx)
 	_ = s.conn.Close()

--- a/session_fuzz_test.go
+++ b/session_fuzz_test.go
@@ -66,6 +66,11 @@ func FuzzSession(f *testing.F) {
 	f.Add("MAIL FROM:<\" \"@0> SIZE=1 SIZE=2\r\n", uint8(7))
 	f.Add("EHLO x\r\nMAIL FROM:<a@example.org> RET=HDRS ENVID=QQ+40314159\r\nRCPT TO:<b@example.net> NOTIFY=SUCCESS,DELAY ORCPT=rfc822;b+40example.net\r\nDATA\r\n.\r\nQUIT\r\n", uint8(8))
 	f.Add("EHLO x\r\nMAIL FROM:<a@example.org> ENVID=a+0D+0A\r\nRCPT TO:<b@example.net> NOTIFY=NEVER,SUCCESS\r\n", uint8(8))
+	f.Add("EHLO x\r\nMAIL FROM:<a@example.org>\r\nRCPT TO:<b@example.net>\r\nBDAT 5\r\nhelloBDAT 0 LAST\r\nQUIT\r\n", uint8(0))
+	f.Add("EHLO x\r\nMAIL FROM:<a@example.org> BODY=BINARYMIME\r\nRCPT TO:<b@example.net>\r\nBDAT 6 LAST\r\n\x00\x01\r\n.\r\nQUIT\r\n", uint8(0))
+	f.Add("EHLO x\r\nBDAT 4\r\nspamNOOP\r\nQUIT\r\n", uint8(0))
+	f.Add("EHLO x\r\nMAIL FROM:<a@example.org>\r\nRCPT TO:<b@example.net>\r\nBDAT 99999999\r\nshort\r\n", uint8(0))
+	f.Add("EHLO x\r\nMAIL FROM:<a@example.org>\r\nRCPT TO:<b@example.net>\r\nBDAT 3\r\nabcRSET\r\nBDAT 1 LAST\r\nz\r\n", uint8(0))
 
 	f.Fuzz(func(t *testing.T, script string, options uint8) {
 		srv := &Server{

--- a/smtpd.go
+++ b/smtpd.go
@@ -100,10 +100,16 @@ func (e PanicError) Error() string {
 }
 
 // Handler delivers a received message. It is the terminal stage of an SMTP
-// transaction: the server invokes Server.Handler once per accepted DATA
-// payload, after every middleware-contributed Handler stage has run. The
-// returned context replaces the session context for any subsequent commands
-// on the connection.
+// transaction: the server invokes Server.Handler once per accepted message,
+// after every middleware-contributed Handler stage has run. The returned
+// context replaces the session context for any subsequent commands on the
+// connection.
+//
+// A message that arrives in BDAT chunks starts its handlers with the first
+// chunk, on a goroutine of its own, and env.Data gives the chunks as they
+// arrive. A handler that reads env.Data to the end therefore waits for the
+// last chunk. The peer is the one of the moment the message started, because
+// the session goes on reading commands while the handler runs.
 //
 // A panic in a Handler stops that session only: the server logs it, replies
 // 421, closes the connection, and reports a PanicError to the Disconnect
@@ -115,18 +121,19 @@ type Handler func(ctx context.Context, peer Peer, env *Envelope) (context.Contex
 // registered via Server.Use, all non-nil hooks for a given phase run in Use
 // order; the first non-nil error short-circuits the phase.
 //
-// Handler is the middleware's pre-deliver stage. It runs after the DATA
-// payload has been received, before Server.Handler, and in series with every
-// other middleware Handler in Use order. Middlewares may mutate the envelope
+// Handler is the middleware's pre-deliver stage. It runs once the message
+// starts to arrive, before Server.Handler, and in series with every other
+// middleware Handler in Use order. Middlewares may mutate the envelope
 // - including replacing env.Data - to rewrite or enrich the message before
 // delivery. A non-nil error aborts the transaction: later middleware Handlers
 // and Server.Handler are not called. This is *not* an "around" wrapper; there
 // is no next to call, the server invokes each stage in sequence.
 type Middleware struct {
-	// Handler runs as a pre-deliver stage, after DATA has been received and
-	// before Server.Handler. nil = no contribution. Middlewares may mutate
-	// env, including replacing env.Data. The first non-nil error aborts
-	// delivery: subsequent middleware Handlers and Server.Handler are skipped.
+	// Handler runs as a pre-deliver stage, once the message starts to
+	// arrive and before Server.Handler. nil = no contribution. Middlewares
+	// may mutate env, including replacing env.Data. The first non-nil error
+	// aborts delivery: subsequent middleware Handlers and Server.Handler are
+	// skipped.
 	Handler Handler
 
 	// Per-phase hooks. nil = no contribution to that phase. Hooks run in
@@ -141,7 +148,7 @@ type Middleware struct {
 	// Disconnect runs exactly once per session, after the final reply is
 	// flushed and before the underlying connection is closed. err is nil
 	// when the session ended cleanly (QUIT or server shutdown) and non-nil
-	// when a TLS handshake, scanner, or DATA read error terminated it.
+	// when a TLS handshake, a read, or a DATA read error terminated it.
 	// Middleware-level rejections (CheckConnection, CheckSender, etc.) are
 	// reported as clean ends - they already produced an SMTP reply.
 	Disconnect func(ctx context.Context, peer Peer, err error)
@@ -328,6 +335,23 @@ func (srv *Server) reset(ctx context.Context, peer Peer) context.Context {
 		ctx = h(ctx, peer)
 	}
 	return ctx
+}
+
+// deliver runs every middleware Handler and then Server.Handler. The peer
+// comes as an argument, because a chunked message runs the handlers on a
+// goroutine of its own, where the peer of the session can change under them.
+func (srv *Server) deliver(ctx context.Context, peer Peer, env *Envelope) (context.Context, error) {
+	var err error
+	for _, h := range srv.handlers {
+		ctx, err = h(ctx, peer, env)
+		if err != nil {
+			return ctx, err
+		}
+	}
+	if srv.Handler != nil {
+		return srv.Handler(ctx, peer, env)
+	}
+	return ctx, nil
 }
 
 func (srv *Server) disconnect(ctx context.Context, peer Peer, err error) {


### PR DESCRIPTION
## What this does

Adds `CHUNKING` with the `BDAT` command and `BINARYMIME`, from
[RFC 3030](https://www.rfc-editor.org/rfc/rfc3030). The server offers both
keywords in the reply to `EHLO`, and there is nothing to turn on, in the same
way as for `PIPELINING` and `8BITMIME`.

```
C: BDAT 24
S: 250 2.0.0 24 octets received
C: BDAT 12 LAST
S: 250 2.0.0 Message OK, 36 octets received
```

## The reader comes first

The first commit stands on its own. The session read its command lines through
a `bufio.Scanner`, and a scanner reads ahead: it takes the octets that follow a
line into a buffer of its own, where nothing can read them again. The octets of
a `BDAT` chunk follow the command line on the same stream, so the session now
reads its lines from the reader of the connection.

`readLine` keeps what the scanner did. A `\n` ends a line, a `\r` before it
belongs to the break, a last line without a break is still a command, and a
line longer than 64 KB ends with `bufio.ErrTooLong`.

A read that fails once fails from then on, which a scanner also does. Without
that rule, the credentials line of an `AUTH` command that was too long left the
rest of itself in the reader, and the session read what followed as commands: a
client could write a command behind its credentials and have the server run it.
`TestAUTHContinuationTooLongEndsTheSession` holds the rule.

One thing changes for the better: a message that a client sends in the same
write as its `DATA` command now arrives whole. The scanner took those octets
where the reader of the body could not reach them. RFC 2920 tells a client to
wait for the `354` reply, so this reached only a client that does not.

## How the chunks reach the handler

`Envelope.Data` streams them. The handler starts with the first chunk, on a
goroutine of its own, and reads the message through the rest of the transfer,
so a chunked message is never held in memory as a whole. The session writes
each chunk into a pipe and waits for the handler at `BDAT LAST`.

The goroutine always ends. After the handler returns, it reads what the
handler left, so a `Server.Handler` of nil works as it does for `DATA`. The
session closes the write end at the last chunk, at `RSET`, and when the
session goes away.

A transfer that ends before the last chunk gives the handler an error in the
place of the rest of the message, so half a message never looks whole to it.

The session and the handler never read the same memory at the same time. A
middleware may write to the envelope, so the session reads the envelope where
the transfer begins and nowhere after that: `RCPT TO` and `DATA` both answer
`503` to a transaction that saw a `BDAT`, before either of them looks inside.
The handler reads a snapshot of the peer for the same reason.

Two contracts of the library hold for a chunked message as well:

- A panic in the handler gives the client `421`, closes the session and reaches
  the Disconnect hooks as a `PanicError`. The handler recovers its own panic on
  its goroutine, and every command looks for a handler that ended, so the panic
  answers whichever command comes next.

- The context that the handler gives back holds for the commands that follow,
  including the commands between an early return and `BDAT LAST`.

## The rules of RFC 3030

| The client sends | The server answers |
| --- | --- |
| `BDAT` before `RCPT TO` | `503`, after it read the chunk off the wire |
| a chunk that takes the message past `MaxMessageSize` | `552`, and every chunk after it gets the same answer |
| `DATA` after `BDAT` in one transaction | `503` |
| `DATA` for a `BODY=BINARYMIME` message | `503` |
| `RCPT TO` after any `BDAT` of the transaction | `503` |
| `BDAT 5 FIRST`, where the length reads but the rest does not | `501`, after it read the five octets |
| `BDAT plenty`, where the length does not read | `501`, and the connection closes |

A refused chunk still comes off the wire. A chunk that stays there is read as
commands. The connection closes for a `BDAT` whose length cannot be read,
because nothing then says where the chunk ends, and for a chunk longer than
twice `MaxMessageSize`, because reading it costs without bound.

## BINARYMIME

`Envelope.BodyType` holds the `BODY` parameter of `MAIL FROM`, as one of
`Body7Bit`, `Body8BitMIME` and `BodyBinaryMIME`. It is empty when the client
sent no such parameter.

## Tests

| Test | What it covers |
| --- | --- |
| `TestReadLine` | The reader that took the place of the scanner, and that a chunk stays in the buffer after its command line. |
| `TestBdatArg` | The chunk size and the `LAST` mark. |
| `TestBDATDelivers` | One chunk, three chunks, an empty message, binary octets, and a line with one dot on it. |
| `TestBDATKeepsTheStreamInSync` | A `NOOP` after each kind of refusal still reads as a command. |
| `TestBDATRefusesEveryChunkAfterAFailure` | The chunks after a `552`, and `RSET` for a transaction that works again. |
| `TestBDATAndDATADoNotMix` | `DATA` after `BDAT`, and `DATA` for a `BINARYMIME` message. |
| `TestBDATStopsTheHandlerOnRSET` | The handler reads an error in the place of the rest. |
| `TestBDATHandlerPanicClosesTheSession` | `421`, and the `PanicError` in the Disconnect hook with the stack of the frame that panicked. |
| `TestBDATLeavesNoGoroutine` | 20 sessions that go away in the middle of a message. |
| `TestBDATSyntaxErrorKeepsTheSession` | `BDAT 5 FIRST` takes its five octets, and the session goes on. |
| `TestBDATRefusedFirstChunkClosesTheTransaction` | `RCPT TO` and `DATA` after a chunk that the server refused. |
| `TestBDATPanicReachesTheHookAfterRSET` | A panic that lands on the command after the chunk still ends the session. |
| `TestBDATPanicSkipsTheResetHook` | A Reset hook does not run after the Disconnect hooks. |
| `TestBDATHandlerContextReachesLaterCommands` | The context of a handler that ended early reaches the next command. |
| `TestAUTHContinuationTooLongEndsTheSession` | A command written behind the credentials does not run. |
| `FuzzSession` | Six BDAT scripts. 3 million sessions in 90 seconds found no panic and no session that does not end. |

## Speed

A message through `BDAT` costs the server much less than the same message
through `DATA`. The numbers below come from one 8-core arm64 machine, over the
loopback interface, with the client and the server in the same process. The
benchmark stays out of the branch.

| Body | DATA | BDAT | Ratio |
| --- | --- | --- | --- |
| 64 KB | 98 MB/s (669 us) | 381 MB/s (172 us) | 3.9x |
| 1 MB | 86 MB/s (12.2 ms) | 1719 MB/s (0.61 ms) | 20x |
| 8 MB | 136 MB/s (61.5 ms) | 2599 MB/s (3.2 ms) | 19x |

A body with a stuffed dot on every tenth line lands inside the noise of these.

The work behind those numbers, for one message of 8 MB:

| Work | Cost |
| --- | --- |
| The client stuffs the dots (`textproto.DotWriter`) | 33.7 ms |
| The server takes the stuffing out (`textproto.DotReader`) | 44.1 ms |
| The server copies a chunk into the pipe (`BDAT`) | 1.5 ms |

The server alone therefore goes from 44 ms to 1.5 ms for the same message. The
rest of the difference is the work of the client, which shares the cores of the
machine in this benchmark.

Two things to read with the numbers:

- They measure `net/textproto`, which reads and writes the dots one byte at a
  time. The difference is that code as much as it is the protocol. It is still
  the cost that this library pays, because `handleDATA` reads the body through
  `textproto.DotReader`.

- The loopback hides the other gain. `DATA` waits for a `354` reply before the
  body, and `BDAT` does not. That wait costs nothing here and costs real
  milliseconds over a long path. It shows a little in the row of 64 KB, where
  the transfer is too short to cover it.

The benchmark also found a buffer that the last commit takes out. `io.CopyN`
allocated one for every chunk, so a message of 1 MB in chunks of 1 KB took
1.7 MB of them. One buffer for each transfer brings that to 0.67 MB.

For a client, the size of the chunk is what matters most. A message of 1 MB in
chunks of 1 KB costs 1024 round trips, and the rate falls to about 30 MB/s.

## The race detector

`go test -race` does not run on my machine: the sanitizer stops with
`unsupported VMA range`, on the tests that were here before as well. CI runs
it, and it passes. That matters more for this change than for most, because it
adds the first goroutine in the path of a message.

