### PR TITLE
fix: read every SMTP keyword as US-ASCII

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The readers of an SMTP keyword take the letters of US-ASCII, where they took
+  `strings.EqualFold` before. That function folds the case of Unicode, and two
+  runes fold to a letter of US-ASCII: U+017F to `s` and U+212A to `k`.
+
+  `BDAT 10 LAſT` therefore ended a message, where `LAſT` is not the marker of
+  RFC 3030. The two other readers, the `utf-8` address type of an `ORCPT`
+  parameter and the marks of an `XCLIENT` attribute, carry no letter that a
+  rune of Unicode folds to today, and they take the same reader now.
+
 - A control character in the message of a reply becomes a space. A middleware
   writes what it knows into the message of a refusal, and some of that comes
   from the client. The user name of an `AUTH` command is one example: the

--- a/command.go
+++ b/command.go
@@ -273,7 +273,7 @@ func (cmd *command) bdatArg() (size int64, last, sized bool, err error) {
 	}
 
 	if len(args) == 2 {
-		if !strings.EqualFold(args[1], "LAST") {
+		if !equalASCIIFold(args[1], "LAST") {
 			return size, false, true, cmd.syntaxError("invalid end marker")
 		}
 		last = true

--- a/command_test.go
+++ b/command_test.go
@@ -154,6 +154,40 @@ func TestCommandPathArgRejectsInvalidInput(t *testing.T) {
 
 // TestCommandVrfyArg covers the argument of a VRFY command. RFC 6531 section
 // 3.7.4.2 writes it as "VRFY" SP String [ SP "SMTPUTF8" ].
+// TestEqualASCIIFold covers the reader of an SMTP keyword. Two runes of
+// Unicode fold to a letter of US-ASCII, and strings.EqualFold takes both:
+// U+017F folds to "s" and U+212A to "k".
+func TestEqualASCIIFold(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		in      string
+		keyword string
+		want    bool
+	}{
+		{name: "the keyword", in: "LAST", keyword: "LAST", want: true},
+		{name: "lower case", in: "last", keyword: "LAST", want: true},
+		{name: "mixed case", in: "LaSt", keyword: "LAST", want: true},
+		{name: "a word of another kind", in: "FIRST", keyword: "LAST"},
+		{name: "one letter short", in: "LAS", keyword: "LAST"},
+		{name: "one letter too many", in: "LASTX", keyword: "LAST"},
+		{name: "an empty word", in: "", keyword: "LAST"},
+		{name: "the long s of Unicode", in: "LAſT", keyword: "LAST"},
+		{name: "the kelvin sign of Unicode", in: "\u212aEY", keyword: "KEY"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := equalASCIIFold(test.in, test.keyword); got != test.want {
+				t.Errorf("equalASCIIFold(%q, %q) = %v, want %v", test.in, test.keyword, got, test.want)
+			}
+		})
+	}
+}
+
 func TestCommandVrfyArg(t *testing.T) {
 	t.Parallel()
 
@@ -346,6 +380,8 @@ func TestBdatArg(t *testing.T) {
 		// The length reads in these two, so the server can still take the
 		// chunk off the wire and keep the session.
 		{name: "a mark of another kind", arg: "10 FIRST", wantSize: 10, wantSized: true, wantErr: true},
+		// An SMTP keyword is US-ASCII, and U+017F folds to "s" in Unicode.
+		{name: "the mark with the long s of Unicode", arg: "10 LAſT", wantSize: 10, wantSized: true, wantErr: true},
 		{name: "three arguments", arg: "10 LAST LAST", wantSize: 10, wantSized: true, wantErr: true},
 	}
 

--- a/command_test.go
+++ b/command_test.go
@@ -152,8 +152,6 @@ func TestCommandPathArgRejectsInvalidInput(t *testing.T) {
 	}
 }
 
-// TestCommandVrfyArg covers the argument of a VRFY command. RFC 6531 section
-// 3.7.4.2 writes it as "VRFY" SP String [ SP "SMTPUTF8" ].
 // TestEqualASCIIFold covers the reader of an SMTP keyword. Two runes of
 // Unicode fold to a letter of US-ASCII, and strings.EqualFold takes both:
 // U+017F folds to "s" and U+212A to "k".
@@ -188,6 +186,8 @@ func TestEqualASCIIFold(t *testing.T) {
 	}
 }
 
