### PR TITLE
feat: take the SMTPUTF8 parameter of a VRFY command (RFC 6531)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   A server with `Server.EnableSMTPUTF8` takes the `SMTPUTF8` parameter of RFC
   6531 section 3.7.4.2 on the command, and the reply to that one command can
-  then carry a mailbox of Unicode. Without the parameter the reply keeps to
-  US-ASCII: a `FullName` of Unicode goes and the mailbox stays, and a
-  `Mailbox` of Unicode gets `252 2.6.8`.
+  then carry a mailbox of Unicode. The parameter takes no value, and a value
+  on it gets a `501` reply. Without the parameter the reply keeps to US-ASCII:
+  a `FullName` of Unicode goes and the mailbox stays, and a `Mailbox` of
+  Unicode gets `252 2.6.8`.
 
 - `Server.EnableSMTPUTF8` offers the `SMTPUTF8` extension of RFC 6531 and takes
   its parameter on `MAIL FROM`. Such a transaction carries an address of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,11 +38,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   implemented. A hook that fails gets a `451` for the same reason, and the
   error goes to the log.
 
-  The reply keeps to US-ASCII. RFC 6531 section 3.7.4.2 gives a reply of UTF-8
-  to a client that asked for one with an `SMTPUTF8` parameter on the `VRFY`
-  command, and the server takes that parameter on `MAIL FROM` alone. A
-  `FullName` of Unicode goes and the mailbox stays, and a `Mailbox` of Unicode
-  gets `252 2.6.8`.
+  A server with `Server.EnableSMTPUTF8` takes the `SMTPUTF8` parameter of RFC
+  6531 section 3.7.4.2 on the command, and the reply to that one command can
+  then carry a mailbox of Unicode. Without the parameter the reply keeps to
+  US-ASCII: a `FullName` of Unicode goes and the mailbox stays, and a
+  `Mailbox` of Unicode gets `252 2.6.8`.
 
 - `Server.EnableSMTPUTF8` offers the `SMTPUTF8` extension of RFC 6531 and takes
   its parameter on `MAIL FROM`. Such a transaction carries an address of

