### PR TITLE
feat: offer SMTPUTF8 for addresses of Unicode (RFC 6531)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,11 +37,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `553 5.6.7`. Without `EnableSMTPUTF8`, the server answers `555` to the
   parameter and reads an address as it did before.
 
-  An `ORCPT` parameter of the `utf-8` address type now decodes with the
-  encoding of RFC 6533, where `\x{HEX}` holds one code point. RFC 6531 asks for
-  that address type from a server that offers `DSN` next to `SMTPUTF8`. A
-  transaction with the parameter takes the bytes of the address as they came,
-  and every other one needs the escape.
+  A server with `EnableSMTPUTF8` reads an `ORCPT` parameter of the `utf-8`
+  address type with the encoding of RFC 6533, where `\x{HEX}` holds one code
+  point. RFC 6531 asks for that address type from a server that offers `DSN`
+  next to `SMTPUTF8`. A transaction with the parameter takes the bytes of the
+  address as they came, and every other one needs the escape.
+
+  A server without `EnableSMTPUTF8` reads that value as ordinary xtext, in the
+  way that it did before.
 
 - The server offers `CHUNKING` and takes a message in chunks with the `BDAT`
   command of RFC 3030. There is nothing to turn on, in the same way as for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Server.EnableSMTPUTF8` offers the `SMTPUTF8` extension of RFC 6531 and takes
+  its parameter on `MAIL FROM`. Such a transaction carries an address of
+  Unicode in UTF-8, in the local part and in the domain, and
+  `Envelope.SMTPUTF8` tells the handler that it did.
+
+  The extension is off by default, in the same way as `DSN`. A server that
+  offers it says that it carries such a message onward, and the next server on
+  the way has to offer the extension as well.
+
+  A server that offers it holds every other transaction to US-ASCII: a
+  non-ASCII sender without the parameter gets `550 5.6.7`, and a recipient gets
+  `553 5.6.7`. Without `EnableSMTPUTF8`, the server answers `555` to the
+  parameter and reads an address as it did before.
+
+  An `ORCPT` parameter of the `utf-8` address type now decodes with the
+  encoding of RFC 6533, where `\x{HEX}` holds one code point. RFC 6531 asks for
+  that address type from a server that offers `DSN` next to `SMTPUTF8`. A
+  transaction with the parameter takes the bytes of the address as they came,
+  and every other one needs the escape.
+
 - The server offers `CHUNKING` and takes a message in chunks with the `BDAT`
   command of RFC 3030. There is nothing to turn on, in the same way as for
   `PIPELINING` and `8BITMIME`.
@@ -76,6 +96,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fails, and `5.7.24` for an error in the check.
 
 ### Changed
+
+- The parser of a `MAIL FROM` and `RCPT TO` command takes a parameter keyword
+  that comes without a value, which is the form of the `SMTPUTF8` parameter.
+  RFC 5321 section 4.1.2 writes the value as an optional part.
+
+  A keyword with an `=` sign and nothing after it is still an error. A known
+  keyword that needs a value and comes without one gets a `501` reply from the
+  parameter reader, where the command parser refused it before. Both replies
+  carry the same code.
 
 - The session reads its command lines from the reader of the connection, where
   it read them through a `bufio.Scanner` before. A read that fails once fails

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Features
   ([RFC 3030](https://www.rfc-editor.org/rfc/rfc3030))
 * DSN parameters ([RFC 3461](https://www.rfc-editor.org/rfc/rfc3461)), off by
   default
+* `SMTPUTF8` for addresses of Unicode
+  ([RFC 6531](https://www.rfc-editor.org/rfc/rfc6531)), off by default
 * [XCLIENT](http://www.postfix.org/XCLIENT_README.html) and the
   [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
 * Per-phase middleware: connection, HELO, MAIL FROM, RCPT TO, AUTH, DATA,
@@ -104,8 +106,10 @@ relay can write the value into a command of its own.
 | `MAIL FROM:<user@example.org>` | `user@example.org` |
 | `MAIL FROM:<"a b"@example.org>` | `"a b"@example.org` |
 | `MAIL FROM:<>` | `""` (the null sender) |
+| `MAIL FROM:<jörg@example.org> SMTPUTF8` | `jörg@example.org` |
 
-The server answers `501` for an address that carries a line break.
+The server answers `501` for an address that carries a line break. An address
+of Unicode needs `Server.EnableSMTPUTF8`. See [SMTPUTF8](#smtputf8).
 
 ### Delivery handlers
 
@@ -356,6 +360,75 @@ where `+` starts a byte written as two hexadecimal digits. The server decodes
 them, so `ENVID=QQ+40314159` gives `QQ@314159`. A value that breaks the
 encoding gets a `501` reply, and so does a byte outside printable US-ASCII.
 That check keeps a line break out of the command that a relay writes next.
+
+An `ORCPT` of the `utf-8` address type carries an address of Unicode, and it
+takes the encoding of
+[RFC 6533](https://www.rfc-editor.org/rfc/rfc6533) instead, where `\x{HEX}`
+holds one code point. The server decodes that one too, so
+`ORCPT=utf-8;j\x{00F6}rg@example.net` gives `jörg@example.net`. A transaction
+with the `SMTPUTF8` parameter takes the bytes of the address as they came, and
+every other one needs the escape.
+
+### SMTPUTF8
+
+Set `Server.EnableSMTPUTF8` to offer the SMTPUTF8 extension of
+[RFC 6531](https://www.rfc-editor.org/rfc/rfc6531). A client that sends the
+`SMTPUTF8` parameter with `MAIL FROM` can then write an address of Unicode in
+UTF-8, in the local part and in the domain. The server offers `8BITMIME` next
+to the keyword, which RFC 6531 section 3.1 asks for.
+
+```
+C: MAIL FROM:<jörg@example.org> SMTPUTF8
+S: 250 2.1.0 Go ahead
+C: RCPT TO:<用户@例子.广告>
+S: 250 2.1.5 Go ahead
+```
+
+The parameter takes no value, and `Envelope.SMTPUTF8` tells the handler that
+the transaction carried it. The message itself can hold headers in UTF-8, and
+the server streams it as it does every other message.
+
+```go
+srv := &smtpd.Server{
+    EnableSMTPUTF8: true,
+
+    Handler: func(ctx context.Context, peer smtpd.Peer, env *smtpd.Envelope) (context.Context, error) {
+        defer func() { _ = env.Data.Close() }()
+
+        if env.SMTPUTF8 {
+            log.Printf("an internationalized message from %s", env.Sender)
+        }
+
+        return ctx, deliver(env)
+    },
+}
+```
+
+The extension is off by default. A server that offers it says that it carries
+such a message onward, and the next server on the way has to offer the
+extension as well. Turn it on where the handler keeps the message, or where it
+relays to a server that takes one.
+
+A server that offers the extension holds every other transaction to US-ASCII.
+RFC 6531 section 3.5 gives the two replies:
+
+| The client sends | The reply |
+| --- | --- |
+| `MAIL FROM:<jörg@example.org>` | `550 5.6.7` |
+| `RCPT TO:<用户@example.net>` | `553 5.6.7` |
+
+An address in such a transaction has to be UTF-8. A byte outside that encoding
+gets a `501` reply.
+
+Without `EnableSMTPUTF8`, the server answers `555` to the parameter and reads
+an address as it did before.
+
+The server looks up no domain of its own, so it keeps an address as the client
+wrote it. A domain of Unicode reaches the handler and the middleware in the
+U-label form. RFC 6531 section 3.2 asks the party that looks a domain up in
+the DNS to convert it to the A-label form first, which the SPF middleware and
+a handler that relays the message have to do. Read
+[RFC 5890](https://www.rfc-editor.org/rfc/rfc5890) for the two forms.
 
 ### Panics
 

--- a/README.md
+++ b/README.md
@@ -364,10 +364,15 @@ That check keeps a line break out of the command that a relay writes next.
 An `ORCPT` of the `utf-8` address type carries an address of Unicode, and it
 takes the encoding of
 [RFC 6533](https://www.rfc-editor.org/rfc/rfc6533) instead, where `\x{HEX}`
-holds one code point. The server decodes that one too, so
-`ORCPT=utf-8;j\x{00F6}rg@example.net` gives `jörg@example.net`. A transaction
-with the `SMTPUTF8` parameter takes the bytes of the address as they came, and
-every other one needs the escape.
+holds one code point. A server with `Server.EnableSMTPUTF8` decodes that one
+too, so `ORCPT=utf-8;j\x{00F6}rg@example.net` gives `jörg@example.net`. A
+transaction with the `SMTPUTF8` parameter takes the bytes of the address as
+they came, and every other one needs the escape.
+
+Without `EnableSMTPUTF8`, the server reads the value as ordinary xtext, in the
+way that it did before, and the escape reaches the handler as it came. RFC
+6531 section 3.2 asks for the address type from a server that offers `DSN`
+next to `SMTPUTF8`, and this one offers neither.
 
 ### SMTPUTF8
 

--- a/address.go
+++ b/address.go
@@ -100,3 +100,15 @@ func isAtext(c byte) bool {
 	}
 	return strings.IndexByte("!#$%&'*+-/=?^_`{|}~", c) >= 0
 }
+
+// isASCII reports whether s keeps to US-ASCII. RFC 5321 gives a mailbox in
+// that character set, and RFC 6531 widens it to UTF-8 for a transaction that
+// carries the SMTPUTF8 parameter.
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
+}

--- a/command.go
+++ b/command.go
@@ -120,6 +120,13 @@ func (cmd *command) parsePath(src string) (path, rest string, ok bool) {
 	return src, "", true
 }
 
