### PR TITLE
feat: answer the VRFY command of RFC 5321

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The server answers the `VRFY` command of RFC 5321. A `Verify` hook in the
+  middleware looks the name up and gives back a `Verification` with the
+  mailbox of the user, which the client reads in a `250` reply.
+
+  A hook that knows the name to be wrong returns an `Error`, such as `550` for
+  a user that the server does not carry, or `553` for a name that more than
+  one user answers to. The hooks run in `Use` order, and the first one that
+  finds a mailbox or returns an error ends the phase.
+
+  A server without a `Verify` hook answers `252`, which RFC 5321 section 7.3
+  asks for. The server answered `500` before, and section 3.5.3 counts that
+  answer as a fault: a `500` or a `502` says that the command is not
+  implemented.
+
 - `Server.EnableSMTPUTF8` offers the `SMTPUTF8` extension of RFC 6531 and takes
   its parameter on `MAIL FROM`. Such a transaction carries an address of
   Unicode in UTF-8, in the local part and in the domain, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   A server without a `Verify` hook answers `252`, which RFC 5321 section 7.3
   asks for. The server answered `500` before, and section 3.5.3 counts that
   answer as a fault: a `500` or a `502` says that the command is not
-  implemented.
+  implemented. A hook that fails gets a `451` for the same reason, and the
+  error goes to the log.
+
+  The reply keeps to US-ASCII. RFC 6531 section 3.7.4.2 gives a reply of UTF-8
+  to a client that asked for one, and this server offers no `SMTPUTF8`. A
+  `FullName` of Unicode goes and the mailbox stays, and a `Mailbox` of Unicode
+  gets `252 2.6.8`.
 
 - `Server.EnableSMTPUTF8` offers the `SMTPUTF8` extension of RFC 6531 and takes
   its parameter on `MAIL FROM`. Such a transaction carries an address of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   error goes to the log.
 
   The reply keeps to US-ASCII. RFC 6531 section 3.7.4.2 gives a reply of UTF-8
-  to a client that asked for one, and this server offers no `SMTPUTF8`. A
+  to a client that asked for one with an `SMTPUTF8` parameter on the `VRFY`
+  command, and the server takes that parameter on `MAIL FROM` alone. A
   `FullName` of Unicode goes and the mailbox stays, and a `Mailbox` of Unicode
   gets `252 2.6.8`.
 

--- a/README.md
+++ b/README.md
@@ -487,7 +487,12 @@ TO` command of its own. `FullName` is optional and stands before the mailbox.
 | a `Verification` with a mailbox | `250` with the mailbox |
 | the zero `Verification` and no error | `252` |
 | an `Error` | the code of that error, such as `550` or `553` |
-| an error of another kind | `502` |
+| an error of another kind | `451`, and the error goes to the log |
+
+A hook that fails gets a `451`, because a `500` or a `502` says that the
+server does not carry the command, which RFC 5321 section 3.5.3 calls a fault.
+The text of the error stays in the log: it comes from the site, and a client
+of any kind reads a reply.
 
 A server without a `Verify` hook answers `252 Cannot VRFY user, but will
 accept message and attempt delivery`. RFC 5321 section 7.3 asks for that code
@@ -506,6 +511,14 @@ kind. A name with a space in it arrives whole.
 A mailbox that is not an address gets the `252` reply, and the server writes
 the fault to the log at the `ERROR` level. The reply carries an address that
 the client uses, so a broken one never goes on the wire.
+
+The reply keeps to US-ASCII. RFC 6531 section 3.7.4.2 gives a reply of UTF-8
+to a client that asked for one with an `SMTPUTF8` parameter of its own, and
+this server offers neither the extension nor that parameter. A `FullName` of
+Unicode therefore goes, and the mailbox stays, because RFC 5321 section 3.5.1
+gives the name as the optional part. A `Mailbox` of Unicode leaves nothing to
+write, so it gets `252 2.6.8`, which is the status code that RFC 6531 gives
+for a reply that needs UTF-8 and cannot use it.
 
 The server offers no `VRFY` keyword in the reply to `EHLO`. RFC 5321 section
 3.5.2 makes that keyword optional, because every server carries the command.

--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ Features
   ([RFC 6531](https://www.rfc-editor.org/rfc/rfc6531)), off by default
 * [XCLIENT](http://www.postfix.org/XCLIENT_README.html) and the
   [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
-* Per-phase middleware: connection, HELO, MAIL FROM, RCPT TO, AUTH, DATA,
-  RESET, DISCONNECT
+* `VRFY` ([RFC 5321](https://www.rfc-editor.org/rfc/rfc5321)), through a
+  middleware hook
+* Per-phase middleware: connection, HELO, MAIL FROM, RCPT TO, AUTH, VRFY,
+  DATA, RESET, DISCONNECT
 * Streaming `Envelope.Data` as `io.ReadCloser` - no forced buffering
 * `context.Context` threaded through every hook and handler
 * Structured logging via `*slog.Logger`
@@ -136,6 +138,7 @@ type Middleware struct {
     CheckSender     func(ctx, peer, addr) (ctx, error)
     CheckRecipient  func(ctx, peer, addr) (ctx, error)
     Authenticate    func(ctx, peer, user, pass) (ctx, error)
+    Verify          func(ctx, peer, name) (ctx, Verification, error)
     Handler         Handler                              // pre-deliver stage
     Reset           func(ctx, peer) ctx
     Disconnect      func(ctx, peer, err error)
@@ -181,6 +184,8 @@ given to the `Authenticate` hooks and is not kept.
 ```mermaid
 flowchart TD
     accept["accept"] --> checkConnection["CheckConnection"]
+    checkConnection --> vrfy["VRFY (any time)"]
+    vrfy --> verifyHook["Verify"]
     checkConnection --> helo["HELO/EHLO"]
     helo --> checkHelo["CheckHelo"]
     checkHelo --> starttls["STARTTLS?"]
@@ -204,8 +209,8 @@ flowchart TD
     classDef phase fill:#1d4ed8,stroke:#1e3a8a,color:#ffffff;
     classDef hook fill:#f59e0b,stroke:#92400e,color:#111827;
 