--- a/README.md
+++ b/README.md
@@ -521,8 +521,8 @@ C: VRFY Smith SMTPUTF8
 S: 250 2.1.5 Jörg Smith <jörg@example.org>
 ```
 
-The parameter stands after the name and takes no value. It holds for that one
-command, so the next `VRFY` needs it again.
+The parameter stands after the name and takes no value. A value on it gets a
+`501` reply. It holds for that one command, so the next `VRFY` needs it again.
 
 Without it, the reply keeps to US-ASCII. A `FullName` of Unicode goes, and the
 mailbox stays, because RFC 5321 section 3.5.1 gives the name as the optional
@@ -541,8 +541,14 @@ argument is the name there: `VRFY Smith SMTPUTF8` looks up `Smith SMTPUTF8`.
 The name of a user takes any form that the site knows, and `VRFY SMTPUTF8`
 asks for the user named `SMTPUTF8` on every server.
 
-The message of an `Error` goes on the wire as the hook wrote it. A hook that
-writes Unicode into one needs to know that the client reads it.
+A mailbox and a name of the hook reach the client as UTF-8, and as nothing
+else. A value that carries a byte outside that encoding gets the `252` reply,
+and the server writes the fault to the log.
+
+The message of an `Error` goes on the wire as the hook wrote it, and the
+server writes it to every client. The hook does not see the parameter, so keep
+that message to US-ASCII. The mailbox needs no such care: the server holds it
+back with a `252` where the client cannot read it.
 
 The server offers no `VRFY` keyword in the reply to `EHLO`. RFC 5321 section
 3.5.2 makes that keyword optional, because every server carries the command.

--- a/README.md
+++ b/README.md
@@ -512,14 +512,37 @@ A mailbox that is not an address gets the `252` reply, and the server writes
 the fault to the log at the `ERROR` level. The reply carries an address that
 the client uses, so a broken one never goes on the wire.
 
-The reply keeps to US-ASCII, and `Server.EnableSMTPUTF8` changes nothing here.
-RFC 6531 section 3.7.4.2 gives a reply of UTF-8 to a client that asked for one
-with an `SMTPUTF8` parameter on the `VRFY` command, and the server takes that
-parameter on `MAIL FROM` alone. A `FullName` of Unicode therefore goes, and
-the mailbox stays, because RFC 5321 section 3.5.1 gives the name as the
-optional part. A `Mailbox` of Unicode leaves nothing to write, so it gets
-`252 2.6.8`, which is the status code that RFC 6531 gives for a reply that
-needs UTF-8 and cannot use it.
+A reply of UTF-8 needs a client that reads one. RFC 6531 section 3.7.4.2 adds
+an `SMTPUTF8` parameter to the command for that, and a server with
+`Server.EnableSMTPUTF8` takes it:
+
+```
+C: VRFY Smith SMTPUTF8
+S: 250 2.1.5 Jörg Smith <jörg@example.org>
+```
+
+The parameter stands after the name and takes no value. It holds for that one
+command, so the next `VRFY` needs it again.
+
+Without it, the reply keeps to US-ASCII. A `FullName` of Unicode goes, and the
+mailbox stays, because RFC 5321 section 3.5.1 gives the name as the optional
+part. A `Mailbox` of Unicode leaves nothing to write, so it gets `252 2.6.8`,
+which is the status code that RFC 6531 gives for a reply that needs UTF-8 and
+cannot use it.
+
+| The client sends | The mailbox | The reply |
+| --- | --- | --- |
+| `VRFY Smith SMTPUTF8` | `jörg@example.org` | `250` with the mailbox |
+| `VRFY Smith` | `jörg@example.org` | `252 2.6.8` |
+| `VRFY Smith` | `joe@example.org` | `250` with the mailbox |
+
+A server without `EnableSMTPUTF8` knows no such parameter, so the whole
+argument is the name there: `VRFY Smith SMTPUTF8` looks up `Smith SMTPUTF8`.
+The name of a user takes any form that the site knows, and `VRFY SMTPUTF8`
+asks for the user named `SMTPUTF8` on every server.
+
+The message of an `Error` goes on the wire as the hook wrote it. A hook that
+writes Unicode into one needs to know that the client reads it.
 
 The server offers no `VRFY` keyword in the reply to `EHLO`. RFC 5321 section
 3.5.2 makes that keyword optional, because every server carries the command.

--- a/command.go
+++ b/command.go
@@ -63,6 +63,42 @@ func (cmd *command) singleArg() (string, bool) {
 	return fields[0], true
 }
 
+// smtputf8Param is the parameter that RFC 6531 section 3.7.4.2 adds to the
+// VRFY and EXPN commands. It carries no value.
+const smtputf8Param = "SMTPUTF8"
+
+// vrfyArg reads the argument of a VRFY command. RFC 6531 section 3.7.4.2
+// writes it as "VRFY" SP String [ SP "SMTPUTF8" ], so the name of the user
+// stands first and the parameter last.
+//
+// The parameter needs a name before it, because the String of the command
+// takes any form that the site knows: "VRFY SMTPUTF8" asks for the user of
+// that name.
+//
+// extension says that the server offers SMTPUTF8. A server without it knows
+// no such parameter, so the whole argument is the name there.
+func (cmd *command) vrfyArg(extension bool) (name string, smtputf8 bool) {
+	if cmd == nil {
+		return "", false
+	}
+
+	name = strings.TrimSpace(cmd.arg)
+	if !extension {
+		return name, false
+	}
+
+	space := strings.LastIndexAny(name, " \t")
+	if space < 0 {
+		return name, false
+	}
+
+	if !strings.EqualFold(strings.TrimLeft(name[space:], " \t"), smtputf8Param) {
+		return name, false
+	}
+
+	return strings.TrimRight(name[:space], " \t"), true
+}
+
 func (cmd *command) pathArg(keyword string) (path string, params map[string]string, err error) {
 	if cmd == nil {
 		return "", nil, SyntaxError{Message: "nil command"}

--- a/command.go
+++ b/command.go
@@ -77,26 +77,66 @@ const smtputf8Param = "SMTPUTF8"
 //
 // extension says that the server offers SMTPUTF8. A server without it knows
 // no such parameter, so the whole argument is the name there.
-func (cmd *command) vrfyArg(extension bool) (name string, smtputf8 bool) {
+//
+// The error says that the parameter came with a value, which RFC 6531 gives
+// it none of.
+func (cmd *command) vrfyArg(extension bool) (name string, smtputf8 bool, err error) {
 	if cmd == nil {
-		return "", false
+		return "", false, SyntaxError{Message: "nil command"}
 	}
 
 	name = strings.TrimSpace(cmd.arg)
 	if !extension {
-		return name, false
+		return name, false, nil
 	}
 
 	space := strings.LastIndexAny(name, " \t")
 	if space < 0 {
-		return name, false
+		return name, false, nil
 	}
 
-	if !strings.EqualFold(strings.TrimLeft(name[space:], " \t"), smtputf8Param) {
-		return name, false
+	last := strings.TrimLeft(name[space:], " \t")
+	keyword, value, valued := strings.Cut(last, "=")
+	if !equalASCIIFold(keyword, smtputf8Param) {
+		return name, false, nil
 	}
 
-	return strings.TrimRight(name[:space], " \t"), true
+	// RFC 6531 section 3.7.4.2 gives the parameter no value, and RFC 5321
+	// section 4.1.1.6 gives 501 for an argument that does not read.
+	if valued {
+		return "", false, cmd.syntaxError(fmt.Sprintf("the %s parameter takes no value, and it came with %q", smtputf8Param, value))
+	}
+
+	return strings.TrimRight(name[:space], " \t"), true, nil
+}
+
+// equalASCIIFold reports whether s is the keyword, with the letters of
+// US-ASCII in either case.
+//
+// strings.EqualFold takes the case folding of Unicode, where U+017F folds to
+// "s" and U+212A to "k". An SMTP keyword is US-ASCII, and a word of Unicode
+// that folds to one is a word of its own.
+func equalASCIIFold(s, keyword string) bool {
+	if len(s) != len(keyword) {
+		return false
+	}
+
+	for i := 0; i < len(s); i++ {
+		if asciiLower(s[i]) != asciiLower(keyword[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// asciiLower gives the lower case of a letter of US-ASCII, and every other
+// byte as it is.
+func asciiLower(c byte) byte {
+	if c >= 'A' && c <= 'Z' {
+		return c + 'a' - 'A'
+	}
+	return c
 }
 
 func (cmd *command) pathArg(keyword string) (path string, params map[string]string, err error) {

--- a/command_test.go
+++ b/command_test.go
@@ -152,6 +152,100 @@ func TestCommandPathArgRejectsInvalidInput(t *testing.T) {
 	}
 }
 
+// TestCommandVrfyArg covers the argument of a VRFY command. RFC 6531 section
+// 3.7.4.2 writes it as "VRFY" SP String [ SP "SMTPUTF8" ].
+func TestCommandVrfyArg(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		arg       string
+		extension bool
+		wantName  string
+		wantParam bool
+	}{
+		{
+			name:     "a name alone",
+			arg:      "Crispin",
+			wantName: "Crispin",
+		},
+		{
+			name:      "the parameter",
+			arg:       "Crispin SMTPUTF8",
+			extension: true,
+			wantName:  "Crispin",
+			wantParam: true,
+		},
+		{
+			name:      "the parameter in lower case",
+			arg:       "Crispin smtputf8",
+			extension: true,
+			wantName:  "Crispin",
+			wantParam: true,
+		},
+		{
+			name:      "a name that carries a space",
+			arg:       "Sam Q. Smith SMTPUTF8",
+			extension: true,
+			wantName:  "Sam Q. Smith",
+			wantParam: true,
+		},
+		{
+			name:      "spaces around the parameter",
+			arg:       "  Crispin   SMTPUTF8  ",
+			extension: true,
+			wantName:  "Crispin",
+			wantParam: true,
+		},
+		{
+			// The String of the command takes any form that the site knows,
+			// so a user of that name is one of them.
+			name:      "the parameter without a name",
+			arg:       "SMTPUTF8",
+			extension: true,
+			wantName:  "SMTPUTF8",
+		},
+		{
+			name:      "the parameter twice",
+			arg:       "Crispin SMTPUTF8 SMTPUTF8",
+			extension: true,
+			wantName:  "Crispin SMTPUTF8",
+			wantParam: true,
+		},
+		{
+			// A server that does not offer the extension knows no such
+			// parameter, so the word belongs to the name.
+			name:     "the parameter without the extension",
+			arg:      "Crispin SMTPUTF8",
+			wantName: "Crispin SMTPUTF8",
+		},
+		{
+			name:      "a word of another kind",
+			arg:       "Crispin UTF8",
+			extension: true,
+			wantName:  "Crispin UTF8",
+		},
+		{
+			name:      "no argument",
+			arg:       "",
+			extension: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := &command{action: "VRFY", arg: test.arg}
+			name, param := cmd.vrfyArg(test.extension)
+			if name != test.wantName || param != test.wantParam {
+				t.Errorf("vrfyArg(%q, %v) = %q, %v, want %q, %v",
+					test.arg, test.extension, name, param, test.wantName, test.wantParam)
+			}
+		})
+	}
+}
+
 func TestCommandSingleArg(t *testing.T) {
 	t.Parallel()
 

--- a/command_test.go
+++ b/command_test.go
@@ -163,6 +163,7 @@ func TestCommandVrfyArg(t *testing.T) {
 		extension bool
 		wantName  string
 		wantParam bool
+		wantErr   bool
 	}{
 		{
 			name:     "a name alone",
@@ -226,6 +227,40 @@ func TestCommandVrfyArg(t *testing.T) {
 			wantName:  "Crispin UTF8",
 		},
 		{
+			// strings.EqualFold takes the case folding of Unicode, where
+			// U+017F folds to "s". An SMTP keyword is US-ASCII.
+			name:      "a word that folds to the parameter in Unicode",
+			arg:       "Crispin \u017fMTPUTF8",
+			extension: true,
+			wantName:  "Crispin \u017fMTPUTF8",
+		},
+		{
+			// RFC 6531 section 3.7.4.2 gives the parameter no value.
+			name:      "the parameter with a value",
+			arg:       "Crispin SMTPUTF8=YES",
+			extension: true,
+			wantErr:   true,
+		},
+		{
+			name:      "the parameter with an empty value",
+			arg:       "Crispin SMTPUTF8=",
+			extension: true,
+			wantErr:   true,
+		},
+		{
+			// A server without the extension knows no parameter to refuse.
+			name:     "the parameter with a value without the extension",
+			arg:      "Crispin SMTPUTF8=YES",
+			wantName: "Crispin SMTPUTF8=YES",
+		},
+		{
+			// The parameter needs a name before it, so this one is a name.
+			name:      "a name that looks like the parameter with a value",
+			arg:       "SMTPUTF8=YES",
+			extension: true,
+			wantName:  "SMTPUTF8=YES",
+		},
+		{
 			name:      "no argument",
 			arg:       "",
 			extension: true,
@@ -237,7 +272,18 @@ func TestCommandVrfyArg(t *testing.T) {
 			t.Parallel()
 
 			cmd := &command{action: "VRFY", arg: test.arg}
-			name, param := cmd.vrfyArg(test.extension)
+			name, param, err := cmd.vrfyArg(test.extension)
+			if gotErr := err != nil; gotErr != test.wantErr {
+				t.Fatalf("vrfyArg(%q, %v) error = %v, want an error = %v",
+					test.arg, test.extension, err, test.wantErr)
+			}
+			if err != nil {
+				var syntaxErr SyntaxError
+				if !errors.As(err, &syntaxErr) {
+					t.Fatalf("error type = %T, want SyntaxError", err)
+				}
+				return
+			}
 			if name != test.wantName || param != test.wantParam {
 				t.Errorf("vrfyArg(%q, %v) = %q, %v, want %q, %v",
 					test.arg, test.extension, name, param, test.wantName, test.wantParam)

--- a/protocol.go
+++ b/protocol.go
@@ -499,7 +499,10 @@ func (s *session) handleVRFY(ctx context.Context, cmd *command) context.Context 
 	//
 	// smtputf8 says that the client sent the SMTPUTF8 parameter of RFC 6531
 	// section 3.7.4.2, which lets the reply to this one command carry UTF-8.
-	name, smtputf8 := cmd.vrfyArg(s.server.EnableSMTPUTF8)
+	name, smtputf8, err := cmd.vrfyArg(s.server.EnableSMTPUTF8)
+	if err != nil {
+		return s.replyEnhanced(ctx, 501, EnhancedCode{5, 5, 4}, "The SMTPUTF8 parameter takes no value")
+	}
 	if name == "" {
 		return s.replyEnhanced(ctx, 501, EnhancedCode{5, 5, 4}, "Missing parameter")
 	}
@@ -543,6 +546,17 @@ func (s *session) handleVRFY(ctx context.Context, cmd *command) context.Context 
 		return s.reply(ctx, 252, cannotVerify)
 	}
 
+	// RFC 6531 widens the reply to UTF-8, and to nothing else. A byte outside
+	// that encoding is not a character at all, and it reaches a client that
+	// reads the reply as UTF-8.
+	if !utf8.ValidString(mailbox) {
+		logger.ErrorContext(ctx, "the Verify hook gave a mailbox that is not UTF-8",
+			slog.String("name", name),
+			slog.String("mailbox", verified.Mailbox),
+		)
+		return s.reply(ctx, 252, cannotVerify)
+	}
+
 	fullName := verified.FullName
 
 	// RFC 5321 holds the text of a reply to US-ASCII, and RFC 6531 section
@@ -560,6 +574,14 @@ func (s *session) handleVRFY(ctx context.Context, cmd *command) context.Context 
 		if !isASCII(fullName) {
 			fullName = ""
 		}
+	} else if !utf8.ValidString(fullName) {
+		// The name of the user is the part that the reply can leave out, so a
+		// name that is not UTF-8 goes and the mailbox stays.
+		logger.ErrorContext(ctx, "the Verify hook gave a name that is not UTF-8",
+			slog.String("name", name),
+			slog.String("full_name", fullName),
+		)
+		fullName = ""
 	}
 
 	return s.replyEnhanced(ctx, 250, EnhancedCode{2, 1, 5}, verifyLine(fullName, mailbox))

--- a/protocol.go
+++ b/protocol.go
@@ -496,7 +496,10 @@ func (s *session) handleVRFY(ctx context.Context, cmd *command) context.Context 
 	// RFC 5321 section 3.5.1 leaves the form of the name to the site, so the
 	// argument goes to the hooks as it came. A name that carries a space
 	// reaches them whole.
-	name := strings.TrimSpace(cmd.arg)
+	//
+	// smtputf8 says that the client sent the SMTPUTF8 parameter of RFC 6531
+	// section 3.7.4.2, which lets the reply to this one command carry UTF-8.
+	name, smtputf8 := cmd.vrfyArg(s.server.EnableSMTPUTF8)
 	if name == "" {
 		return s.replyEnhanced(ctx, 501, EnhancedCode{5, 5, 4}, "Missing parameter")
 	}
@@ -540,23 +543,23 @@ func (s *session) handleVRFY(ctx context.Context, cmd *command) context.Context 
 		return s.reply(ctx, 252, cannotVerify)
 	}
 
+	fullName := verified.FullName
+
 	// RFC 5321 holds the text of a reply to US-ASCII, and RFC 6531 section
-	// 3.7.4.2 widens it for a client that asked with an SMTPUTF8 parameter on
-	// the command. The server takes that parameter on MAIL FROM alone, so the
-	// reply carries no Unicode at all, and Server.EnableSMTPUTF8 changes
-	// nothing here.
+	// 3.7.4.2 widens it for the client that asked with the SMTPUTF8 parameter
+	// of this command. A client without it reads a reply that it cannot,
+	// which the same section keeps it away from.
 	//
 	// The name of the user is the part that RFC 5321 section 3.5.1 leaves
 	// out, so a name of Unicode goes and the mailbox stays. A mailbox of
-	// Unicode leaves nothing to write, and the same section of RFC 6531 gives
-	// 252 for it.
-	if !isASCII(mailbox) {
-		return s.replyEnhanced(ctx, 252, EnhancedCode{2, 6, 8}, cannotShowMailbox)
-	}
-
-	fullName := verified.FullName
-	if !isASCII(fullName) {
-		fullName = ""
+	// Unicode leaves nothing to write, and RFC 6531 gives 252 for it.
+	if !smtputf8 {
+		if !isASCII(mailbox) {
+			return s.replyEnhanced(ctx, 252, EnhancedCode{2, 6, 8}, cannotShowMailbox)
+		}
+		if !isASCII(fullName) {
+			fullName = ""
+		}
 	}
 
 	return s.replyEnhanced(ctx, 250, EnhancedCode{2, 1, 5}, verifyLine(fullName, mailbox))

--- a/session_fuzz_test.go
+++ b/session_fuzz_test.go
@@ -77,6 +77,7 @@ func FuzzSession(f *testing.F) {
 	f.Add("EHLO x\r\nVRFY user@example.org\r\nQUIT\r\n", uint8(0))
 	f.Add("VRFY a@b\r\n250 injected\r\n", uint8(0))
 	f.Add("EHLO x\r\nVRFY \r\nVRFY \"a b\"@example.org\r\n", uint8(0))
+	f.Add("EHLO x\r\nVRFY jörg@example.org SMTPUTF8\r\nVRFY SMTPUTF8\r\nQUIT\r\n", uint8(16))
 
 	f.Fuzz(func(t *testing.T, script string, options uint8) {
 		srv := &Server{

--- a/smtpd.go
+++ b/smtpd.go
@@ -161,10 +161,13 @@ type Middleware struct {
 	// 252 reply, which RFC 5321 section 7.3 asks for: a server must never
 	// look as though it verified a name that it did not.
 	//
-	// The message of an Error goes on the wire as the hook wrote it. RFC 6531
-	// section 3.7.4.2 holds a reply to US-ASCII unless the client asked for
-	// UTF-8 with the SMTPUTF8 parameter of the command, so a hook that writes
-	// Unicode into a message needs to know that the client reads it.
+	// The message of an Error goes on the wire as the hook wrote it, and the
+	// server writes it to every client. RFC 6531 section 3.7.4.2 holds a
+	// reply to US-ASCII unless the client asked for UTF-8, and the hook does
+	// not see that parameter, so keep the message to US-ASCII.
+	//
+	// The mailbox needs no such care. A mailbox of Unicode takes the reply of
+	// RFC 6531 where the client asked for one, and a 252 where it did not.
 	//
 	// The hooks run in Use order. The first one that finds a mailbox or
 	// returns an error ends the phase.

--- a/smtpd.go
+++ b/smtpd.go
@@ -161,6 +161,11 @@ type Middleware struct {
 	// 252 reply, which RFC 5321 section 7.3 asks for: a server must never
 	// look as though it verified a name that it did not.
 	//
+	// The message of an Error goes on the wire as the hook wrote it. RFC 6531
+	// section 3.7.4.2 holds a reply to US-ASCII unless the client asked for
+	// UTF-8 with the SMTPUTF8 parameter of the command, so a hook that writes
+	// Unicode into a message needs to know that the client reads it.
+	//
 	// The hooks run in Use order. The first one that finds a mailbox or
 	// returns an error ends the phase.
 	Verify func(ctx context.Context, peer Peer, name string) (context.Context, Verification, error)
@@ -215,6 +220,9 @@ type Server struct {
 	// parameter on MAIL FROM. A transaction that carries the parameter takes
 	// an address of Unicode in UTF-8, and Envelope.SMTPUTF8 tells the handler
 	// that it did.
+	//
+	// A VRFY command takes the parameter as well, and the reply to that one
+	// command can then carry a mailbox of Unicode. See Middleware.Verify.
 	//
 	// The extension is off by default. A server that offers it says that it
 	// carries such a message onward, and the next server on the way has to

--- a/smtptest/smtptest_test.go
+++ b/smtptest/smtptest_test.go
@@ -307,8 +307,19 @@ func TestServerDialAfterServeError(t *testing.T) {
 	srv.Config.BaseContext = func(net.Listener) context.Context { return nil }
 	srv.Start()
 
-	// Serve stops on its own here, so the test waits for that to happen.
-	// Close would panic on the same error, so this test does not call it.
+	// Serve stops on its own here, and it closes the listener as it goes, so
+	// the test waits for that first. Close would panic on the same error, so
+	// this test does not call it.
+	//
+	// A dial before the close reaches a listener that nothing accepts on, and
+	// it then waits for a greeting that never comes. The loop below reads its
+	// deadline between the dials, so one dial of that kind takes the whole
+	// time and the test fails with a dial error.
+	waitForRefused(t, srv.Addr)
+
+	// Serve closes the listener before it reports, so the reason reaches the
+	// channel of the server a moment after the close. Every dial here fails
+	// at once, because nothing listens any more.
 	deadline := time.Now().Add(5 * time.Second)
 	for {
 		got := dialPanic(srv)
@@ -317,6 +328,27 @@ func TestServerDialAfterServeError(t *testing.T) {
 		}
 		if time.Now().After(deadline) {
 			t.Fatalf("Dial did not report the reason of the stop: got %v", got)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// waitForRefused waits until nothing listens on addr any more. A connection
+// reaches an open listener that nothing accepts on, so a dial that succeeds
+// says that the listener is still there.
+func waitForRefused(t *testing.T, addr string) {
+	t.Helper()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		conn, err := net.DialTimeout("tcp", addr, time.Second)
+		if err != nil {
+			return
+		}
+		_ = conn.Close()
+
+		if time.Now().After(deadline) {
+			t.Fatalf("the listener on %s still takes connections", addr)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/verify.go
+++ b/verify.go
@@ -34,11 +34,10 @@ type Verification struct {
 // that the name is wrong.
 const cannotVerify = "Cannot VRFY user, but will accept message and attempt delivery"
 
-// cannotShowMailbox is the reply to a mailbox of Unicode. RFC 5321 holds a
-// reply to US-ASCII, and RFC 6531 section 3.7.4.2 gives UTF-8 to a client that
-// asked for it with an SMTPUTF8 parameter on the VRFY command. The server
-// takes that parameter on MAIL FROM alone, so it writes no mailbox of Unicode
-// in a reply at all.
+// cannotShowMailbox is the reply to a mailbox of Unicode that the client
+// cannot read. RFC 5321 holds a reply to US-ASCII, and RFC 6531 section
+// 3.7.4.2 gives UTF-8 to a client that asked for it with the SMTPUTF8
+// parameter of the VRFY command.
 //
 // The same section gives 252 or 550 for that, with the status code X.6.8.
 const cannotShowMailbox = "Cannot show the mailbox of the user without a reply in UTF-8"

--- a/verify_session_test.go
+++ b/verify_session_test.go
@@ -262,6 +262,159 @@ func TestVerifyHookOrder(t *testing.T) {
 	}
 }
 
+// TestVerifySMTPUTF8 covers the SMTPUTF8 parameter of RFC 6531 section
+// 3.7.4.2. A client that sends it reads a reply of UTF-8, and a client
+// without it reads one of US-ASCII.
+func TestVerifySMTPUTF8(t *testing.T) {
+	t.Parallel()
+
+	unicode := smtpd.Verification{Mailbox: "jörg@example.org", FullName: "Jörg Smith"}
+
+	tests := []struct {
+		name     string
+		enabled  bool
+		verified smtpd.Verification
+		cmd      string
+		want     string
+	}{
+		{
+			name:     "the parameter with a mailbox of Unicode",
+			enabled:  true,
+			verified: unicode,
+			cmd:      "VRFY Smith SMTPUTF8",
+			want:     "250 2.1.5 Jörg Smith <jörg@example.org>",
+		},
+		{
+			name:     "the parameter in lower case",
+			enabled:  true,
+			verified: unicode,
+			cmd:      "VRFY Smith smtputf8",
+			want:     "250 2.1.5 Jörg Smith <jörg@example.org>",
+		},
+		{
+			name:     "no parameter",
+			enabled:  true,
+			verified: unicode,
+			cmd:      "VRFY Smith",
+			want:     "252 2.6.8 Cannot show the mailbox of the user without a reply in UTF-8",
+		},
+		{
+			// The server offers no extension, so it knows no such parameter
+			// and the word belongs to the name. The hook finds no user of
+			// that name here.
+			name:     "the parameter without the extension",
+			verified: unicode,
+			cmd:      "VRFY Smith SMTPUTF8",
+			want:     "252 2.6.8 Cannot show the mailbox of the user without a reply in UTF-8",
+		},
+		{
+			name:     "the parameter with a name of Unicode alone",
+			enabled:  true,
+			verified: smtpd.Verification{Mailbox: "joe@example.org", FullName: "Jörg Smith"},
+			cmd:      "VRFY Smith SMTPUTF8",
+			want:     "250 2.1.5 Jörg Smith <joe@example.org>",
+		},
+		{
+			name:     "a mailbox of US-ASCII with the parameter",
+			enabled:  true,
+			verified: smtpd.Verification{Mailbox: "joe@example.org"},
+			cmd:      "VRFY Smith SMTPUTF8",
+			want:     "250 2.1.5 <joe@example.org>",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := runserver(t, &smtpd.Server{
+				Logger:         testLogger(t),
+				EnableSMTPUTF8: test.enabled,
+			}, verifier(test.verified, nil))
+
+			c := dialRaw(t, srv.Addr)
+			if reply := c.send("EHLO localhost"); !strings.HasPrefix(reply, "250") {
+				t.Fatalf("EHLO reply = %q, want 250", reply)
+			}
+
+			if reply := c.send("%s", test.cmd); reply != test.want {
+				t.Errorf("%s reply = %q, want %q", test.cmd, reply, test.want)
+			}
+		})
+	}
+}
+
+// TestVerifySMTPUTF8EndsWithTheCommand covers RFC 6531 section 3.7.4.2: the
+// parameter enables a reply of UTF-8 for that one command.
+func TestVerifySMTPUTF8EndsWithTheCommand(t *testing.T) {
+	t.Parallel()
+
+	srv := runserver(t, &smtpd.Server{
+		Logger:         testLogger(t),
+		EnableSMTPUTF8: true,
+	}, verifier(smtpd.Verification{Mailbox: "jörg@example.org"}, nil))
+
+	c := dialRaw(t, srv.Addr)
+	if reply := c.send("EHLO localhost"); !strings.HasPrefix(reply, "250") {
+		t.Fatalf("EHLO reply = %q, want 250", reply)
+	}
+
+	if reply := c.send("VRFY Smith SMTPUTF8"); reply != "250 2.1.5 <jörg@example.org>" {
+		t.Fatalf("the first VRFY reply = %q, want %q", reply, "250 2.1.5 <jörg@example.org>")
+	}
+
+	want := "252 2.6.8 Cannot show the mailbox of the user without a reply in UTF-8"
+	if reply := c.send("VRFY Smith"); reply != want {
+		t.Errorf("the second VRFY reply = %q, want %q", reply, want)
+	}
+}
+
+// TestVerifySMTPUTF8Name covers the name that reaches the hook when the
+// client sends the parameter.
+func TestVerifySMTPUTF8Name(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{name: "a user name", cmd: "VRFY Crispin SMTPUTF8", want: "Crispin"},
+		{name: "a name of Unicode", cmd: "VRFY Jörg SMTPUTF8", want: "Jörg"},
+		{name: "a name with a space", cmd: "VRFY Sam Q. Smith SMTPUTF8", want: "Sam Q. Smith"},
+		{name: "a user of the name of the parameter", cmd: "VRFY SMTPUTF8", want: "SMTPUTF8"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := make(chan string, 1)
+			srv := runserver(t, &smtpd.Server{
+				Logger:         testLogger(t),
+				EnableSMTPUTF8: true,
+			}, smtpd.Middleware{
+				Verify: func(ctx context.Context, _ smtpd.Peer, name string) (context.Context, smtpd.Verification, error) {
+					got <- name
+					return ctx, smtpd.Verification{}, nil
+				},
+			})
+
+			c := dialRaw(t, srv.Addr)
+			if reply := c.send("EHLO localhost"); !strings.HasPrefix(reply, "250") {
+				t.Fatalf("EHLO reply = %q, want 250", reply)
+			}
+			if reply := c.send("%s", test.cmd); !strings.HasPrefix(reply, "252") {
+				t.Fatalf("%s reply = %q, want 252", test.cmd, reply)
+			}
+
+			if name := <-got; name != test.want {
+				t.Errorf("the hook read the name %q, want %q", name, test.want)
+			}
+		})
+	}
+}
+
 // TestVerifyPanicKeepsServerAlive covers a Verify hook that panics. The
 // client that reached it gets a 421 and the session ends, in the same way as
 // for every other hook, and the server carries on.

--- a/verify_session_test.go
+++ b/verify_session_test.go
@@ -344,6 +344,68 @@ func TestVerifySMTPUTF8(t *testing.T) {
 	}
 }
 
+// TestVerifySMTPUTF8Refused covers the replies to a parameter and to a
+// mailbox that the server cannot write.
+func TestVerifySMTPUTF8Refused(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		verified smtpd.Verification
+		cmd      string
+		want     string
+	}{
+		{
+			// RFC 6531 section 3.7.4.2 gives the parameter no value.
+			name:     "the parameter with a value",
+			verified: smtpd.Verification{Mailbox: "joe@example.org"},
+			cmd:      "VRFY Smith SMTPUTF8=YES",
+			want:     "501 5.5.4 The SMTPUTF8 parameter takes no value",
+		},
+		{
+			name:     "a mailbox that is not UTF-8",
+			verified: smtpd.Verification{Mailbox: "j\xf6rg@example.org"},
+			cmd:      "VRFY Smith SMTPUTF8",
+			want:     "252 2.0.0 Cannot VRFY user, but will accept message and attempt delivery",
+		},
+		{
+			// The name of the user is the part that the reply leaves out.
+			name: "a name that is not UTF-8",
+			verified: smtpd.Verification{
+				Mailbox:  "jörg@example.org",
+				FullName: "J\xf6rg Smith",
+			},
+			cmd:  "VRFY Smith SMTPUTF8",
+			want: "250 2.1.5 <jörg@example.org>",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := runserver(t, &smtpd.Server{
+				Logger:         testLogger(t),
+				EnableSMTPUTF8: true,
+			}, verifier(test.verified, nil))
+
+			c := dialRaw(t, srv.Addr)
+			if reply := c.send("EHLO localhost"); !strings.HasPrefix(reply, "250") {
+				t.Fatalf("EHLO reply = %q, want 250", reply)
+			}
+
+			if reply := c.send("%s", test.cmd); reply != test.want {
+				t.Errorf("%s reply = %q, want %q", test.cmd, reply, test.want)
+			}
+
+			// The session survives every one of these replies.
+			if reply := c.send("NOOP"); !strings.HasPrefix(reply, "250") {
+				t.Errorf("NOOP after the reply = %q, want 250", reply)
+			}
+		})
+	}
+}
+
 // TestVerifySMTPUTF8EndsWithTheCommand covers RFC 6531 section 3.7.4.2: the
 // parameter enables a reply of UTF-8 for that one command.
 func TestVerifySMTPUTF8EndsWithTheCommand(t *testing.T) {
@@ -383,6 +445,7 @@ func TestVerifySMTPUTF8Name(t *testing.T) {
 		{name: "a name of Unicode", cmd: "VRFY Jörg SMTPUTF8", want: "Jörg"},
 		{name: "a name with a space", cmd: "VRFY Sam Q. Smith SMTPUTF8", want: "Sam Q. Smith"},
 		{name: "a user of the name of the parameter", cmd: "VRFY SMTPUTF8", want: "SMTPUTF8"},
+		{name: "a word that folds to the parameter in Unicode", cmd: "VRFY Smith \u017fMTPUTF8", want: "Smith \u017fMTPUTF8"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
RFC 6531 section 3.7.4.2 adds an `SMTPUTF8` parameter to the `VRFY` command. A
client that sends it says that it reads a reply of UTF-8, and a server with
`Server.EnableSMTPUTF8` takes it:

```
C: VRFY Smith SMTPUTF8
S: 250 2.1.5 Jörg Smith <jörg@example.org>
```

The parameter takes no value, and a value on it gets a `501` reply, in the way
that the same parameter does on `MAIL FROM`. It holds for that one command, so
the next `VRFY` needs it again.
Without it, the reply keeps to US-ASCII, which is what the server did until
now: a `FullName` of Unicode goes and the mailbox stays, and a `Mailbox` of
Unicode gets `252 2.6.8`.

| The client sends | The mailbox | The reply |
| --- | --- | --- |
| `VRFY Smith SMTPUTF8` | `jörg@example.org` | `250` with the mailbox |
| `VRFY Smith` | `jörg@example.org` | `252 2.6.8` |
| `VRFY Smith` | `joe@example.org` | `250` with the mailbox |

### The grammar

The parameter stands after the name and takes no value:

```
vrfy = "VRFY" SP String [ SP "SMTPUTF8" ] CRLF
```

It needs a name before it. The `String` of the command takes any form that the
site knows, so `VRFY SMTPUTF8` asks for the user named `SMTPUTF8`, on every
server.

A server without `EnableSMTPUTF8` knows no such parameter, so the whole
argument is the name there and `VRFY Smith SMTPUTF8` looks up `Smith
SMTPUTF8`. That keeps the command as it was for a server that does not offer
the extension.

RFC 6531 widens the reply to UTF-8, and to nothing else. A `Mailbox` that
carries a byte outside that encoding gets the `252` reply, and a `FullName`
that does goes, in the way that the `MAIL FROM` and `RCPT TO` paths read an
address.

The keyword is read as US-ASCII. `strings.EqualFold` takes the case folding of
Unicode, where U+017F folds to "s", so `VRFY Smith ſMTPUTF8` would have read as
a name of `Smith` with the parameter set.

### One thing left to the hook

The message of an `Error` goes on the wire as the hook wrote it, and the
server writes it to every client. The hook does not see the parameter, so
`Middleware.Verify` asks for a message of US-ASCII. The mailbox needs no such
care: the server holds a mailbox of Unicode back with a `252` where the client
cannot read it.

### Tests

`TestCommandVrfyArg` covers the grammar: the parameter, the parameter in lower
case, a name with a space before it, a user of the name of the parameter, and
a server without the extension.

`TestVerifySMTPUTF8` drives the replies for both forms, and
`TestVerifySMTPUTF8EndsWithTheCommand` holds the rule that the parameter
covers one command. `TestVerifySMTPUTF8Name` reads the name back from the
hook.

`FuzzSession` gained a seed that sends the parameter.

One commit here touches a test of the `smtptest` package.
`TestServerDialAfterServeError` dialed in a loop until `Dial` reported why the
server stopped, and it read its deadline between the dials. A dial before
`Serve` returns reaches a listener that nothing accepts on, because the
listener is open from `NewUnstartedServer` and `Serve` closes it on the way
out. Such a dial waits for a greeting that never comes, and one of them takes
the whole deadline of the loop. The test now waits for the listener to close
first, and every dial after that fails at once.

`EXPN` takes the same parameter in RFC 6531. The server carries no `EXPN`
command, so that one waits for it.