+// parseESMTPParams reads the parameters that follow the path of a MAIL FROM
+// or RCPT TO command. RFC 5321 section 4.1.2 writes a parameter as a keyword
+// with an optional value after an "=" sign.
+//
+// A keyword that came alone gets the empty string, in the way that the
+// SMTPUTF8 parameter of RFC 6531 arrives. A keyword with an "=" and nothing
+// after it is an error: the grammar asks for one character or more there.
 func (cmd *command) parseESMTPParams(src string) (map[string]string, error) {
 	src = strings.TrimSpace(src)
 	if src == "" {
@@ -136,8 +143,8 @@ func (cmd *command) parseESMTPParams(src string) (map[string]string, error) {
 		if _, dup := params[name]; dup {
 			return nil, cmd.syntaxError("duplicate parameter")
 		}
-		if !hasValue || value == "" {
-			return nil, cmd.syntaxError("missing parameter value")
+		if hasValue && value == "" {
+			return nil, cmd.syntaxError("empty parameter value")
 		}
 		params[name] = value
 	}

--- a/command_fuzz_test.go
+++ b/command_fuzz_test.go
@@ -54,10 +54,13 @@ func FuzzParseCommand(f *testing.F) {
 //   - The parser never panics.
 //   - A path that starts with "<" also ends with ">".
 //   - A path without those marks carries no space.
-//   - Every parameter has an upper case name and a value.
+//   - Every parameter has an upper case name.
+//   - No parameter carries a space in its name or its value.
 //
 // A path that keeps a space reaches parseAddress, and a parameter name in
-// lower case misses the switch in validateMailParams.
+// lower case misses the switch in validateMailParams. A parameter with an
+// empty value is one that came without an "=" sign, which is how the
+// SMTPUTF8 parameter of RFC 6531 arrives.
 func FuzzPathArg(f *testing.F) {
 	f.Add("MAIL", "FROM:<a@example.org>")
 	f.Add("MAIL", "FROM:<a@example.org> SIZE=100")
@@ -100,9 +103,6 @@ func FuzzPathArg(f *testing.F) {
 			}
 			if name != strings.ToUpper(name) {
 				t.Errorf("pathArg(%q, %q) gave the parameter name %q, which is not upper case", keyword, arg, name)
-			}
-			if value == "" {
-				t.Errorf("pathArg(%q, %q) gave the parameter %q an empty value", keyword, arg, name)
 			}
 			if strings.ContainsAny(name+value, " \t") {
 				t.Errorf("pathArg(%q, %q) gave the parameter %q=%q, which carries a space", keyword, arg, name, value)

--- a/command_test.go
+++ b/command_test.go
@@ -79,6 +79,16 @@ func TestCommandPathArg(t *testing.T) {
 			wantPath:   "recipient@example.net",
 			wantParams: nil,
 		},
+		{
+			name:     "a parameter without a value",
+			arg:      "FROM: <test@example.org> SMTPUTF8 BODY=8BITMIME",
+			keyword:  "FROM",
+			wantPath: "<test@example.org>",
+			wantParams: map[string]string{
+				"SMTPUTF8": "",
+				"BODY":     "8BITMIME",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -116,7 +126,6 @@ func TestCommandPathArgRejectsInvalidInput(t *testing.T) {
 		{name: "missing colon", arg: "FROM <test@example.org>"},
 		{name: "missing path", arg: "FROM:"},
 		{name: "unterminated path", arg: "FROM:<test@example.org"},
-		{name: "missing parameter value", arg: "FROM:<test@example.org> SIZE"},
 		{name: "empty parameter value", arg: "FROM:<test@example.org> SIZE="},
 		{name: "duplicate parameter", arg: "FROM:<test@example.org> SIZE=1 SIZE=2"},
 		{name: "missing keyword", arg: "TO:<test@example.org>"},

--- a/dsn.go
+++ b/dsn.go
@@ -49,7 +49,9 @@ type RecipientDSN struct {
 	Notify DSNNotify
 
 	// OriginalRecipient is the address of the ORCPT parameter, decoded from
-	// xtext, or from the encoding of RFC 6533 where OriginalType is "utf-8".
+	// xtext. A server with Server.EnableSMTPUTF8 reads the encoding of RFC
+	// 6533 instead where OriginalType is "utf-8".
+	//
 	// It holds the recipient as the first sender wrote it, which a forward or
 	// an alias along the way can have changed since.
 	//
@@ -173,15 +175,21 @@ func parseNotify(value string) (DSNNotify, bool) {
 // holds the value to 500 characters.
 //
 // The "utf-8" address type of RFC 6533 carries an address of Unicode, and it
-// takes an encoding of its own where "\x{HEX}" holds a code point. smtputf8
-// says that the transaction carries the SMTPUTF8 parameter, which lets such
-// an address hold UTF-8 as it is. RFC 6531 section 3.2 asks for this address
-// type from a server that offers both extensions.
+// takes an encoding of its own where "\x{HEX}" holds a code point. RFC 6531
+// section 3.2 asks for this address type from a server that offers both
+// extensions, so two flags say how to read it:
+//
+//   - utf8Type says that the server offers SMTPUTF8 and reads the address
+//     type. A server without the extension takes the value as ordinary
+//     xtext, in the way that it did before RFC 6533.
+//   - raw says that the transaction carries the SMTPUTF8 parameter, which
+//     lets the address hold UTF-8 as it is. RFC 6533 section 3 asks every
+//     other client for the escape.
 //
 // The address is empty when the client writes an address type and a
 // semicolon alone. RFC 3461 gives xtext as a string of no length or more,
 // which makes that value a good one.
-func parseORcpt(value string, smtputf8 bool) (addrType, addr string, ok bool) {
+func parseORcpt(value string, utf8Type, raw bool) (addrType, addr string, ok bool) {
 	if len(value) > maxORcptLength {
 		return "", "", false
 	}
@@ -191,8 +199,8 @@ func parseORcpt(value string, smtputf8 bool) (addrType, addr string, ok bool) {
 		return "", "", false
 	}
 
-	if strings.EqualFold(addrType, utf8AddrType) {
-		addr, ok = parseUnitext(encoded, smtputf8)
+	if utf8Type && strings.EqualFold(addrType, utf8AddrType) {
+		addr, ok = parseUnitext(encoded, raw)
 	} else {
 		addr, ok = parseXtext(encoded)
 	}

--- a/dsn.go
+++ b/dsn.go
@@ -49,8 +49,9 @@ type RecipientDSN struct {
 	Notify DSNNotify
 
 	// OriginalRecipient is the address of the ORCPT parameter, decoded from
-	// xtext. It holds the recipient as the first sender wrote it, which a
-	// forward or an alias along the way can have changed since.
+	// xtext, or from the encoding of RFC 6533 where OriginalType is "utf-8".
+	// It holds the recipient as the first sender wrote it, which a forward or
+	// an alias along the way can have changed since.
 	//
 	// RFC 3461 lets the address be empty, so OriginalType is the field that
 	// tells you whether the client sent an ORCPT parameter.
@@ -112,6 +113,10 @@ const (
 	// maxORcptLength is the length that RFC 3461 section 4.2 gives for the
 	// value of the ORCPT parameter.
 	maxORcptLength = 500
+
+	// utf8AddrType is the address type that RFC 6533 section 3 gives to an
+	// ORCPT parameter that carries an address of Unicode.
+	utf8AddrType = "utf-8"
 )
 
 // parseDSNReturn reads the RET parameter of MAIL FROM. RFC 3461 section 4.3
@@ -167,10 +172,16 @@ func parseNotify(value string) (DSNNotify, bool) {
 // writes it as an address type, a semicolon and the address in xtext, and
 // holds the value to 500 characters.
 //
+// The "utf-8" address type of RFC 6533 carries an address of Unicode, and it
+// takes an encoding of its own where "\x{HEX}" holds a code point. smtputf8
+// says that the transaction carries the SMTPUTF8 parameter, which lets such
+// an address hold UTF-8 as it is. RFC 6531 section 3.2 asks for this address
+// type from a server that offers both extensions.
+//
 // The address is empty when the client writes an address type and a
 // semicolon alone. RFC 3461 gives xtext as a string of no length or more,
 // which makes that value a good one.
-func parseORcpt(value string) (addrType, addr string, ok bool) {
+func parseORcpt(value string, smtputf8 bool) (addrType, addr string, ok bool) {
 	if len(value) > maxORcptLength {
 		return "", "", false
 	}
@@ -180,7 +191,11 @@ func parseORcpt(value string) (addrType, addr string, ok bool) {
 		return "", "", false
 	}
 
-	addr, ok = parseXtext(encoded)
+	if strings.EqualFold(addrType, utf8AddrType) {
+		addr, ok = parseUnitext(encoded, smtputf8)
+	} else {
+		addr, ok = parseXtext(encoded)
+	}
 	if !ok {
 		return "", "", false
 	}

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -106,14 +106,15 @@ func TestParseNotify(t *testing.T) {
 	}
 }
 
-// TestParseORcpt covers the ORCPT parameter of RCPT TO. smtputf8 says that
-// the transaction carries the SMTPUTF8 parameter, which the "utf-8" address
-// type of RFC 6533 reads.
+// TestParseORcpt covers the ORCPT parameter of RCPT TO. utf8Type says that the
+// server reads the "utf-8" address type of RFC 6533, and raw that the
+// transaction carries the SMTPUTF8 parameter.
 func TestParseORcpt(t *testing.T) {
 	tests := []struct {
 		name     string
 		in       string
-		smtputf8 bool
+		utf8Type bool
+		raw      bool
 		wantType string
 		wantAddr string
 		ok       bool
@@ -155,6 +156,7 @@ func TestParseORcpt(t *testing.T) {
 		{
 			name:     "a utf-8 address type with an escape",
 			in:       `utf-8;j\x{00F6}rg@example.org`,
+			utf8Type: true,
 			wantType: "utf-8",
 			wantAddr: "jörg@example.org",
 			ok:       true,
@@ -162,6 +164,7 @@ func TestParseORcpt(t *testing.T) {
 		{
 			name:     "a utf-8 address type in upper case",
 			in:       `UTF-8;\x{5C}@example.org`,
+			utf8Type: true,
 			wantType: "UTF-8",
 			wantAddr: `\@example.org`,
 			ok:       true,
@@ -169,7 +172,8 @@ func TestParseORcpt(t *testing.T) {
 		{
 			name:     "a utf-8 address type with the bytes as they came",
 			in:       "utf-8;jörg@example.org",
-			smtputf8: true,
+			utf8Type: true,
+			raw:      true,
 			wantType: "utf-8",
 			wantAddr: "jörg@example.org",
 			ok:       true,
@@ -177,6 +181,7 @@ func TestParseORcpt(t *testing.T) {
 		{
 			name:     "a utf-8 address type outside the basic plane",
 			in:       `utf-8;\x{1F600}@example.org`,
+			utf8Type: true,
 			wantType: "utf-8",
 			wantAddr: "\U0001F600@example.org",
 			ok:       true,
@@ -184,18 +189,29 @@ func TestParseORcpt(t *testing.T) {
 		{
 			name:     "a utf-8 address type and a semicolon alone",
 			in:       "utf-8;",
+			utf8Type: true,
 			wantType: "utf-8",
 			ok:       true,
 		},
-		{name: "utf-8 bytes without the SMTPUTF8 parameter", in: "utf-8;jörg@example.org"},
-		{name: "a utf-8 address type with a line break in the escape", in: `utf-8;user\x{0D}\x{0A}@example.org`, smtputf8: true},
-		{name: "a utf-8 address type with a surrogate half", in: `utf-8;\x{D800}@example.org`, smtputf8: true},
-		{name: "a utf-8 address type with a code point that is too high", in: `utf-8;\x{110000}@example.org`, smtputf8: true},
-		{name: "a utf-8 address type with an escape that does not close", in: `utf-8;\x{00F6@example.org`},
-		{name: "a utf-8 address type with one digit", in: `utf-8;\x{F}@example.org`},
-		{name: "a utf-8 address type with a bare backslash", in: `utf-8;a\b@example.org`},
-		{name: "a utf-8 address type with a bare equals sign", in: "utf-8;a=b@example.org"},
-		{name: "a utf-8 address type with a byte that is not UTF-8", in: "utf-8;a\xffb@example.org", smtputf8: true},
+		{
+			// A server that does not offer SMTPUTF8 reads the value as the
+			// xtext of RFC 3461, in the way that it did before RFC 6533.
+			name:     "a utf-8 address type on a server without the extension",
+			in:       `utf-8;j\x{00F6}rg@example.org`,
+			wantType: "utf-8",
+			wantAddr: `j\x{00F6}rg@example.org`,
+			ok:       true,
+		},
+		{name: "utf-8 bytes on a server without the extension", in: "utf-8;jörg@example.org"},
+		{name: "utf-8 bytes without the SMTPUTF8 parameter", in: "utf-8;jörg@example.org", utf8Type: true},
+		{name: "a utf-8 address type with a line break in the escape", in: `utf-8;user\x{0D}\x{0A}@example.org`, utf8Type: true, raw: true},
+		{name: "a utf-8 address type with a surrogate half", in: `utf-8;\x{D800}@example.org`, utf8Type: true, raw: true},
+		{name: "a utf-8 address type with a code point that is too high", in: `utf-8;\x{110000}@example.org`, utf8Type: true, raw: true},
+		{name: "a utf-8 address type with an escape that does not close", in: `utf-8;\x{00F6@example.org`, utf8Type: true},
+		{name: "a utf-8 address type with one digit", in: `utf-8;\x{F}@example.org`, utf8Type: true},
+		{name: "a utf-8 address type with a bare backslash", in: `utf-8;a\b@example.org`, utf8Type: true},
+		{name: "a utf-8 address type with a bare equals sign", in: "utf-8;a=b@example.org", utf8Type: true},
+		{name: "a utf-8 address type with a byte that is not UTF-8", in: "utf-8;a\xffb@example.org", utf8Type: true, raw: true},
 		{name: "no semicolon", in: "rfc822"},
 		{name: "no address type", in: ";user@example.org"},
 		{name: "an address type that is not an atom", in: "rfc 822;user@example.org"},
@@ -206,12 +222,13 @@ func TestParseORcpt(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			addrType, addr, ok := parseORcpt(test.in, test.smtputf8)
+			addrType, addr, ok := parseORcpt(test.in, test.utf8Type, test.raw)
 			if ok != test.ok {
-				t.Fatalf("parseORcpt(%q, %v) ok = %v, want %v", test.in, test.smtputf8, ok, test.ok)
+				t.Fatalf("parseORcpt(%q, %v, %v) ok = %v, want %v", test.in, test.utf8Type, test.raw, ok, test.ok)
 			}
 			if addrType != test.wantType || addr != test.wantAddr {
-				t.Errorf("parseORcpt(%q, %v) = %q, %q, want %q, %q", test.in, test.smtputf8, addrType, addr, test.wantType, test.wantAddr)
+				t.Errorf("parseORcpt(%q, %v, %v) = %q, %q, want %q, %q",
+					test.in, test.utf8Type, test.raw, addrType, addr, test.wantType, test.wantAddr)
 			}
 		})
 	}

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -106,11 +106,14 @@ func TestParseNotify(t *testing.T) {
 	}
 }
 
-// TestParseORcpt covers the ORCPT parameter of RCPT TO.
+// TestParseORcpt covers the ORCPT parameter of RCPT TO. smtputf8 says that
+// the transaction carries the SMTPUTF8 parameter, which the "utf-8" address
+// type of RFC 6533 reads.
 func TestParseORcpt(t *testing.T) {
 	tests := []struct {
 		name     string
 		in       string
+		smtputf8 bool
 		wantType string
 		wantAddr string
 		ok       bool
@@ -149,6 +152,50 @@ func TestParseORcpt(t *testing.T) {
 			wantType: "rfc822",
 			ok:       true,
 		},
+		{
+			name:     "a utf-8 address type with an escape",
+			in:       `utf-8;j\x{00F6}rg@example.org`,
+			wantType: "utf-8",
+			wantAddr: "jörg@example.org",
+			ok:       true,
+		},
+		{
+			name:     "a utf-8 address type in upper case",
+			in:       `UTF-8;\x{5C}@example.org`,
+			wantType: "UTF-8",
+			wantAddr: `\@example.org`,
+			ok:       true,
+		},
+		{
+			name:     "a utf-8 address type with the bytes as they came",
+			in:       "utf-8;jörg@example.org",
+			smtputf8: true,
+			wantType: "utf-8",
+			wantAddr: "jörg@example.org",
+			ok:       true,
+		},
+		{
+			name:     "a utf-8 address type outside the basic plane",
+			in:       `utf-8;\x{1F600}@example.org`,
+			wantType: "utf-8",
+			wantAddr: "\U0001F600@example.org",
+			ok:       true,
+		},
+		{
+			name:     "a utf-8 address type and a semicolon alone",
+			in:       "utf-8;",
+			wantType: "utf-8",
+			ok:       true,
+		},
+		{name: "utf-8 bytes without the SMTPUTF8 parameter", in: "utf-8;jörg@example.org"},
+		{name: "a utf-8 address type with a line break in the escape", in: `utf-8;user\x{0D}\x{0A}@example.org`, smtputf8: true},
+		{name: "a utf-8 address type with a surrogate half", in: `utf-8;\x{D800}@example.org`, smtputf8: true},
+		{name: "a utf-8 address type with a code point that is too high", in: `utf-8;\x{110000}@example.org`, smtputf8: true},
+		{name: "a utf-8 address type with an escape that does not close", in: `utf-8;\x{00F6@example.org`},
+		{name: "a utf-8 address type with one digit", in: `utf-8;\x{F}@example.org`},
+		{name: "a utf-8 address type with a bare backslash", in: `utf-8;a\b@example.org`},
+		{name: "a utf-8 address type with a bare equals sign", in: "utf-8;a=b@example.org"},
+		{name: "a utf-8 address type with a byte that is not UTF-8", in: "utf-8;a\xffb@example.org", smtputf8: true},
 		{name: "no semicolon", in: "rfc822"},
 		{name: "no address type", in: ";user@example.org"},
 		{name: "an address type that is not an atom", in: "rfc 822;user@example.org"},
@@ -159,12 +206,12 @@ func TestParseORcpt(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			addrType, addr, ok := parseORcpt(test.in)
+			addrType, addr, ok := parseORcpt(test.in, test.smtputf8)
 			if ok != test.ok {
-				t.Fatalf("parseORcpt(%q) ok = %v, want %v", test.in, ok, test.ok)
+				t.Fatalf("parseORcpt(%q, %v) ok = %v, want %v", test.in, test.smtputf8, ok, test.ok)
 			}
 			if addrType != test.wantType || addr != test.wantAddr {
-				t.Errorf("parseORcpt(%q) = %q, %q, want %q, %q", test.in, addrType, addr, test.wantType, test.wantAddr)
+				t.Errorf("parseORcpt(%q, %v) = %q, %q, want %q, %q", test.in, test.smtputf8, addrType, addr, test.wantType, test.wantAddr)
 			}
 		})
 	}

--- a/envelope.go
+++ b/envelope.go
@@ -43,6 +43,19 @@ type Envelope struct {
 	// handler that writes it on must keep it whole.
 	BodyType BodyType
 
+	// SMTPUTF8 says that the client sent the SMTPUTF8 parameter of RFC 6531
+	// with MAIL FROM. Such a transaction takes an address of Unicode in
+	// UTF-8 in Sender and Recipients, and the message carries headers in
+	// UTF-8 as well.
+	//
+	// It is false when the server runs without Server.EnableSMTPUTF8, where
+	// every address keeps to US-ASCII.
+	//
+	// A handler that hands the message to another server must send the
+	// parameter on, and must find a server that offers the extension. A
+	// server without it takes none of these addresses.
+	SMTPUTF8 bool
+
 	// DSN holds the delivery status notification parameters of RFC 3461
 	// that came with the transaction. It is nil when the server runs
 	// without Server.EnableDSN, and nil when the client sent none of the

--- a/envelope.go
+++ b/envelope.go
@@ -48,8 +48,10 @@ type Envelope struct {
 	// UTF-8 in Sender and Recipients, and the message carries headers in
 	// UTF-8 as well.
 	//
-	// It is false when the server runs without Server.EnableSMTPUTF8, where
-	// every address keeps to US-ASCII.
+	// A server without Server.EnableSMTPUTF8 offers the extension to no
+	// client, so the parameter never arrives and the field is always false
+	// there. Such a server reads an address as it did before the extension,
+	// which leaves a value of Unicode possible in Sender and Recipients.
 	//
 	// A handler that hands the message to another server must send the
 	// parameter on, and must find a server that offers the extension. A

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"reflect"
 	"testing"
 
 	"github.com/chrj/smtpd/v2"
@@ -211,8 +212,35 @@ type message struct {
 	sender     string
 	recipients []string
 	bodyType   smtpd.BodyType
+	smtputf8   bool
 	body       string
 	readErr    error
+}
+
+// assertMessage compares what a handler read with what the test expects. The
+// error of the read is a failure of its own, because a message that stopped
+// halfway explains every field that follows.
+func assertMessage(t *testing.T, got, want message) {
+	t.Helper()
+
+	if got.readErr != nil {
+		t.Fatalf("the handler read the body with the error %v", got.readErr)
+	}
+	if got.sender != want.sender {
+		t.Errorf("sender = %q, want %q", got.sender, want.sender)
+	}
+	if !reflect.DeepEqual(got.recipients, want.recipients) {
+		t.Errorf("recipients = %q, want %q", got.recipients, want.recipients)
+	}
+	if got.bodyType != want.bodyType {
+		t.Errorf("body type = %q, want %q", got.bodyType, want.bodyType)
+	}
+	if got.smtputf8 != want.smtputf8 {
+		t.Errorf("SMTPUTF8 = %v, want %v", got.smtputf8, want.smtputf8)
+	}
+	if got.body != want.body {
+		t.Errorf("body = %q, want %q", got.body, want.body)
+	}
 }
 
 // captureMessage returns a Handler that reads the whole body and hands the
@@ -227,6 +255,7 @@ func captureMessage(got chan<- message) smtpd.Handler {
 			sender:     env.Sender,
 			recipients: env.Recipients,
 			bodyType:   env.BodyType,
+			smtputf8:   env.SMTPUTF8,
 			body:       string(body),
 			readErr:    err,
 		}

--- a/protocol.go
+++ b/protocol.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // errMailParams answers a MAIL FROM parameter that the server does not know.
@@ -20,11 +21,22 @@ var errMailParams = Error{Code: 555, Enhanced: EnhancedCode{5, 5, 4}, Message: "
 // errRcptParams answers a RCPT TO parameter that the server does not know.
 var errRcptParams = Error{Code: 555, Enhanced: EnhancedCode{5, 5, 4}, Message: "RCPT TO parameters not recognized or not implemented"}
 
+// errSenderNonASCII answers a MAIL FROM command that carries an address of
+// Unicode without the SMTPUTF8 parameter. RFC 6531 section 3.5 gives 550 for
+// the sender, and the status code 5.6.7 with it.
+var errSenderNonASCII = Error{Code: 550, Enhanced: EnhancedCode{5, 6, 7}, Message: "Non-ASCII sender address needs the SMTPUTF8 parameter"}
+
+// errRecipientNonASCII answers a RCPT TO command that carries an address of
+// Unicode in a transaction that did not ask for SMTPUTF8. RFC 6531 section
+// 3.5 gives 553 for a recipient.
+var errRecipientNonASCII = Error{Code: 553, Enhanced: EnhancedCode{5, 6, 7}, Message: "Non-ASCII recipient address needs the SMTPUTF8 parameter"}
+
 // mailParams holds what the parameters of a MAIL FROM command say about the
 // message that follows.
 type mailParams struct {
-	body BodyType
-	dsn  *DSN
+	body     BodyType
+	smtputf8 bool
+	dsn      *DSN
 }
 
 // parseMailParams reads the parameters of a MAIL FROM command.
@@ -60,7 +72,21 @@ func (s *session) parseMailParams(params map[string]string) (mailParams, error) 
 				return mailParams{}, Error{Code: 501, Enhanced: EnhancedCode{5, 5, 4}, Message: "Invalid BODY parameter"}
 			}
 		case "AUTH":
-			// AUTH=<> and xtext-style identities are accepted as opaque values.
+			// AUTH=<> and xtext-style identities are accepted as opaque
+			// values. RFC 4954 section 5 writes the keyword with a value, so
+			// one that came alone is an error.
+			if value == "" {
+				return mailParams{}, Error{Code: 501, Enhanced: EnhancedCode{5, 5, 4}, Message: "Missing AUTH parameter value"}
+			}
+		case "SMTPUTF8":
+			if !s.server.EnableSMTPUTF8 {
+				return mailParams{}, errMailParams
+			}
+			// RFC 6531 section 3.1 gives the parameter no value at all.
+			if value != "" {
+				return mailParams{}, Error{Code: 501, Enhanced: EnhancedCode{5, 5, 4}, Message: "The SMTPUTF8 parameter takes no value"}
+			}
+			out.smtputf8 = true
 		case "RET":
 			if !s.server.EnableDSN {
 				return mailParams{}, errMailParams
@@ -76,6 +102,11 @@ func (s *session) parseMailParams(params map[string]string) (mailParams, error) 
 		case "ENVID":
 			if !s.server.EnableDSN {
 				return mailParams{}, errMailParams
+			}
+			// RFC 3461 section 4.4 writes the keyword with a value, so one
+			// that came alone is an error.
+			if value == "" {
+				return mailParams{}, Error{Code: 501, Enhanced: EnhancedCode{5, 5, 4}, Message: "Missing ENVID parameter value"}
 			}
 			envID, ok := parseEnvID(value)
 			if !ok {
@@ -96,7 +127,10 @@ func (s *session) parseMailParams(params map[string]string) (mailParams, error) 
 // parseRcptParams reads the parameters of a RCPT TO command. It returns the
 // delivery status notification parameters of RFC 3461, and the zero value
 // when the client sent none of them.
-func (s *session) parseRcptParams(params map[string]string) (RecipientDSN, error) {
+//
+// smtputf8 says that the transaction carries the SMTPUTF8 parameter, which
+// lets an ORCPT parameter of the "utf-8" address type hold UTF-8 as it is.
+func (s *session) parseRcptParams(params map[string]string, smtputf8 bool) (RecipientDSN, error) {
 	var rcpt RecipientDSN
 
 	if len(params) == 0 {
@@ -115,7 +149,7 @@ func (s *session) parseRcptParams(params map[string]string) (RecipientDSN, error
 			}
 			rcpt.Notify = notify
 		case "ORCPT":
-			addrType, addr, ok := parseORcpt(value)
+			addrType, addr, ok := parseORcpt(value, smtputf8)
 			if !ok {
 				return RecipientDSN{}, Error{Code: 501, Enhanced: EnhancedCode{5, 5, 4}, Message: "Invalid ORCPT parameter"}
 			}
@@ -127,6 +161,15 @@ func (s *session) parseRcptParams(params map[string]string) (RecipientDSN, error
 	}
 
 	return rcpt, nil
+}
+
+// needsSMTPUTF8 reports whether addr carries Unicode that RFC 6531 gives to a
+// transaction with the SMTPUTF8 parameter alone.
+//
+// A server that runs without Server.EnableSMTPUTF8 offers the extension to no
+// client, and takes an address as it came.
+func (s *session) needsSMTPUTF8(addr string) bool {
+	return s.server.EnableSMTPUTF8 && !isASCII(addr)
 }
 
 func (s *session) handle(ctx context.Context, line string) context.Context {
@@ -286,6 +329,15 @@ func (s *session) handleMAIL(ctx context.Context, cmd *command) context.Context 
 		return s.replyError(ctx, err)
 	}
 
+	if s.needsSMTPUTF8(addr) {
+		if !mail.smtputf8 {
+			return s.replyError(ctx, errSenderNonASCII)
+		}
+		if !utf8.ValidString(addr) {
+			return s.replyEnhanced(ctx, 501, EnhancedCode{5, 1, 7}, "Malformed e-mail address")
+		}
+	}
+
 	ctx, err = s.server.checkSender(ctx, s.peer, addr)
 	if err != nil {
 		return s.replyError(ctx, err)
@@ -296,6 +348,7 @@ func (s *session) handleMAIL(ctx context.Context, cmd *command) context.Context 
 	s.envelope = &Envelope{
 		Sender:   addr,
 		BodyType: mail.body,
+		SMTPUTF8: mail.smtputf8,
 		DSN:      mail.dsn,
 	}
 
@@ -326,7 +379,7 @@ func (s *session) handleRCPT(ctx context.Context, cmd *command) context.Context 
 		return s.replyEnhanced(ctx, 452, EnhancedCode{4, 5, 3}, "Too many recipients")
 	}
 
-	rcptDSN, err := s.parseRcptParams(params)
+	rcptDSN, err := s.parseRcptParams(params, s.envelope.SMTPUTF8)
 	if err != nil {
 		return s.replyError(ctx, err)
 	}
@@ -335,6 +388,15 @@ func (s *session) handleRCPT(ctx context.Context, cmd *command) context.Context 
 
 	if err != nil {
 		return s.replyEnhanced(ctx, 501, EnhancedCode{5, 1, 3}, "Malformed e-mail address")
+	}
+
+	if s.needsSMTPUTF8(addr) {
+		if !s.envelope.SMTPUTF8 {
+			return s.replyError(ctx, errRecipientNonASCII)
+		}
+		if !utf8.ValidString(addr) {
+			return s.replyEnhanced(ctx, 501, EnhancedCode{5, 1, 3}, "Malformed e-mail address")
+		}
 	}
 
 	ctx, err = s.server.checkRecipient(ctx, s.peer, addr)

--- a/protocol.go
+++ b/protocol.go
@@ -130,6 +130,8 @@ func (s *session) parseMailParams(params map[string]string) (mailParams, error) 
 //
 // smtputf8 says that the transaction carries the SMTPUTF8 parameter, which
 // lets an ORCPT parameter of the "utf-8" address type hold UTF-8 as it is.
+// The server reads that address type where it offers the extension, and takes
+// the value as ordinary xtext without it.
 func (s *session) parseRcptParams(params map[string]string, smtputf8 bool) (RecipientDSN, error) {
 	var rcpt RecipientDSN
 
@@ -149,7 +151,7 @@ func (s *session) parseRcptParams(params map[string]string, smtputf8 bool) (Reci
 			}
 			rcpt.Notify = notify
 		case "ORCPT":
-			addrType, addr, ok := parseORcpt(value, smtputf8)
+			addrType, addr, ok := parseORcpt(value, s.server.EnableSMTPUTF8, smtputf8)
 			if !ok {
 				return RecipientDSN{}, Error{Code: 501, Enhanced: EnhancedCode{5, 5, 4}, Message: "Invalid ORCPT parameter"}
 			}

--- a/session.go
+++ b/session.go
@@ -404,6 +404,13 @@ func (s *session) extensions() []string {
 		extensions = append(extensions, "DSN")
 	}
 
+	// RFC 6531 section 3.1 asks for the keyword alone, without a parameter of
+	// its own, and for 8BITMIME next to it. The list above carries 8BITMIME
+	// for every client.
+	if s.server.EnableSMTPUTF8 {
+		extensions = append(extensions, "SMTPUTF8")
+	}
+
 	if s.server.EnableXCLIENT {
 		extensions = append(extensions, "XCLIENT")
 	}

--- a/session_fuzz_test.go
+++ b/session_fuzz_test.go
@@ -71,6 +71,9 @@ func FuzzSession(f *testing.F) {
 	f.Add("EHLO x\r\nBDAT 4\r\nspamNOOP\r\nQUIT\r\n", uint8(0))
 	f.Add("EHLO x\r\nMAIL FROM:<a@example.org>\r\nRCPT TO:<b@example.net>\r\nBDAT 99999999\r\nshort\r\n", uint8(0))
 	f.Add("EHLO x\r\nMAIL FROM:<a@example.org>\r\nRCPT TO:<b@example.net>\r\nBDAT 3\r\nabcRSET\r\nBDAT 1 LAST\r\nz\r\n", uint8(0))
+	f.Add("EHLO x\r\nMAIL FROM:<jörg@example.org> SMTPUTF8\r\nRCPT TO:<用户@example.net>\r\nDATA\r\nGrüße\r\n.\r\nQUIT\r\n", uint8(16))
+	f.Add("EHLO x\r\nMAIL FROM:<a@example.org> SMTPUTF8\r\nRCPT TO:<b@example.net> ORCPT=utf-8;\\x{00F6}@example.net\r\nQUIT\r\n", uint8(24))
+	f.Add("EHLO x\r\nMAIL FROM:<\xff@example.org> SMTPUTF8\r\nRCPT TO:<b@\xc3(example.net>\r\n", uint8(16))
 
 	f.Fuzz(func(t *testing.T, script string, options uint8) {
 		srv := &Server{
@@ -78,6 +81,7 @@ func FuzzSession(f *testing.F) {
 			EnableProxyProtocol: options&2 != 0,
 			AllowInsecureAuth:   options&4 != 0,
 			EnableDSN:           options&8 != 0,
+			EnableSMTPUTF8:      options&16 != 0,
 
 			// Small enough that a short script reaches the limit and the
 			// drain that follows it.

--- a/smtpd.go
+++ b/smtpd.go
@@ -191,6 +191,23 @@ type Server struct {
 	// and a client that follows RFC 3461 sends none of them.
 	EnableDSN bool
 
+	// EnableSMTPUTF8 offers the SMTPUTF8 extension of RFC 6531 and takes its
+	// parameter on MAIL FROM. A transaction that carries the parameter takes
+	// an address of Unicode in UTF-8, and Envelope.SMTPUTF8 tells the handler
+	// that it did.
+	//
+	// The extension is off by default. A server that offers it says that it
+	// carries such a message onward, and the next server on the way has to
+	// offer the extension as well. Turn it on where the handler keeps the
+	// message, or where it relays to a server that takes one.
+	//
+	// A server that offers the extension holds every other transaction to
+	// US-ASCII: it answers 550 to a non-ASCII sender and 553 to a non-ASCII
+	// recipient that came without the parameter, which is what RFC 6531
+	// section 3.5 asks for. Without EnableSMTPUTF8, the server answers 555 to
+	// the parameter and reads an address as it did before.
+	EnableSMTPUTF8 bool
+
 	// TLS
 	TLSConfig *tls.Config
 

--- a/smtputf8_test.go
+++ b/smtputf8_test.go
@@ -522,6 +522,60 @@ func TestSMTPUTF8ORcpt(t *testing.T) {
 	}
 }
 
+// TestORcptUTF8WithoutTheExtension covers a server that offers DSN alone. It
+// reads an ORCPT parameter of the "utf-8" address type as the xtext of RFC
+// 3461, in the way that it did before RFC 6533, so the escape reaches the
+// handler as it came.
+func TestORcptUTF8WithoutTheExtension(t *testing.T) {
+	t.Parallel()
+
+	got := make(chan *smtpd.DSN, 1)
+	srv := runserver(t, &smtpd.Server{
+		Logger:    testLogger(t),
+		EnableDSN: true,
+		Handler:   dsnCapture(got),
+	})
+
+	c := srv.Dial()
+	if err := c.Hello("localhost"); err != nil {
+		t.Fatalf("EHLO failed: %v", err)
+	}
+
+	if err := smtptest.Cmd(c.Text, 250, "MAIL FROM:<sender@example.org>"); err != nil {
+		t.Fatalf("MAIL FROM failed: %v", err)
+	}
+
+	rcpt := `RCPT TO:<one@example.net> ORCPT=utf-8;j\x{00F6}rg@example.net`
+	if err := smtptest.Cmd(c.Text, 250, "%s", rcpt); err != nil {
+		t.Fatalf("%s failed: %v", rcpt, err)
+	}
+
+	w, err := c.Data()
+	if err != nil {
+		t.Fatalf("DATA failed: %v", err)
+	}
+	if _, err := fmt.Fprint(w, "body\r\n"); err != nil {
+		t.Fatalf("write body failed: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close body failed: %v", err)
+	}
+
+	want := &smtpd.DSN{
+		Recipients: []smtpd.RecipientDSN{{
+			OriginalType:      "utf-8",
+			OriginalRecipient: `j\x{00F6}rg@example.net`,
+		}},
+	}
+	if dsn := <-got; !reflect.DeepEqual(dsn, want) {
+		t.Errorf("env.DSN = %+v, want %+v", dsn, want)
+	}
+
+	if err := c.Quit(); err != nil {
+		t.Errorf("QUIT failed: %v", err)
+	}
+}
+
 // TestORcptUTF8WithoutTheParameter covers an ORCPT parameter of the "utf-8"
 // address type whose address carries UTF-8 as it is. RFC 6533 section 3 asks
 // the client for the escape where the transaction did not ask for SMTPUTF8.

--- a/smtputf8_test.go
+++ b/smtputf8_test.go
@@ -1,0 +1,554 @@
+package smtpd_test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/chrj/smtpd/v2"
+	"github.com/chrj/smtpd/v2/smtptest"
+)
+
+// TestSMTPUTF8OfferedOnlyWhenEnabled covers the EHLO keyword of RFC 6531. A
+// server that offers it says that it carries an address of Unicode onward, so
+// the operator turns it on.
+func TestSMTPUTF8OfferedOnlyWhenEnabled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		enabled bool
+	}{
+		{name: "the extension is on", enabled: true},
+		{name: "the extension is off", enabled: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := runserver(t, &smtpd.Server{
+				Logger:         testLogger(t),
+				EnableSMTPUTF8: test.enabled,
+			})
+
+			c := srv.Dial()
+			if err := c.Hello("localhost"); err != nil {
+				t.Fatalf("EHLO failed: %v", err)
+			}
+
+			if got, params := c.Extension("SMTPUTF8"); got != test.enabled {
+				t.Errorf("the server offers SMTPUTF8 = %v, want %v", got, test.enabled)
+			} else if params != "" {
+				// RFC 6531 section 3.1 asks for the keyword alone.
+				t.Errorf("the SMTPUTF8 keyword carries the parameters %q, want none", params)
+			}
+
+			// RFC 6531 section 3.1 asks for 8BITMIME next to the extension.
+			if got, _ := c.Extension("8BITMIME"); !got {
+				t.Error("the server does not offer 8BITMIME")
+			}
+
+			if err := c.Quit(); err != nil {
+				t.Errorf("QUIT failed: %v", err)
+			}
+		})
+	}
+}
+
+// TestSMTPUTF8ReachesTheHandler drives a whole transaction and reads the
+// addresses of Unicode back from the envelope.
+func TestSMTPUTF8ReachesTheHandler(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		mail  string
+		rcpts []string
+		want  message
+	}{
+		{
+			name:  "a local part of Unicode",
+			mail:  "MAIL FROM:<jörg@example.org> SMTPUTF8",
+			rcpts: []string{"RCPT TO:<用户@example.net>"},
+			want: message{
+				sender:     "jörg@example.org",
+				recipients: []string{"用户@example.net"},
+				smtputf8:   true,
+			},
+		},
+		{
+			name:  "a domain of Unicode",
+			mail:  "MAIL FROM:<sender@exämple.org> SMTPUTF8",
+			rcpts: []string{"RCPT TO:<one@例子.广告>"},
+			want: message{
+				sender:     "sender@exämple.org",
+				recipients: []string{"one@例子.广告"},
+				smtputf8:   true,
+			},
+		},
+		{
+			name:  "the parameter in lower case next to BODY",
+			mail:  "MAIL FROM:<jörg@example.org> smtputf8 BODY=8BITMIME",
+			rcpts: []string{"RCPT TO:<one@example.net>"},
+			want: message{
+				sender:     "jörg@example.org",
+				recipients: []string{"one@example.net"},
+				bodyType:   smtpd.Body8BitMIME,
+				smtputf8:   true,
+			},
+		},
+		{
+			name:  "the parameter on an address of US-ASCII",
+			mail:  "MAIL FROM:<sender@example.org> SMTPUTF8",
+			rcpts: []string{"RCPT TO:<one@example.net>"},
+			want: message{
+				sender:     "sender@example.org",
+				recipients: []string{"one@example.net"},
+				smtputf8:   true,
+			},
+		},
+		{
+			name:  "an address of US-ASCII without the parameter",
+			mail:  "MAIL FROM:<sender@example.org>",
+			rcpts: []string{"RCPT TO:<one@example.net>"},
+			want: message{
+				sender:     "sender@example.org",
+				recipients: []string{"one@example.net"},
+			},
+		},
+		{
+			name:  "a null sender with the parameter",
+			mail:  "MAIL FROM:<> SMTPUTF8",
+			rcpts: []string{"RCPT TO:<用户@example.net>"},
+			want: message{
+				recipients: []string{"用户@example.net"},
+				smtputf8:   true,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := make(chan message, 1)
+			srv := runserver(t, &smtpd.Server{
+				Logger:         testLogger(t),
+				EnableSMTPUTF8: true,
+				Handler:        captureMessage(got),
+			})
+
+			c := srv.Dial()
+			if err := c.Hello("localhost"); err != nil {
+				t.Fatalf("EHLO failed: %v", err)
+			}
+
+			if err := smtptest.Cmd(c.Text, 250, "%s", test.mail); err != nil {
+				t.Fatalf("%s failed: %v", test.mail, err)
+			}
+
+			for _, rcpt := range test.rcpts {
+				if err := smtptest.Cmd(c.Text, 250, "%s", rcpt); err != nil {
+					t.Fatalf("%s failed: %v", rcpt, err)
+				}
+			}
+
+			w, err := c.Data()
+			if err != nil {
+				t.Fatalf("DATA failed: %v", err)
+			}
+			if _, err := fmt.Fprint(w, "Subject: Grüße\r\n\r\nA short body.\r\n"); err != nil {
+				t.Fatalf("write body failed: %v", err)
+			}
+			if err := w.Close(); err != nil {
+				t.Fatalf("close body failed: %v", err)
+			}
+
+			// The DATA reader gives the body with the line breaks of the
+			// host, in the way that the standard library reads a dot stream.
+			want := test.want
+			want.body = "Subject: Grüße\n\nA short body.\n"
+
+			assertMessage(t, <-got, want)
+
+			if err := c.Quit(); err != nil {
+				t.Errorf("QUIT failed: %v", err)
+			}
+		})
+	}
+}
+
+// TestNonASCIIAddressWithoutTheParameter covers RFC 6531 section 3.5. A
+// server that offers the extension holds every other transaction to US-ASCII,
+// and answers 550 for the sender and 553 for a recipient.
+func TestNonASCIIAddressWithoutTheParameter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mail string
+		rcpt string
+		want int
+	}{
+		{
+			name: "a sender of Unicode",
+			mail: "MAIL FROM:<jörg@example.org>",
+			want: 550,
+		},
+		{
+			name: "a sender domain of Unicode",
+			mail: "MAIL FROM:<sender@exämple.org>",
+			want: 550,
+		},
+		{
+			name: "a recipient of Unicode",
+			mail: "MAIL FROM:<sender@example.org>",
+			rcpt: "RCPT TO:<用户@example.net>",
+			want: 553,
+		},
+		{
+			name: "a recipient of Unicode after a sender of US-ASCII with the parameter",
+			mail: "MAIL FROM:<sender@example.org> SMTPUTF8",
+			rcpt: "RCPT TO:<用户@example.net>",
+			want: 250,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := runserver(t, &smtpd.Server{
+				Logger:         testLogger(t),
+				EnableSMTPUTF8: true,
+			})
+
+			c := srv.Dial()
+			if err := c.Hello("localhost"); err != nil {
+				t.Fatalf("EHLO failed: %v", err)
+			}
+
+			want := test.want
+			if test.rcpt != "" {
+				if err := smtptest.Cmd(c.Text, 250, "%s", test.mail); err != nil {
+					t.Fatalf("%s failed: %v", test.mail, err)
+				}
+				if err := smtptest.Cmd(c.Text, want, "%s", test.rcpt); err != nil {
+					t.Errorf("%s: %v", test.rcpt, err)
+				}
+			} else if err := smtptest.Cmd(c.Text, want, "%s", test.mail); err != nil {
+				t.Errorf("%s: %v", test.mail, err)
+			}
+
+			// The session survives a refused address.
+			if err := smtptest.Cmd(c.Text, 250, "NOOP"); err != nil {
+				t.Errorf("NOOP after the reply: %v", err)
+			}
+
+			if err := c.Quit(); err != nil {
+				t.Errorf("QUIT failed: %v", err)
+			}
+		})
+	}
+}
+
+// TestNonASCIIAddressWithoutTheExtension covers a server that runs without
+// Server.EnableSMTPUTF8. It offers the extension to no client, and reads an
+// address as it did before the extension.
+func TestNonASCIIAddressWithoutTheExtension(t *testing.T) {
+	t.Parallel()
+
+	got := make(chan message, 1)
+	srv := runserver(t, &smtpd.Server{
+		Logger:  testLogger(t),
+		Handler: captureMessage(got),
+	})
+
+	c := srv.Dial()
+	if err := c.Hello("localhost"); err != nil {
+		t.Fatalf("EHLO failed: %v", err)
+	}
+
+	if err := smtptest.Cmd(c.Text, 250, "MAIL FROM:<jörg@example.org>"); err != nil {
+		t.Fatalf("MAIL FROM failed: %v", err)
+	}
+	if err := smtptest.Cmd(c.Text, 250, "RCPT TO:<用户@example.net>"); err != nil {
+		t.Fatalf("RCPT TO failed: %v", err)
+	}
+
+	w, err := c.Data()
+	if err != nil {
+		t.Fatalf("DATA failed: %v", err)
+	}
+	if _, err := fmt.Fprint(w, "body\r\n"); err != nil {
+		t.Fatalf("write body failed: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close body failed: %v", err)
+	}
+
+	assertMessage(t, <-got, message{
+		sender:     "jörg@example.org",
+		recipients: []string{"用户@example.net"},
+		body:       "body\n",
+	})
+
+	if err := c.Quit(); err != nil {
+		t.Errorf("QUIT failed: %v", err)
+	}
+}
+
+// TestSMTPUTF8ParameterRefused covers the replies to a parameter that the
+// server cannot take.
+func TestSMTPUTF8ParameterRefused(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		enabled  bool
+		greeting string
+		cmd      string
+		want     int
+	}{
+		{
+			name:     "the extension is off",
+			greeting: "EHLO",
+			cmd:      "MAIL FROM:<sender@example.org> SMTPUTF8",
+			want:     555,
+		},
+		{
+			name:     "the client greeted with HELO",
+			enabled:  true,
+			greeting: "HELO",
+			cmd:      "MAIL FROM:<sender@example.org> SMTPUTF8",
+			want:     555,
+		},
+		{
+			name:     "the parameter carries a value",
+			enabled:  true,
+			greeting: "EHLO",
+			cmd:      "MAIL FROM:<sender@example.org> SMTPUTF8=YES",
+			want:     501,
+		},
+		{
+			name:     "the address is not UTF-8",
+			enabled:  true,
+			greeting: "EHLO",
+			cmd:      "MAIL FROM:<j\xf6rg@example.org> SMTPUTF8",
+			want:     501,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := runserver(t, &smtpd.Server{
+				Logger:         testLogger(t),
+				EnableSMTPUTF8: test.enabled,
+			})
+
+			c := srv.Dial()
+			if err := smtptest.Cmd(c.Text, 250, "%s localhost", test.greeting); err != nil {
+				t.Fatalf("%s failed: %v", test.greeting, err)
+			}
+
+			if err := smtptest.Cmd(c.Text, test.want, "%s", test.cmd); err != nil {
+				t.Errorf("%s: %v", test.cmd, err)
+			}
+
+			// The session survives a refused parameter.
+			if err := smtptest.Cmd(c.Text, 250, "NOOP"); err != nil {
+				t.Errorf("NOOP after the reply: %v", err)
+			}
+
+			if err := c.Quit(); err != nil {
+				t.Errorf("QUIT failed: %v", err)
+			}
+		})
+	}
+}
+
+// TestSMTPUTF8RecipientNotUTF8 covers a RCPT TO command whose address carries
+// a byte that is not UTF-8. RFC 6531 gives the address in that encoding, and
+// a byte outside it is not a character at all.
+func TestSMTPUTF8RecipientNotUTF8(t *testing.T) {
+	t.Parallel()
+
+	srv := runserver(t, &smtpd.Server{
+		Logger:         testLogger(t),
+		EnableSMTPUTF8: true,
+	})
+
+	c := srv.Dial()
+	if err := c.Hello("localhost"); err != nil {
+		t.Fatalf("EHLO failed: %v", err)
+	}
+
+	if err := smtptest.Cmd(c.Text, 250, "MAIL FROM:<sender@example.org> SMTPUTF8"); err != nil {
+		t.Fatalf("MAIL FROM failed: %v", err)
+	}
+
+	cmd := "RCPT TO:<one@ex\xe4mple.net>"
+	if err := smtptest.Cmd(c.Text, 501, "%s", cmd); err != nil {
+		t.Errorf("%s: %v", cmd, err)
+	}
+
+	if err := c.Quit(); err != nil {
+		t.Errorf("QUIT failed: %v", err)
+	}
+}
+
+// TestSMTPUTF8EndsWithTheTransaction covers the second transaction of a
+// connection. The parameter belongs to one MAIL FROM command, so a
+// transaction that follows it starts without it.
+func TestSMTPUTF8EndsWithTheTransaction(t *testing.T) {
+	t.Parallel()
+
+	srv := runserver(t, &smtpd.Server{
+		Logger:         testLogger(t),
+		EnableSMTPUTF8: true,
+	})
+
+	c := srv.Dial()
+	if err := c.Hello("localhost"); err != nil {
+		t.Fatalf("EHLO failed: %v", err)
+	}
+
+	if err := smtptest.Cmd(c.Text, 250, "MAIL FROM:<jörg@example.org> SMTPUTF8"); err != nil {
+		t.Fatalf("MAIL FROM failed: %v", err)
+	}
+	if err := smtptest.Cmd(c.Text, 250, "RCPT TO:<用户@example.net>"); err != nil {
+		t.Fatalf("RCPT TO failed: %v", err)
+	}
+	if err := smtptest.Cmd(c.Text, 250, "RSET"); err != nil {
+		t.Fatalf("RSET failed: %v", err)
+	}
+
+	if err := smtptest.Cmd(c.Text, 550, "MAIL FROM:<jörg@example.org>"); err != nil {
+		t.Errorf("the sender of the second transaction: %v", err)
+	}
+	if err := smtptest.Cmd(c.Text, 250, "MAIL FROM:<sender@example.org>"); err != nil {
+		t.Fatalf("MAIL FROM failed: %v", err)
+	}
+	if err := smtptest.Cmd(c.Text, 553, "RCPT TO:<用户@example.net>"); err != nil {
+		t.Errorf("the recipient of the second transaction: %v", err)
+	}
+
+	if err := c.Quit(); err != nil {
+		t.Errorf("QUIT failed: %v", err)
+	}
+}
+
+// TestSMTPUTF8ORcpt covers the "utf-8" address type of RFC 6533. A server
+// that offers both SMTPUTF8 and DSN takes it, with the bytes as they came.
+func TestSMTPUTF8ORcpt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mail string
+		rcpt string
+		want *smtpd.DSN
+	}{
+		{
+			name: "the address as it came",
+			mail: "MAIL FROM:<sender@example.org> SMTPUTF8",
+			rcpt: "RCPT TO:<用户@example.net> ORCPT=utf-8;用户@example.net",
+			want: &smtpd.DSN{
+				Recipients: []smtpd.RecipientDSN{{
+					OriginalType:      "utf-8",
+					OriginalRecipient: "用户@example.net",
+				}},
+			},
+		},
+		{
+			name: "the address in the escape of RFC 6533",
+			mail: "MAIL FROM:<sender@example.org>",
+			rcpt: `RCPT TO:<one@example.net> ORCPT=utf-8;j\x{00F6}rg@example.net`,
+			want: &smtpd.DSN{
+				Recipients: []smtpd.RecipientDSN{{
+					OriginalType:      "utf-8",
+					OriginalRecipient: "jörg@example.net",
+				}},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := make(chan *smtpd.DSN, 1)
+			srv := runserver(t, &smtpd.Server{
+				Logger:         testLogger(t),
+				EnableSMTPUTF8: true,
+				EnableDSN:      true,
+				Handler:        dsnCapture(got),
+			})
+
+			c := srv.Dial()
+			if err := c.Hello("localhost"); err != nil {
+				t.Fatalf("EHLO failed: %v", err)
+			}
+
+			if err := smtptest.Cmd(c.Text, 250, "%s", test.mail); err != nil {
+				t.Fatalf("%s failed: %v", test.mail, err)
+			}
+			if err := smtptest.Cmd(c.Text, 250, "%s", test.rcpt); err != nil {
+				t.Fatalf("%s failed: %v", test.rcpt, err)
+			}
+
+			w, err := c.Data()
+			if err != nil {
+				t.Fatalf("DATA failed: %v", err)
+			}
+			if _, err := fmt.Fprint(w, "body\r\n"); err != nil {
+				t.Fatalf("write body failed: %v", err)
+			}
+			if err := w.Close(); err != nil {
+				t.Fatalf("close body failed: %v", err)
+			}
+
+			if dsn := <-got; !reflect.DeepEqual(dsn, test.want) {
+				t.Errorf("env.DSN = %+v, want %+v", dsn, test.want)
+			}
+
+			if err := c.Quit(); err != nil {
+				t.Errorf("QUIT failed: %v", err)
+			}
+		})
+	}
+}
+
+// TestORcptUTF8WithoutTheParameter covers an ORCPT parameter of the "utf-8"
+// address type whose address carries UTF-8 as it is. RFC 6533 section 3 asks
+// the client for the escape where the transaction did not ask for SMTPUTF8.
+func TestORcptUTF8WithoutTheParameter(t *testing.T) {
+	t.Parallel()
+
+	srv := runserver(t, &smtpd.Server{
+		Logger:         testLogger(t),
+		EnableSMTPUTF8: true,
+		EnableDSN:      true,
+	})
+
+	c := srv.Dial()
+	if err := c.Hello("localhost"); err != nil {
+		t.Fatalf("EHLO failed: %v", err)
+	}
+
+	if err := smtptest.Cmd(c.Text, 250, "MAIL FROM:<sender@example.org>"); err != nil {
+		t.Fatalf("MAIL FROM failed: %v", err)
+	}
+
+	cmd := "RCPT TO:<one@example.net> ORCPT=utf-8;用户@example.net"
+	if err := smtptest.Cmd(c.Text, 501, "%s", cmd); err != nil {
+		t.Errorf("%s: %v", cmd, err)
+	}
+
+	if err := c.Quit(); err != nil {
+		t.Errorf("QUIT failed: %v", err)
+	}
+}

--- a/xtext.go
+++ b/xtext.go
@@ -131,11 +131,16 @@ func parseXtext(value string) (string, bool) {
 // RFC 6533 gives that form to a server that offers SMTPUTF8, and asks a
 // client that talks to any other server for the escape.
 //
-// The value decodes to printable characters alone, in the way that parseXtext
-// reads the xtext of RFC 3461. A control character ends a MAIL or RCPT
-// command that a relay writes the address into, and the next line then comes
-// from the client. RFC 6533 keeps CR and LF out of the escape for the same
+// The value decodes to no control character of US-ASCII, in the way that
+// parseXtext reads the xtext of RFC 3461. Such a character ends a MAIL or
+// RCPT command that a relay writes the address into, and the next line then
+// comes from the client. RFC 6533 keeps CR and LF out of the escape for that
 // reason, and this reading keeps the rest of them out too.
+//
+// A code point above US-ASCII stands, and the C1 range from U+0080 to U+009F
+// with it. RFC 6533 gives that range to both forms of the encoding, and the
+// UTF-8 of such a code point carries no CR and no LF, so it stays inside its
+// command line.
 func parseUnitext(value string, raw bool) (string, bool) {
 	var out strings.Builder
 	out.Grow(len(value))
@@ -188,8 +193,8 @@ func parseUnitext(value string, raw bool) (string, bool) {
 //
 // The digits run from two to six, and they hold a code point that a
 // character stands for: a surrogate half or a value above the last code
-// point is not one. A control character is refused as well, so that the
-// decoded address stays on one line.
+// point is not one. A control character of US-ASCII is refused as well, so
+// that the decoded address stays on one line.
 func parseEmbeddedUnicodeChar(src string) (r rune, width int, ok bool) {
 	if !strings.HasPrefix(src, `\x{`) {
 		return 0, 0, false

--- a/xtext.go
+++ b/xtext.go
@@ -1,6 +1,9 @@
 package smtpd
 
-import "strings"
+import (
+	"strings"
+	"unicode/utf8"
+)
 
 // decodeXtext decodes the xtext encoding of RFC 1891, which the XCLIENT
 // specification asks for on every attribute value. A "+" starts a byte
@@ -115,4 +118,105 @@ func parseXtext(value string) (string, bool) {
 	}
 
 	return out.String(), true
+}
+
+// parseUnitext decodes the unitext encoding that RFC 6533 section 3 gives to
+// the "utf-8" address type of an ORCPT parameter, and reports whether the
+// value keeps to it. A "\x{HEX}" holds one code point in two to six
+// hexadecimal digits, and every other character stands for itself.
+//
+// The characters that stand for themselves are the printable US-ASCII ones
+// without the space, "\", "+" and "=", which the encoding writes as code
+// points. raw says whether a byte above US-ASCII stands for itself as well:
+// RFC 6533 gives that form to a server that offers SMTPUTF8, and asks a
+// client that talks to any other server for the escape.
+//
+// The value decodes to printable characters alone, in the way that parseXtext
+// reads the xtext of RFC 3461. A control character ends a MAIL or RCPT
+// command that a relay writes the address into, and the next line then comes
+// from the client. RFC 6533 keeps CR and LF out of the escape for the same
+// reason, and this reading keeps the rest of them out too.
+func parseUnitext(value string, raw bool) (string, bool) {
+	var out strings.Builder
+	out.Grow(len(value))
+
+	for i := 0; i < len(value); i++ {
+		c := value[i]
+
+		if c >= 0x80 {
+			if !raw {
+				return "", false
+			}
+			out.WriteByte(c)
+			continue
+		}
+
+		if c == '\\' {
+			r, width, ok := parseEmbeddedUnicodeChar(value[i:])
+			if !ok {
+				return "", false
+			}
+			out.WriteRune(r)
+			i += width - 1
+			continue
+		}
+
+		// QCHAR is the printable US-ASCII without the space, "\", "+" and
+		// "=". The three signs carry a meaning of their own in the ORCPT
+		// parameter and in the encoding.
+		if c <= ' ' || c == 0x7f || c == '+' || c == '=' {
+			return "", false
+		}
+
+		out.WriteByte(c)
+	}
+
+	decoded := out.String()
+
+	// A raw value carries the bytes as they came, and they have to form
+	// UTF-8. RFC 6531 gives an address in that encoding, and a byte outside
+	// it is not a character at all.
+	if raw && !utf8.ValidString(decoded) {
+		return "", false
+	}
+
+	return decoded, true
+}
+
+// parseEmbeddedUnicodeChar reads one "\x{HEX}" escape of RFC 6533 from the
+// start of src and gives the code point and the length of the escape.
+//
+// The digits run from two to six, and they hold a code point that a
+// character stands for: a surrogate half or a value above the last code
+// point is not one. A control character is refused as well, so that the
+// decoded address stays on one line.
+func parseEmbeddedUnicodeChar(src string) (r rune, width int, ok bool) {
+	if !strings.HasPrefix(src, `\x{`) {
+		return 0, 0, false
+	}
+
+	end := strings.IndexByte(src, '}')
+	if end < 0 {
+		return 0, 0, false
+	}
+
+	digits := src[len(`\x{`):end]
+	if len(digits) < 2 || len(digits) > 6 {
+		return 0, 0, false
+	}
+
+	var value rune
+	for i := 0; i < len(digits); i++ {
+		d, dOK := hexDigit(digits[i])
+		if !dOK {
+			return 0, 0, false
+		}
+		value = value<<4 | rune(d)
+	}
+
+	if !utf8.ValidRune(value) || value < ' ' || value == 0x7f {
+		return 0, 0, false
+	}
+
+	return value, end + 1, true
 }

--- a/xtext_fuzz_test.go
+++ b/xtext_fuzz_test.go
@@ -3,6 +3,7 @@ package smtpd
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 // FuzzDecodeXtext runs the xtext decoder over an XCLIENT attribute value. It
@@ -80,6 +81,56 @@ func FuzzParseXtext(f *testing.F) {
 			if got[i] < ' ' || got[i] > '~' {
 				t.Fatalf("parseXtext(%q) gave %q, which carries the byte %#x", value, got, got[i])
 			}
+		}
+	})
+}
+
+// FuzzParseUnitext runs the reader of the "utf-8" address type of an ORCPT
+// parameter. It holds four properties:
+//
+//   - The reader never panics.
+//   - A value that it refuses comes back empty.
+//   - The result carries no control character.
+//   - The result is UTF-8.
+//
+// The third property is the one that keeps the address inside its command. A
+// relay writes an ORCPT that it took here into a command of its own, and a
+// line break there would end that command.
+func FuzzParseUnitext(f *testing.F) {
+	f.Add(`j\x{00F6}rg@example.org`, true)
+	f.Add(`j\x{00F6}rg@example.org`, false)
+	f.Add("jörg@example.org", true)
+	f.Add("jörg@example.org", false)
+	f.Add(`\x{1F600}@example.org`, true)
+	f.Add(`\x{D800}@example.org`, true)
+	f.Add(`\x{110000}@example.org`, true)
+	f.Add(`user\x{0D}\x{0A}250 injected`, true)
+	f.Add(`\x{`, true)
+	f.Add(`\x{}`, true)
+	f.Add(`\x{F}`, true)
+	f.Add(`a\b`, true)
+	f.Add("a=b", true)
+	f.Add("a b", true)
+	f.Add("a\xffb", true)
+	f.Add("", true)
+
+	f.Fuzz(func(t *testing.T, value string, raw bool) {
+		got, ok := parseUnitext(value, raw)
+		if !ok {
+			if got != "" {
+				t.Fatalf("parseUnitext(%q, %v) refused the value and gave %q, want an empty string", value, raw, got)
+			}
+			return
+		}
+
+		for i := 0; i < len(got); i++ {
+			if got[i] < ' ' || got[i] == 0x7f {
+				t.Fatalf("parseUnitext(%q, %v) gave %q, which carries the byte %#x", value, raw, got, got[i])
+			}
+		}
+
+		if !utf8.ValidString(got) {
+			t.Fatalf("parseUnitext(%q, %v) gave %q, which is not UTF-8", value, raw, got)
 		}
 	})
 }

--- a/xtext_fuzz_test.go
+++ b/xtext_fuzz_test.go
@@ -90,12 +90,14 @@ func FuzzParseXtext(f *testing.F) {
 //
 //   - The reader never panics.
 //   - A value that it refuses comes back empty.
-//   - The result carries no control character.
+//   - The result carries no control character of US-ASCII.
 //   - The result is UTF-8.
 //
 // The third property is the one that keeps the address inside its command. A
 // relay writes an ORCPT that it took here into a command of its own, and a
-// line break there would end that command.
+// line break there would end that command. A code point above US-ASCII
+// stands, because RFC 6533 gives it to the encoding and its UTF-8 carries no
+// CR and no LF.
 func FuzzParseUnitext(f *testing.F) {
 	f.Add(`j\x{00F6}rg@example.org`, true)
 	f.Add(`j\x{00F6}rg@example.org`, false)
@@ -109,6 +111,7 @@ func FuzzParseUnitext(f *testing.F) {
 	f.Add(`\x{}`, true)
 	f.Add(`\x{F}`, true)
 	f.Add(`a\b`, true)
+	f.Add(`\x{85}`, true)
 	f.Add("a=b", true)
 	f.Add("a b", true)
 	f.Add("a\xffb", true)


### PR DESCRIPTION
`Server.EnableSMTPUTF8` offers the SMTPUTF8 extension of
[RFC 6531](https://www.rfc-editor.org/rfc/rfc6531) and takes its parameter on
`MAIL FROM`. Such a transaction carries an address of Unicode in UTF-8, in the
local part and in the domain. `Envelope.SMTPUTF8` tells the handler that it
did.

```
C: MAIL FROM:<jörg@example.org> SMTPUTF8
S: 250 2.1.0 Go ahead
C: RCPT TO:<用户@例子.广告>
S: 250 2.1.5 Go ahead
```

The extension is off by default, in the same way as `DSN`. A server that
offers it says that it carries such a message onward, and the next server on
the way has to offer the extension as well.

A server that offers it holds every other transaction to US-ASCII. RFC 6531
section 3.5 gives the replies:

| The client sends | The reply |
| --- | --- |
| `MAIL FROM:<jörg@example.org>` | `550 5.6.7` |
| `RCPT TO:<用户@example.net>` | `553 5.6.7` |
| an address that is not UTF-8 | `501` |

Without `EnableSMTPUTF8`, the server answers `555` to the parameter and reads
an address as it did before. No behavior changes for a server that leaves the
field alone.

### The utf-8 address type of ORCPT

RFC 6531 section 3.2 asks for [RFC 6533](https://www.rfc-editor.org/rfc/rfc6533)
from a server that offers `DSN` next to `SMTPUTF8`, so this PR carries it. A
server with `EnableSMTPUTF8` reads an `ORCPT` parameter of the `utf-8` address
type with the encoding of that document, where `\x{HEX}` holds one code point:

```
ORCPT=utf-8;j\x{00F6}rg@example.net   ->   jörg@example.net
```

A transaction with the `SMTPUTF8` parameter takes the bytes of the address as
they came. Every other one needs the escape, and a raw byte above US-ASCII
gets a `501` reply.

A server without `EnableSMTPUTF8` reads that value as ordinary xtext, in the
way that it did before, and the escape reaches the handler as it came.

The decoded address carries no control character of US-ASCII, in the way that
the xtext reader of RFC 3461 works: such a character would end the command
that a relay writes the address into. A code point above US-ASCII stands,
because RFC 6533 gives it to the encoding and its UTF-8 carries no CR and
no LF.

### The parameter parser

The first commit takes a parameter keyword that comes without a value, because
`SMTPUTF8` has none. RFC 5321 section 4.1.2 writes the value as an optional
part.

A keyword with an `=` sign and nothing after it is still an error. A known
keyword that needs a value and comes without one now gets its `501` reply from
the parameter reader, where the command parser refused it before. Both replies
carry the same code.

### Tests

`smtputf8_test.go` drives whole sessions: the EHLO keyword, the envelope flag,
both refusal codes, a client that greets with `HELO`, a parameter that carries
a value, an address that is not UTF-8, the `ORCPT` forms, and a second
transaction after `RSET`. `FuzzParseUnitext` is new, and `FuzzSession` gained
an option bit for the extension with three seeds.

### Two things this PR leaves out

- VRFY and EXPN take the parameter as well in RFC 6531 section 3.1. The server
  implements neither command, so there is nothing to take.
- The server looks up no domain of its own and keeps an address as the client
  wrote it, so a domain of Unicode reaches the handler in the U-label form.
  RFC 6531 section 3.2 asks the party that looks a domain up in the DNS to
  convert it to the A-label form first. That conversion needs
  `golang.org/x/net/idna`, and the SPF middleware is where it belongs. The
  README says so.