+// TestCommandVrfyArg covers the argument of a VRFY command. RFC 6531 section
+// 3.7.4.2 writes it as "VRFY" SP String [ SP "SMTPUTF8" ].
 func TestCommandVrfyArg(t *testing.T) {
 	t.Parallel()
 

--- a/dsn.go
+++ b/dsn.go
@@ -199,7 +199,7 @@ func parseORcpt(value string, utf8Type, raw bool) (addrType, addr string, ok boo
 		return "", "", false
 	}
 
-	if utf8Type && strings.EqualFold(addrType, utf8AddrType) {
+	if utf8Type && equalASCIIFold(addrType, utf8AddrType) {
 		addr, ok = parseUnitext(encoded, raw)
 	} else {
 		addr, ok = parseXtext(encoded)

--- a/xtext.go
+++ b/xtext.go
@@ -61,8 +61,8 @@ func hexDigit(c byte) (byte, bool) {
 // information for that attribute. Postfix sends these two marks, and the
 // attribute they carry has to stay as it was.
 func isUnavailable(value string) bool {
-	return strings.EqualFold(value, "[UNAVAILABLE]") ||
-		strings.EqualFold(value, "[TEMPUNAVAIL]")
+	return equalASCIIFold(value, "[UNAVAILABLE]") ||
+		equalASCIIFold(value, "[TEMPUNAVAIL]")
 }
 
 // parseXtext decodes the xtext of RFC 3461 section 4 and reports whether the


### PR DESCRIPTION
Follow-up to #57, where the reader of the `SMTPUTF8` parameter of a `VRFY`
command moved off `strings.EqualFold`. The other readers of a keyword take it
still.

`strings.EqualFold` folds the case of Unicode. Two runes fold to a letter of
US-ASCII, and no others do:

| The rune | Folds to |
| --- | --- |
| U+017F, the long s | `s` |
| U+212A, the kelvin sign | `k` |

### The one that a client can reach

`BDAT 10 LAſT` ended a message. `LAſT` is not the marker that RFC 3030 gives,
and a client that writes it means something else, or nothing at all.

The reader of the marker now takes the letters of US-ASCII, so such a command
gets the `501` reply of a marker of any other kind. The chunk still comes off
the wire, which is what RFC 3030 asks for.

### The two that carry no such letter

The `utf-8` address type of an `ORCPT` parameter, and the `[UNAVAILABLE]` and
`[TEMPUNAVAIL]` marks of an `XCLIENT` attribute, hold no `s` and no `k`. No
rune of Unicode folds into them today.

They take the same reader now, so that a keyword of the server stays US-ASCII
whatever the tables of Unicode come to hold. The reader is `equalASCIIFold`,
which #57 added, and `TestEqualASCIIFold` covers it.

### One reader that stays as it is

`redactLine` reads the first word of a line to find an `AUTH` command, and it
keeps `strings.EqualFold`. That reader takes more lines than the dispatcher
does, and every line that it takes gets its credentials redacted. `AUTH`
carries no `s` and no `k`, so the two agree on every line today, and the
lenient one is the safe side of that pair.

### A finding for another change

`parseCommand` reads the verb of a command with `strings.ToUpper`, and
`parseESMTPParams` reads the name of a parameter the same way. `ToUpper` maps
U+0131 to `I` and U+017F to `S`, so `MAıL FROM:<a@b>` opens a transaction and
`sıze=100` reads as the `SIZE` parameter. The values of `BODY`, `RET` and
`NOTIFY` take `ToUpper` as well.

None of that reaches the credentials of an `AUTH` command, because `AUTH`
carries no `I` and no `S`. It is a wider change than this one, so it waits for
a word from you.