-    class accept,helo,starttls,auth,mailFrom,rcptTo,data,bdat,rset phase;
-    class checkConnection,checkHelo,authenticate,checkSender,checkRecipient,middlewareHandler,serverHandler,resetHook hook;
+    class accept,helo,starttls,auth,vrfy,mailFrom,rcptTo,data,bdat,rset phase;
+    class checkConnection,checkHelo,authenticate,verifyHook,checkSender,checkRecipient,middlewareHandler,serverHandler,resetHook hook;
 ```
 
 Blue boxes are SMTP phases; amber boxes are middleware hooks. The `Envelope`
@@ -217,6 +222,9 @@ them, both for `DATA` and for `BDAT`. The two differ in where they run: the
 handlers of a `DATA` message hold the session while they read, and the
 handlers of a `BDAT` message run on a goroutine of their own while the session
 reads the commands that carry the chunks.
+
+`VRFY` stands outside the transaction. RFC 5321 section 4.1.4 lets a client
+send it at any time, and it changes nothing that the transaction holds.
 
 `Disconnect` always runs exactly once per session. `err` is nil on clean
 shutdown (QUIT or server `Shutdown`); non-nil if a TLS/read/DATA error
@@ -434,6 +442,79 @@ U-label form. RFC 6531 section 3.2 asks the party that looks a domain up in
 the DNS to convert it to the A-label form first, which the SPF middleware and
 a handler that relays the message have to do. Read
 [RFC 5890](https://www.rfc-editor.org/rfc/rfc5890) for the two forms.
+
+### VRFY
+
+The `VRFY` command asks the server to confirm that a name stands for a user.
+RFC 5321 section 4.5.1 counts it among the commands that every server
+implements. A `Verify` hook looks the name up:
+
+```go
+srv.Use(smtpd.Middleware{
+    Verify: func(ctx context.Context, peer smtpd.Peer, name string) (context.Context, smtpd.Verification, error) {
+        user, err := directory.Lookup(ctx, name)
+        if errors.Is(err, directory.ErrNoSuchUser) {
+            return ctx, smtpd.Verification{}, smtpd.Error{
+                Code:     550,
+                Enhanced: smtpd.EnhancedCode{5, 1, 1},
+                Message:  "No such user here",
+            }
+        }
+        if err != nil {
+            return ctx, smtpd.Verification{}, err
+        }
+
+        return ctx, smtpd.Verification{
+            Mailbox:  user.Mailbox,
+            FullName: user.FullName,
+        }, nil
+    },
+})
+```
+
+```
+C: VRFY Smith
+S: 250 2.1.5 Jörg Smith <jörg@example.org>
+```
+
+`Verification.Mailbox` is an address in the form that `Envelope.Sender` takes,
+without the angle brackets. The server writes it inside them, which RFC 5321
+section 3.5.2 asks for, because the client writes that address into a `RCPT
+TO` command of its own. `FullName` is optional and stands before the mailbox.
+
+| What the hook gives back | The reply |
+| --- | --- |
+| a `Verification` with a mailbox | `250` with the mailbox |
+| the zero `Verification` and no error | `252` |
+| an `Error` | the code of that error, such as `550` or `553` |
+| an error of another kind | `502` |
+
+A server without a `Verify` hook answers `252 Cannot VRFY user, but will
+accept message and attempt delivery`. RFC 5321 section 7.3 asks for that code
+and no other one: a server that answers `250` says that it verified the name,
+and one that answers `550` says that the name is wrong. A `502` there would
+say that the command is not implemented, which the same section calls a fault.
+
+The hooks run in `Use` order. The first one that finds a mailbox, or that
+returns an error, ends the phase. A hook that finds nothing returns the zero
+`Verification` and lets the next one look.
+
+The name reaches the hook as the client wrote it, and RFC 5321 section 3.5.1
+leaves its form to the site: a user name, an address, or a string of another
+kind. A name with a space in it arrives whole.
+
+A mailbox that is not an address gets the `252` reply, and the server writes
+the fault to the log at the `ERROR` level. The reply carries an address that
+the client uses, so a broken one never goes on the wire.
+
+The server offers no `VRFY` keyword in the reply to `EHLO`. RFC 5321 section
+3.5.2 makes that keyword optional, because every server carries the command.
+
+> [!NOTE]
+> `VRFY` tells anybody who asks which addresses exist, and RFC 5321 section
+> 7.3 gives that as the reason to hold it back. The hook reads `Peer`, so it
+> can answer for an authenticated client alone, and give the zero
+> `Verification` to every other one.
 
 ### Panics
 

--- a/README.md
+++ b/README.md
@@ -512,13 +512,14 @@ A mailbox that is not an address gets the `252` reply, and the server writes
 the fault to the log at the `ERROR` level. The reply carries an address that
 the client uses, so a broken one never goes on the wire.
 
-The reply keeps to US-ASCII. RFC 6531 section 3.7.4.2 gives a reply of UTF-8
-to a client that asked for one with an `SMTPUTF8` parameter of its own, and
-this server offers neither the extension nor that parameter. A `FullName` of
-Unicode therefore goes, and the mailbox stays, because RFC 5321 section 3.5.1
-gives the name as the optional part. A `Mailbox` of Unicode leaves nothing to
-write, so it gets `252 2.6.8`, which is the status code that RFC 6531 gives
-for a reply that needs UTF-8 and cannot use it.
+The reply keeps to US-ASCII, and `Server.EnableSMTPUTF8` changes nothing here.
+RFC 6531 section 3.7.4.2 gives a reply of UTF-8 to a client that asked for one
+with an `SMTPUTF8` parameter on the `VRFY` command, and the server takes that
+parameter on `MAIL FROM` alone. A `FullName` of Unicode therefore goes, and
+the mailbox stays, because RFC 5321 section 3.5.1 gives the name as the
+optional part. A `Mailbox` of Unicode leaves nothing to write, so it gets
+`252 2.6.8`, which is the status code that RFC 6531 gives for a reply that
+needs UTF-8 and cannot use it.
 
 The server offers no `VRFY` keyword in the reply to `EHLO`. RFC 5321 section
 3.5.2 makes that keyword optional, because every server carries the command.

--- a/bdat_test.go
+++ b/bdat_test.go
@@ -485,8 +485,6 @@ func TestBDATLeavesNoGoroutine(t *testing.T) {
 		},
 	})
 
-	before := runtime.NumGoroutine()
-
 	for range 20 {
 		c := dialRaw(t, srv.Addr)
 		openTransaction(t, c, "MAIL FROM:<sender@example.org>")
@@ -501,12 +499,37 @@ func TestBDATLeavesNoGoroutine(t *testing.T) {
 
 	// The sessions end on their own, so give them a moment to.
 	deadline := time.Now().Add(2 * time.Second)
-	for runtime.NumGoroutine() > before+5 && time.Now().Before(deadline) {
+	for blockedHandlers(t) > 0 && time.Now().Before(deadline) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	if after := runtime.NumGoroutine(); after > before+5 {
-		t.Errorf("the server holds %d goroutines, and it held %d before the 20 sessions", after, before)
+	if got := blockedHandlers(t); got != 0 {
+		t.Errorf("the server holds %d goroutines that run the handler of this test, want 0", got)
+	}
+}
+
+// handlerFrame names the handler of TestBDATLeavesNoGoroutine in a stack
+// dump. Every closure of that test carries the name, and the handler is the
+// only one that runs on a goroutine of its own.
+const handlerFrame = "TestBDATLeavesNoGoroutine.func"
+
+// blockedHandlers counts the goroutines that still run the handler of
+// TestBDATLeavesNoGoroutine.
+//
+// The count comes from a stack dump and not from runtime.NumGoroutine,
+// because that one counts the goroutines of the whole process. The tests that
+// run next to this one open sessions of their own, and each one holds a
+// goroutine while it does.
+func blockedHandlers(t *testing.T) int {
+	t.Helper()
+
+	buf := make([]byte, 64*1024)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			return strings.Count(string(buf[:n]), handlerFrame)
+		}
+		buf = make([]byte, 2*len(buf))
 	}
 }
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -187,6 +187,16 @@ func rejectRecipient() smtpd.Middleware {
 	}
 }
 
+// verifier returns a Middleware whose Verify hook gives the same answer to
+// every name.
+func verifier(verified smtpd.Verification, err error) smtpd.Middleware {
+	return smtpd.Middleware{
+		Verify: func(ctx context.Context, _ smtpd.Peer, _ string) (context.Context, smtpd.Verification, error) {
+			return ctx, verified, err
+		},
+	}
+}
+
 // dsnCapture returns a Handler that hands the DSN parameters of the envelope
 // to the test. The channel is buffered, so the handler returns and the client
 // gets its 250 before the test reads the value.

--- a/protocol.go
+++ b/protocol.go
@@ -233,6 +233,9 @@ func (s *session) handle(ctx context.Context, line string) context.Context {
 	case "NOOP":
 		return s.handleNOOP(ctx, cmd)
 
+	case "VRFY":
+		return s.handleVRFY(ctx, cmd)
+
 	case "QUIT":
 		return s.handleQUIT(ctx, cmd)
 
@@ -478,6 +481,49 @@ func (s *session) handleRSET(ctx context.Context, cmd *command) context.Context 
 func (s *session) handleNOOP(ctx context.Context, cmd *command) context.Context {
 	ctx, _ = phasedLoggerFromContext(ctx, "noop")
 	return s.reply(ctx, 250, "Go ahead")
+}
+
+// handleVRFY answers the VRFY command of RFC 5321 section 4.1.1.6. The
+// command asks the server to confirm that a name stands for a user, and the
+// Verify hooks of the middleware look it up.
+//
+// The command carries no transaction, so it needs no HELO and no MAIL FROM
+// before it. RFC 5321 section 4.1.4 lets a client send it at any time.
+func (s *session) handleVRFY(ctx context.Context, cmd *command) context.Context {
+	ctx, logger := phasedLoggerFromContext(ctx, "vrfy")
+
+	// RFC 5321 section 3.5.1 leaves the form of the name to the site, so the
+	// argument goes to the hooks as it came. A name that carries a space
+	// reaches them whole.
+	name := strings.TrimSpace(cmd.arg)
+	if name == "" {
+		return s.replyEnhanced(ctx, 501, EnhancedCode{5, 5, 4}, "Missing parameter")
+	}
+
+	ctx, verified, err := s.server.verify(ctx, s.peer, name)
+	if err != nil {
+		return s.replyError(ctx, err)
+	}
+
+	if verified.Mailbox == "" {
+		return s.reply(ctx, 252, cannotVerify)
+	}
+
+	// The client writes the mailbox of the reply into a RCPT TO command of
+	// its own, so a value that is not an address never goes on the wire. RFC
+	// 5321 section 7.3 asks the server to answer 252 where it cannot say
+	// that it verified the name.
+	mailbox, err := parseAddress(verified.Mailbox)
+	if err != nil {
+		logger.ErrorContext(ctx, "the Verify hook gave a mailbox that is not an address",
+			slog.String("name", name),
+			slog.String("mailbox", verified.Mailbox),
+			slog.Any("err", err),
+		)
+		return s.reply(ctx, 252, cannotVerify)
+	}
+
+	return s.replyEnhanced(ctx, 250, EnhancedCode{2, 1, 5}, verifyLine(verified.FullName, mailbox))
 }
 
 func (s *session) handleQUIT(ctx context.Context, cmd *command) context.Context {

--- a/protocol.go
+++ b/protocol.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -502,7 +503,23 @@ func (s *session) handleVRFY(ctx context.Context, cmd *command) context.Context 
 
 	ctx, verified, err := s.server.verify(ctx, s.peer, name)
 	if err != nil {
-		return s.replyError(ctx, err)
+		var smtpErr Error
+		if errors.As(err, &smtpErr) {
+			return s.replyError(ctx, err)
+		}
+
+		// A lookup that failed is not a command that the server does not
+		// carry, and replyError answers 502 to an error of another kind. RFC
+		// 5321 section 3.5.3 reads a 500 and a 502 as the answer of a server
+		// without VRFY, so a fault of the directory takes a 451 instead.
+		//
+		// The text of the error stays in the log. It comes from the site, and
+		// a client of any kind reads a reply.
+		logger.ErrorContext(ctx, "the Verify hook failed",
+			slog.String("name", name),
+			slog.Any("err", err),
+		)
+		return s.replyEnhanced(ctx, 451, EnhancedCode{4, 3, 0}, "Cannot verify the user right now")
 	}
 
 	if verified.Mailbox == "" {
@@ -523,7 +540,25 @@ func (s *session) handleVRFY(ctx context.Context, cmd *command) context.Context 
 		return s.reply(ctx, 252, cannotVerify)
 	}
 
-	return s.replyEnhanced(ctx, 250, EnhancedCode{2, 1, 5}, verifyLine(verified.FullName, mailbox))
+	// RFC 5321 holds the text of a reply to US-ASCII, and RFC 6531 section
+	// 3.7.4.2 widens it for a client that asked with the SMTPUTF8 parameter
+	// of the command. This server offers neither, so the reply carries no
+	// Unicode at all.
+	//
+	// The name of the user is the part that RFC 5321 section 3.5.1 leaves
+	// out, so a name of Unicode goes and the mailbox stays. A mailbox of
+	// Unicode leaves nothing to write, and the same section of RFC 6531 gives
+	// 252 for it.
+	if !isASCII(mailbox) {
+		return s.replyEnhanced(ctx, 252, EnhancedCode{2, 6, 8}, cannotShowMailbox)
+	}
+
+	fullName := verified.FullName
+	if !isASCII(fullName) {
+		fullName = ""
+	}
+
+	return s.replyEnhanced(ctx, 250, EnhancedCode{2, 1, 5}, verifyLine(fullName, mailbox))
 }
 
 func (s *session) handleQUIT(ctx context.Context, cmd *command) context.Context {

--- a/protocol.go
+++ b/protocol.go
@@ -541,9 +541,10 @@ func (s *session) handleVRFY(ctx context.Context, cmd *command) context.Context 
 	}
 
 	// RFC 5321 holds the text of a reply to US-ASCII, and RFC 6531 section
-	// 3.7.4.2 widens it for a client that asked with the SMTPUTF8 parameter
-	// of the command. This server offers neither, so the reply carries no
-	// Unicode at all.
+	// 3.7.4.2 widens it for a client that asked with an SMTPUTF8 parameter on
+	// the command. The server takes that parameter on MAIL FROM alone, so the
+	// reply carries no Unicode at all, and Server.EnableSMTPUTF8 changes
+	// nothing here.
 	//
 	// The name of the user is the part that RFC 5321 section 3.5.1 leaves
 	// out, so a name of Unicode goes and the mailbox stays. A mailbox of

--- a/session_fuzz_test.go
+++ b/session_fuzz_test.go
@@ -74,6 +74,9 @@ func FuzzSession(f *testing.F) {
 	f.Add("EHLO x\r\nMAIL FROM:<jörg@example.org> SMTPUTF8\r\nRCPT TO:<用户@example.net>\r\nDATA\r\nGrüße\r\n.\r\nQUIT\r\n", uint8(16))
 	f.Add("EHLO x\r\nMAIL FROM:<a@example.org> SMTPUTF8\r\nRCPT TO:<b@example.net> ORCPT=utf-8;\\x{00F6}@example.net\r\nQUIT\r\n", uint8(24))
 	f.Add("EHLO x\r\nMAIL FROM:<\xff@example.org> SMTPUTF8\r\nRCPT TO:<b@\xc3(example.net>\r\n", uint8(16))
+	f.Add("EHLO x\r\nVRFY user@example.org\r\nQUIT\r\n", uint8(0))
+	f.Add("VRFY a@b\r\n250 injected\r\n", uint8(0))
+	f.Add("EHLO x\r\nVRFY \r\nVRFY \"a b\"@example.org\r\n", uint8(0))
 
 	f.Fuzz(func(t *testing.T, script string, options uint8) {
 		srv := &Server{
@@ -97,6 +100,13 @@ func FuzzSession(f *testing.F) {
 		srv.Use(Middleware{
 			Authenticate: func(ctx context.Context, _ Peer, _, _ string) (context.Context, error) {
 				return ctx, nil
+			},
+
+			// The name of a VRFY command comes from the client, and the
+			// reply carries the mailbox back. parseAddress is what keeps a
+			// line break out of that reply.
+			Verify: func(ctx context.Context, _ Peer, name string) (context.Context, Verification, error) {
+				return ctx, Verification{Mailbox: name, FullName: name}, nil
 			},
 		})
 

--- a/smtpd.go
+++ b/smtpd.go
@@ -46,7 +46,8 @@ type Peer struct {
 }
 
 // Error is the SMTP protocol error returned by middleware phase hooks
-// (CheckConnection, CheckHelo, CheckSender, CheckRecipient, Authenticate)
+// (CheckConnection, CheckHelo, CheckSender, CheckRecipient, Authenticate,
+// Verify)
 // and by Handler to signal a wire-level rejection. Code is the 3-digit
 // SMTP status code (for example 550 or 421) and Message is the text after
 // the code in the reply line. The session layer inspects the returned error
@@ -144,6 +145,25 @@ type Middleware struct {
 	CheckRecipient  func(ctx context.Context, peer Peer, addr string) (context.Context, error)
 	Authenticate    func(ctx context.Context, peer Peer, username, password string) (context.Context, error)
 	Reset           func(ctx context.Context, peer Peer) context.Context
+
+	// Verify runs for a VRFY command and looks the name up. name is the
+	// argument of the command, as the client wrote it: RFC 5321 section
+	// 3.5.1 gives a user name, a mailbox, or a string of another kind that
+	// the site knows.
+	//
+	// A hook that finds the user returns the mailbox, and the client gets a
+	// 250 reply with it. A hook that knows the name to be wrong returns an
+	// Error, such as 550 for a user that the server does not carry, or 553
+	// for a name that more than one user answers to.
+	//
+	// A hook that finds nothing returns the zero Verification and no error,
+	// and the hook after it looks next. A name that no hook verified gets a
+	// 252 reply, which RFC 5321 section 7.3 asks for: a server must never
+	// look as though it verified a name that it did not.
+	//
+	// The hooks run in Use order. The first one that finds a mailbox or
+	// returns an error ends the phase.
+	Verify func(ctx context.Context, peer Peer, name string) (context.Context, Verification, error)
 
 	// Disconnect runs exactly once per session, after the final reply is
 	// flushed and before the underlying connection is closed. err is nil
@@ -250,6 +270,7 @@ type Server struct {
 	senderCheckers     []func(ctx context.Context, peer Peer, addr string) (context.Context, error)
 	recipientCheckers  []func(ctx context.Context, peer Peer, addr string) (context.Context, error)
 	authenticators     []func(ctx context.Context, peer Peer, username, password string) (context.Context, error)
+	verifiers          []func(ctx context.Context, peer Peer, name string) (context.Context, Verification, error)
 	resetters          []func(ctx context.Context, peer Peer) context.Context
 	disconnecters      []func(ctx context.Context, peer Peer, err error)
 
@@ -282,6 +303,9 @@ func (srv *Server) Use(m Middleware) *Server {
 	}
 	if m.Authenticate != nil {
 		srv.authenticators = append(srv.authenticators, m.Authenticate)
+	}
+	if m.Verify != nil {
+		srv.verifiers = append(srv.verifiers, m.Verify)
 	}
 	if m.Reset != nil {
 		srv.resetters = append(srv.resetters, m.Reset)
@@ -345,6 +369,27 @@ func (srv *Server) authenticate(ctx context.Context, peer Peer, username, passwo
 		}
 	}
 	return ctx, nil
+}
+
+// verify runs the Verify hooks until one of them finds a mailbox or refuses
+// the name. A hook that finds nothing lets the next one look, and a name that
+// none of them verified comes back as the zero Verification.
+func (srv *Server) verify(ctx context.Context, peer Peer, name string) (context.Context, Verification, error) {
+	var (
+		verified Verification
+		err      error
+	)
+
+	for _, h := range srv.verifiers {
+		ctx, verified, err = h(ctx, peer, name)
+		if err != nil {
+			return ctx, Verification{}, err
+		}
+		if verified.Mailbox != "" {
+			return ctx, verified, nil
+		}
+	}
+	return ctx, Verification{}, nil
 }
 
 func (srv *Server) reset(ctx context.Context, peer Peer) context.Context {

--- a/smtpd_test.go
+++ b/smtpd_test.go
@@ -72,8 +72,10 @@ func TestSMTP(t *testing.T) {
 		t.Fatalf("Reset failed: %v", err)
 	}
 
-	if err := c.Verify("foobar@example.net"); err == nil {
-		t.Fatal("Unexpected support for VRFY")
+	// A server without a Verify hook verifies nothing, and RFC 5321 section
+	// 7.3 gives 252 for that.
+	if err := smtptest.Cmd(c.Text, 252, "VRFY foobar@example.net"); err != nil {
+		t.Fatalf("VRFY failed: %v", err)
 	}
 
 	if err := smtptest.Cmd(c.Text, 250, "NOOP"); err != nil {

--- a/verify.go
+++ b/verify.go
@@ -1,0 +1,61 @@
+package smtpd
+
+import "strings"
+
+// Verification is what a Verify hook found for the name that a VRFY command
+// carried. RFC 5321 section 3.5.1 gives the command a user name, a mailbox,
+// or a string of another kind that the site knows.
+//
+// The zero value says that the hook verified nothing, and the client gets the
+// 252 reply of RFC 5321 section 7.3. A hook that knows the name to be wrong
+// returns an Error instead, such as 550 for a user that the server does not
+// carry.
+type Verification struct {
+	// Mailbox is the address of the user, in the form that Envelope.Sender
+	// takes: "user@example.org", without the angle brackets. The server
+	// writes it inside them, which RFC 5321 section 3.5.2 asks for.
+	//
+	// The address needs a domain, because the client writes it into a RCPT
+	// TO command of its own. A mailbox that is not an address gets the 252
+	// reply, and the server writes the fault to the log.
+	Mailbox string
+
+	// FullName is the name of the user, such as "Jörg Smith". RFC 5321
+	// section 3.5.1 writes it before the mailbox, and it is optional.
+	//
+	// The server takes the angle brackets out of it, so that the reply
+	// carries one address alone.
+	FullName string
+}
+
+// cannotVerify is the reply to a name that the server did not verify. RFC
+// 5321 section 7.3 asks for 252 there, and for that code alone: a server that
+// answers 250 says that it verified the name, and one that answers 550 says
+// that the name is wrong.
+const cannotVerify = "Cannot VRFY user, but will accept message and attempt delivery"
+
+// verifyLine writes the text of a 250 reply to a VRFY command. RFC 5321
+// section 3.5.1 gives two forms for it:
+//
+//	User Name <local-part@domain>
+//	<local-part@domain>
+//
+// mailbox comes from parseAddress, so it is an address that the client can
+// write into a RCPT TO command.
+func verifyLine(fullName, mailbox string) string {
+	name := strings.TrimSpace(stripBrackets(fullName))
+	if name == "" {
+		return "<" + mailbox + ">"
+	}
+	return name + " <" + mailbox + ">"
+}
+
+// stripBrackets takes the angle brackets out of a name. The name of a user
+// comes from a directory of the site, where anything can stand, and a reply
+// that carries a second pair of brackets gives the client a second address.
+func stripBrackets(name string) string {
+	if !strings.ContainsAny(name, "<>") {
+		return name
+	}
+	return strings.NewReplacer("<", "", ">", "").Replace(name)
+}

--- a/verify.go
+++ b/verify.go
@@ -36,8 +36,9 @@ const cannotVerify = "Cannot VRFY user, but will accept message and attempt deli
 
 // cannotShowMailbox is the reply to a mailbox of Unicode. RFC 5321 holds a
 // reply to US-ASCII, and RFC 6531 section 3.7.4.2 gives UTF-8 to a client that
-// asked for it with the SMTPUTF8 parameter of a VRFY command. This server
-// offers neither, so it cannot write such a mailbox at all.
+// asked for it with an SMTPUTF8 parameter on the VRFY command. The server
+// takes that parameter on MAIL FROM alone, so it writes no mailbox of Unicode
+// in a reply at all.
 //
 // The same section gives 252 or 550 for that, with the status code X.6.8.
 const cannotShowMailbox = "Cannot show the mailbox of the user without a reply in UTF-8"

--- a/verify.go
+++ b/verify.go
@@ -34,6 +34,14 @@ type Verification struct {
 // that the name is wrong.
 const cannotVerify = "Cannot VRFY user, but will accept message and attempt delivery"
 
+// cannotShowMailbox is the reply to a mailbox of Unicode. RFC 5321 holds a
+// reply to US-ASCII, and RFC 6531 section 3.7.4.2 gives UTF-8 to a client that
+// asked for it with the SMTPUTF8 parameter of a VRFY command. This server
+// offers neither, so it cannot write such a mailbox at all.
+//
+// The same section gives 252 or 550 for that, with the status code X.6.8.
+const cannotShowMailbox = "Cannot show the mailbox of the user without a reply in UTF-8"
+
 // verifyLine writes the text of a 250 reply to a VRFY command. RFC 5321
 // section 3.5.1 gives two forms for it:
 //

--- a/verify_session_test.go
+++ b/verify_session_test.go
@@ -41,11 +41,30 @@ func TestVerifyReplies(t *testing.T) {
 		{
 			name: "a mailbox with the name of the user",
 			mws: []smtpd.Middleware{verifier(smtpd.Verification{
-				Mailbox:  "jörg@example.org",
+				Mailbox:  "joe@example.org",
+				FullName: "Joe Smith",
+			}, nil)},
+			cmd:  "VRFY Smith",
+			want: "250 2.1.5 Joe Smith <joe@example.org>",
+		},
+		{
+			// RFC 5321 section 3.5.1 leaves the name of the user out of the
+			// reply, so a name of Unicode goes and the mailbox stays.
+			name: "a name of Unicode",
+			mws: []smtpd.Middleware{verifier(smtpd.Verification{
+				Mailbox:  "joe@example.org",
 				FullName: "Jörg Smith",
 			}, nil)},
 			cmd:  "VRFY Smith",
-			want: "250 2.1.5 Jörg Smith <jörg@example.org>",
+			want: "250 2.1.5 <joe@example.org>",
+		},
+		{
+			// RFC 6531 section 3.7.4.2 gives a reply of UTF-8 to a client
+			// that asked for one, and this server offers no SMTPUTF8.
+			name: "a mailbox of Unicode",
+			mws:  []smtpd.Middleware{verifier(smtpd.Verification{Mailbox: "jörg@example.org"}, nil)},
+			cmd:  "VRFY Smith",
+			want: "252 2.6.8 Cannot show the mailbox of the user without a reply in UTF-8",
 		},
 		{
 			name: "a name that carries angle brackets",
@@ -89,10 +108,13 @@ func TestVerifyReplies(t *testing.T) {
 			want: "553 5.1.4 User ambiguous",
 		},
 		{
+			// RFC 5321 section 3.5.3 reads a 500 and a 502 as the answer of a
+			// server that does not carry the command, so a fault of the
+			// directory takes a 451. The text of the error stays in the log.
 			name: "a hook that fails",
 			mws:  []smtpd.Middleware{verifier(smtpd.Verification{}, errors.New("the directory is down"))},
 			cmd:  "VRFY user",
-			want: "502 5.5.1 the directory is down",
+			want: "451 4.3.0 Cannot verify the user right now",
 		},
 		{
 			name: "a command without a name",

--- a/verify_session_test.go
+++ b/verify_session_test.go
@@ -1,0 +1,324 @@
+package smtpd_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/chrj/smtpd/v2"
+	"github.com/chrj/smtpd/v2/smtptest"
+)
+
+// TestVerifyReplies covers the reply to a VRFY command for every answer that
+// a Verify hook can give.
+func TestVerifyReplies(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mws  []smtpd.Middleware
+		cmd  string
+		want string
+	}{
+		{
+			name: "no hook at all",
+			cmd:  "VRFY user@example.org",
+			want: "252 2.0.0 Cannot VRFY user, but will accept message and attempt delivery",
+		},
+		{
+			name: "a hook that finds nothing",
+			mws:  []smtpd.Middleware{verifier(smtpd.Verification{}, nil)},
+			cmd:  "VRFY user@example.org",
+			want: "252 2.0.0 Cannot VRFY user, but will accept message and attempt delivery",
+		},
+		{
+			name: "a mailbox alone",
+			mws:  []smtpd.Middleware{verifier(smtpd.Verification{Mailbox: "user@example.org"}, nil)},
+			cmd:  "VRFY user",
+			want: "250 2.1.5 <user@example.org>",
+		},
+		{
+			name: "a mailbox with the name of the user",
+			mws: []smtpd.Middleware{verifier(smtpd.Verification{
+				Mailbox:  "jörg@example.org",
+				FullName: "Jörg Smith",
+			}, nil)},
+			cmd:  "VRFY Smith",
+			want: "250 2.1.5 Jörg Smith <jörg@example.org>",
+		},
+		{
+			name: "a name that carries angle brackets",
+			mws: []smtpd.Middleware{verifier(smtpd.Verification{
+				Mailbox:  "user@example.org",
+				FullName: "Joe <other@example.net>",
+			}, nil)},
+			cmd:  "VRFY Joe",
+			want: "250 2.1.5 Joe other@example.net <user@example.org>",
+		},
+		{
+			name: "a mailbox with a local part in quotes",
+			mws:  []smtpd.Middleware{verifier(smtpd.Verification{Mailbox: `"a b"@example.org`}, nil)},
+			cmd:  "VRFY a b",
+			want: `250 2.1.5 <"a b"@example.org>`,
+		},
+		{
+			name: "a mailbox that is not an address",
+			mws:  []smtpd.Middleware{verifier(smtpd.Verification{Mailbox: "user"}, nil)},
+			cmd:  "VRFY user",
+			want: "252 2.0.0 Cannot VRFY user, but will accept message and attempt delivery",
+		},
+		{
+			name: "a user that the server does not carry",
+			mws: []smtpd.Middleware{verifier(smtpd.Verification{}, smtpd.Error{
+				Code:     550,
+				Enhanced: smtpd.EnhancedCode{5, 1, 1},
+				Message:  "No such user here",
+			})},
+			cmd:  "VRFY nobody",
+			want: "550 5.1.1 No such user here",
+		},
+		{
+			name: "a name that more than one user answers to",
+			mws: []smtpd.Middleware{verifier(smtpd.Verification{}, smtpd.Error{
+				Code:     553,
+				Enhanced: smtpd.EnhancedCode{5, 1, 4},
+				Message:  "User ambiguous",
+			})},
+			cmd:  "VRFY Smith",
+			want: "553 5.1.4 User ambiguous",
+		},
+		{
+			name: "a hook that fails",
+			mws:  []smtpd.Middleware{verifier(smtpd.Verification{}, errors.New("the directory is down"))},
+			cmd:  "VRFY user",
+			want: "502 5.5.1 the directory is down",
+		},
+		{
+			name: "a command without a name",
+			cmd:  "VRFY",
+			want: "501 5.5.4 Missing parameter",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := runserver(t, &smtpd.Server{Logger: testLogger(t)}, test.mws...)
+
+			c := dialRaw(t, srv.Addr)
+			if reply := c.send("EHLO localhost"); !strings.HasPrefix(reply, "250") {
+				t.Fatalf("EHLO reply = %q, want 250", reply)
+			}
+
+			if reply := c.send("%s", test.cmd); reply != test.want {
+				t.Errorf("%s reply = %q, want %q", test.cmd, reply, test.want)
+			}
+
+			// The session survives every one of these replies.
+			if reply := c.send("NOOP"); !strings.HasPrefix(reply, "250") {
+				t.Errorf("NOOP after the reply = %q, want 250", reply)
+			}
+		})
+	}
+}
+
+// TestVerifyBeforeGreeting covers a client that sends VRFY as its first
+// command. RFC 5321 section 4.1.4 lets it, because the command carries no
+// transaction. The reply has no status code, because the client never saw the
+// server offer the extension of RFC 2034.
+func TestVerifyBeforeGreeting(t *testing.T) {
+	t.Parallel()
+
+	srv := runserver(t, &smtpd.Server{Logger: testLogger(t)},
+		verifier(smtpd.Verification{Mailbox: "user@example.org"}, nil))
+
+	c := dialRaw(t, srv.Addr)
+	if reply := c.send("VRFY user"); reply != "250 <user@example.org>" {
+		t.Errorf("VRFY reply = %q, want %q", reply, "250 <user@example.org>")
+	}
+}
+
+// TestVerifyName covers the name that reaches the hook. RFC 5321 section
+// 3.5.1 leaves its form to the site, so the argument goes through as it came.
+func TestVerifyName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{name: "a user name", cmd: "VRFY Crispin", want: "Crispin"},
+		{name: "a mailbox", cmd: "VRFY user@example.org", want: "user@example.org"},
+		{name: "a name with a space", cmd: "VRFY Sam Q. Smith", want: "Sam Q. Smith"},
+		{name: "a name in quotes", cmd: `VRFY "Sam Smith"`, want: `"Sam Smith"`},
+		{name: "spaces around the name", cmd: "VRFY   Crispin   ", want: "Crispin"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := make(chan string, 1)
+			srv := runserver(t, &smtpd.Server{Logger: testLogger(t)}, smtpd.Middleware{
+				Verify: func(ctx context.Context, _ smtpd.Peer, name string) (context.Context, smtpd.Verification, error) {
+					got <- name
+					return ctx, smtpd.Verification{}, nil
+				},
+			})
+
+			c := dialRaw(t, srv.Addr)
+			if reply := c.send("%s", test.cmd); !strings.HasPrefix(reply, "252") {
+				t.Fatalf("%s reply = %q, want 252", test.cmd, reply)
+			}
+
+			if name := <-got; name != test.want {
+				t.Errorf("the hook read the name %q, want %q", name, test.want)
+			}
+		})
+	}
+}
+
+// TestVerifyHookOrder covers a server with more than one Verify hook. They run
+// in Use order, and the first one that finds a mailbox ends the phase.
+func TestVerifyHookOrder(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		first smtpd.Middleware
+		want  string
+		ran   bool
+	}{
+		{
+			name:  "the first hook finds nothing",
+			first: verifier(smtpd.Verification{}, nil),
+			want:  "250 2.1.5 <second@example.org>",
+			ran:   true,
+		},
+		{
+			name:  "the first hook finds the user",
+			first: verifier(smtpd.Verification{Mailbox: "first@example.org"}, nil),
+			want:  "250 2.1.5 <first@example.org>",
+		},
+		{
+			name:  "the first hook refuses the name",
+			first: verifier(smtpd.Verification{}, smtpd.Error{Code: 550, Message: "No such user here"}),
+			want:  "550 5.0.0 No such user here",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			second := make(chan struct{}, 1)
+			srv := runserver(t, &smtpd.Server{Logger: testLogger(t)},
+				test.first,
+				smtpd.Middleware{
+					Verify: func(ctx context.Context, _ smtpd.Peer, _ string) (context.Context, smtpd.Verification, error) {
+						second <- struct{}{}
+						return ctx, smtpd.Verification{Mailbox: "second@example.org"}, nil
+					},
+				})
+
+			c := dialRaw(t, srv.Addr)
+			if reply := c.send("EHLO localhost"); !strings.HasPrefix(reply, "250") {
+				t.Fatalf("EHLO reply = %q, want 250", reply)
+			}
+
+			if reply := c.send("VRFY user"); reply != test.want {
+				t.Errorf("VRFY reply = %q, want %q", reply, test.want)
+			}
+
+			if ran := len(second) == 1; ran != test.ran {
+				t.Errorf("the second hook ran = %v, want %v", ran, test.ran)
+			}
+		})
+	}
+}
+
+// TestVerifyPanicKeepsServerAlive covers a Verify hook that panics. The
+// client that reached it gets a 421 and the session ends, in the same way as
+// for every other hook, and the server carries on.
+func TestVerifyPanicKeepsServerAlive(t *testing.T) {
+	t.Parallel()
+
+	boom := panicOnce("boom")
+	srv := runserver(t, &smtpd.Server{Logger: testLogger(t)}, smtpd.Middleware{
+		Verify: func(ctx context.Context, _ smtpd.Peer, _ string) (context.Context, smtpd.Verification, error) {
+			boom()
+			return ctx, smtpd.Verification{Mailbox: "user@example.org"}, nil
+		},
+	})
+
+	c := dialRaw(t, srv.Addr)
+	if reply := c.send("VRFY user"); !strings.HasPrefix(reply, "421") {
+		t.Errorf("VRFY reply = %q, want 421", reply)
+	}
+
+	// The hook no longer panics, so a second connection proves that the
+	// server kept running.
+	second := dialRaw(t, srv.Addr)
+	if reply := second.send("VRFY user"); reply != "250 <user@example.org>" {
+		t.Errorf("VRFY reply = %q, want %q", reply, "250 <user@example.org>")
+	}
+}
+
+// TestVerifyKeepsTheTransaction covers RFC 5321 section 4.1.1.6: the command
+// has no effect on the reverse path, the forward path, or the message.
+func TestVerifyKeepsTheTransaction(t *testing.T) {
+	t.Parallel()
+
+	got := make(chan message, 1)
+	srv := runserver(t, &smtpd.Server{
+		Logger:  testLogger(t),
+		Handler: captureMessage(got),
+	}, verifier(smtpd.Verification{Mailbox: "user@example.org"}, nil))
+
+	c := srv.Dial()
+	if err := c.Hello("localhost"); err != nil {
+		t.Fatalf("EHLO failed: %v", err)
+	}
+
+	if err := smtptest.Cmd(c.Text, 250, "MAIL FROM:<sender@example.org>"); err != nil {
+		t.Fatalf("MAIL FROM failed: %v", err)
+	}
+	if err := smtptest.Cmd(c.Text, 250, "VRFY user"); err != nil {
+		t.Fatalf("VRFY failed: %v", err)
+	}
+	if err := smtptest.Cmd(c.Text, 250, "RCPT TO:<one@example.net>"); err != nil {
+		t.Fatalf("RCPT TO failed: %v", err)
+	}
+
+	w, err := c.Data()
+	if err != nil {
+		t.Fatalf("DATA failed: %v", err)
+	}
+	if _, err := w.Write([]byte("body\r\n")); err != nil {
+		t.Fatalf("write body failed: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close body failed: %v", err)
+	}
+
+	msg := <-got
+	if msg.readErr != nil {
+		t.Fatalf("the handler read the body with the error %v", msg.readErr)
+	}
+	if msg.sender != "sender@example.org" {
+		t.Errorf("sender = %q, want %q", msg.sender, "sender@example.org")
+	}
+	if len(msg.recipients) != 1 || msg.recipients[0] != "one@example.net" {
+		t.Errorf("recipients = %q, want %q", msg.recipients, []string{"one@example.net"})
+	}
+	if msg.body != "body\n" {
+		t.Errorf("body = %q, want %q", msg.body, "body\n")
+	}
+
+	if err := c.Quit(); err != nil {
+		t.Errorf("QUIT failed: %v", err)
+	}
+}

--- a/verify_test.go
+++ b/verify_test.go
@@ -1,0 +1,58 @@
+package smtpd
+
+import "testing"
+
+// TestVerifyLine covers the text of a 250 reply to a VRFY command. RFC 5321
+// section 3.5.1 gives the mailbox in angle brackets, with the name of the
+// user before it.
+func TestVerifyLine(t *testing.T) {
+	tests := []struct {
+		name     string
+		fullName string
+		mailbox  string
+		want     string
+	}{
+		{
+			name:    "a mailbox alone",
+			mailbox: "user@example.org",
+			want:    "<user@example.org>",
+		},
+		{
+			name:     "a mailbox with the name of the user",
+			fullName: "Jörg Smith",
+			mailbox:  "jörg@example.org",
+			want:     "Jörg Smith <jörg@example.org>",
+		},
+		{
+			name:     "a name of spaces alone",
+			fullName: "   ",
+			mailbox:  "user@example.org",
+			want:     "<user@example.org>",
+		},
+		{
+			name:     "spaces around the name",
+			fullName: "  Joe  ",
+			mailbox:  "user@example.org",
+			want:     "Joe <user@example.org>",
+		},
+		{
+			name:     "a name that carries an address of its own",
+			fullName: "Joe <other@example.net>",
+			mailbox:  "user@example.org",
+			want:     "Joe other@example.net <user@example.org>",
+		},
+		{
+			name:    "a local part in quotes",
+			mailbox: `"a b"@example.org`,
+			want:    `<"a b"@example.org>`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := verifyLine(test.fullName, test.mailbox); got != test.want {
+				t.Errorf("verifyLine(%q, %q) = %q, want %q", test.fullName, test.mailbox, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
[RFC 5321](https://www.rfc-editor.org/rfc/rfc5321) section 4.5.1 counts `VRFY`
among the commands that every server implements. The server answered `500` to
it, and section 3.5.3 counts that answer as a fault.

A `Verify` hook in the middleware looks the name up:

```go
srv.Use(smtpd.Middleware{
    Verify: func(ctx context.Context, peer smtpd.Peer, name string) (context.Context, smtpd.Verification, error) {
        user, err := directory.Lookup(ctx, name)
        if errors.Is(err, directory.ErrNoSuchUser) {
            return ctx, smtpd.Verification{}, smtpd.Error{
                Code:     550,
                Enhanced: smtpd.EnhancedCode{5, 1, 1},
                Message:  "No such user here",
            }
        }
        if err != nil {
            return ctx, smtpd.Verification{}, err
        }

        return ctx, smtpd.Verification{Mailbox: user.Mailbox, FullName: user.FullName}, nil
    },
})
```

```
C: VRFY Smith
S: 250 2.1.5 Jörg Smith <jörg@example.org>
```

| What the hook gives back | The reply |
| --- | --- |
| a `Verification` with a mailbox | `250` with the mailbox |
| the zero `Verification` and no error | `252` |
| an `Error` | the code of that error, such as `550` or `553` |
| an error of another kind | `451`, and the error goes to the log |

A hook that fails takes a `451`, because a `500` and a `502` say that the
server does not carry the command, which section 3.5.3 calls a fault. The text
of the error stays in the log: it comes from the site, and a client of any
kind reads a reply.

`Verification.Mailbox` is an address in the form that `Envelope.Sender` takes,
without the angle brackets. The server writes it inside them, which section
3.5.2 asks for: the client writes that address into a `RCPT TO` command of its
own. `FullName` is optional and stands before the mailbox, and the server
takes the angle brackets out of it so that the reply carries one address
alone.

The hooks run in `Use` order. The first one that finds a mailbox, or that
returns an error, ends the phase. The name reaches them as the client wrote
it, because section 3.5.1 leaves its form to the site.

### Two points for review

**A server without a `Verify` hook now answers `252`, where it answered `500`
before.** Section 7.3 asks for that code and no other one: a server that
answers `250` says that it verified the name, and one that answers `550` says
that the name is wrong. The `252` text tells the client nothing about the
name, so it gives no help to an address harvester. The hook reads `Peer`, so a
site can verify for an authenticated client alone.

**The server offers no `VRFY` keyword in the reply to `EHLO`.** Section 3.5.2
makes that keyword optional, because every server carries the command, and
Postfix leaves it out as well. It is one line to add.

A hook that gives back a mailbox which is not an address gets the `252` reply,
and the server writes the fault to the log at the `ERROR` level with the name
and the value. The reply carries an address that the client uses, so a broken
one never goes on the wire.

The reply keeps to US-ASCII, and `Server.EnableSMTPUTF8` changes nothing here.
RFC 6531 section 3.7.4.2 gives a reply of UTF-8 to a client that asked for one
with an `SMTPUTF8` parameter on the `VRFY` command, and the server takes that
parameter on `MAIL FROM` alone. A `FullName` of Unicode therefore goes and the
mailbox stays, because section 3.5.1 gives the name as the optional part. A
`Mailbox` of Unicode leaves nothing to write, so it takes `252 2.6.8`, the
status code for a reply that needs UTF-8 and cannot use it.

The `251` reply of a user that the server forwards for is out of reach from
the hook, because a `Verification` carries a mailbox alone. The `551` reply is
still there, through an `Error`.

### Tests

`verify_test.go` covers the text of a 250 reply. `verify_session_test.go`
drives whole sessions: every reply shape, the name that reaches the hook, the
order of two hooks, `VRFY` as the first command of a session, `VRFY` inside a
transaction that then delivers, and a hook that panics.

`FuzzSession` gained a `Verify` hook that gives the name of the client back as
the mailbox. A fuzzed name then travels into a reply line, where the property
that every line is a reply holds it. 40 seconds of fuzzing found nothing.

One commit here touches a test of another feature. `TestBDATLeavesNoGoroutine`
read `runtime.NumGoroutine`, which counts the goroutines of the whole process,
so the sessions of every test that runs next to it went into the count. The
tests of this branch tipped it over. The count now comes from a stack dump and
takes the goroutines that run the handler of that test alone, and the test
asks for none of them in the place of a tolerance of five. A handler that
hangs still fails it.

### Two follow-ups

- `EXPN` is a command of its own, with a multiline reply.
- RFC 6531 section 3.1 adds an `SMTPUTF8` parameter to `VRFY` and `EXPN`. The
  server takes that parameter on `MAIL FROM` alone, so a `VRFY` reply keeps to
  US-ASCII. Reading it on `VRFY` lets the reply carry a mailbox of Unicode.
