### PR TITLE
fix: give the Dial of a test server a deadline for the handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `smtptest.Server.Dial` gives up after ten seconds on the part of a session
+  that comes before the test: the connection, the greeting, and the TLS
+  handshake of a transport that needs one. It waited for the greeting with no
+  deadline before.
+
+  A server that takes a connection and answers nothing held the client for as
+  long as the test run, and the run then failed on its own timeout, with no
+  line to name the cause. A listener that nobody accepts on does that, because
+  the connection reaches the queue of the listener and waits there.
+
+  The deadline comes off once the handshake is over, so a test that drives a
+  slow session keeps its own pace.
+
 - The parser of a `MAIL FROM` and `RCPT TO` command takes a parameter keyword
   that comes without a value, which is the form of the `SMTPUTF8` parameter.
   RFC 5321 section 4.1.2 writes the value as an optional part.

--- a/smtptest/dial_internal_test.go
+++ b/smtptest/dial_internal_test.go
@@ -1,0 +1,63 @@
+package smtptest
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chrj/smtpd/v2"
+)
+
+// TestDialGivesUpOnASilentServer covers a server that takes the connection and
+// answers nothing. Dial gives up on its deadline, where it waited for the
+// greeting until the whole test run timed out.
+func TestDialGivesUpOnASilentServer(t *testing.T) {
+	// A test cannot wait for the deadline of the package.
+	old := handshakeTimeout
+	handshakeTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { handshakeTimeout = old })
+
+	// The hook holds the session, so the client sees no greeting. The
+	// cleanups run in the order that a session needs: the hook returns, and
+	// Close then finds nothing to wait for.
+	release := make(chan struct{})
+
+	srv := NewUnstartedServer(nil)
+	srv.Config.Use(smtpd.Middleware{
+		CheckConnection: func(ctx context.Context, _ smtpd.Peer) (context.Context, error) {
+			<-release
+			return ctx, nil
+		},
+	})
+
+	srv.Start()
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(release) })
+
+	start := time.Now()
+	value := dialValue(t, srv)
+
+	if value == nil {
+		t.Fatal("Dial read a greeting from a server that sent none")
+	}
+	if got := time.Since(start); got > 5*time.Second {
+		t.Errorf("Dial gave up after %s, want the deadline of %s", got, handshakeTimeout)
+	}
+
+	if text, ok := value.(string); !ok || !strings.Contains(text, "greeting") {
+		t.Errorf("Dial panicked with %v, want the greeting that it waited for", value)
+	}
+}
+
+// dialValue returns the panic value of Dial, or nil when Dial did not panic.
+// A client that Dial returned is closed again.
+func dialValue(t *testing.T, srv *Server) (value any) {
+	t.Helper()
+
+	defer func() { value = recover() }()
+
+	c := srv.Dial()
+	_ = c.Close()
+	return nil
+}

--- a/smtptest/smtptest.go
+++ b/smtptest/smtptest.go
@@ -28,6 +28,21 @@ import (
 	"github.com/chrj/smtpd/v2"
 )
 
+// handshakeTimeout bounds the part of Dial that runs before the test does:
+// the connection, the greeting, and the TLS handshake of a transport that
+// needs one.
+//
+// A server that takes a connection and answers nothing holds the client for
+// as long as the test runs, and the test then fails on the timeout of the
+// whole run, with no line to name the cause. A listener that nobody accepts
+// on does that: the connection reaches the queue of the listener and waits
+// there.
+//
+// The deadline comes off once the handshake is over, so a test that drives a
+// slow session keeps its own pace.
+// A test of the package shortens it, so this is a variable.
+var handshakeTimeout = 10 * time.Second
+
 // shutdownTimeout is the time that Close gives the sessions that are still
 // open before it closes their connections.
 const shutdownTimeout = 5 * time.Second
@@ -170,23 +185,17 @@ func (s *Server) Dial() *smtp.Client {
 	default:
 	}
 
-	if s.transport == implicitTLS {
-		conn, err := tls.Dial("tcp", s.Addr, s.ClientTLSConfig())
-		if err != nil {
-			panic(fmt.Sprintf("smtptest: TLS dial %s: %v", s.Addr, err))
-		}
+	conn := s.dialConn()
 
-		c, err := smtp.NewClient(conn, s.Host)
-		if err != nil {
-			_ = conn.Close()
-			panic(fmt.Sprintf("smtptest: read the greeting of %s: %v", s.Addr, err))
-		}
-		return c
-	}
+	// The deadline covers the greeting and the STARTTLS handshake below. A
+	// server that answers nothing would hold the client until the whole test
+	// run times out.
+	_ = conn.SetDeadline(time.Now().Add(handshakeTimeout))
 
-	c, err := smtp.Dial(s.Addr)
+	c, err := smtp.NewClient(conn, s.Host)
 	if err != nil {
-		panic(fmt.Sprintf("smtptest: dial %s: %v", s.Addr, err))
+		_ = conn.Close()
+		panic(fmt.Sprintf("smtptest: read the greeting of %s: %v", s.Addr, err))
 	}
 
 	if s.transport == starttls {
@@ -196,7 +205,37 @@ func (s *Server) Dial() *smtp.Client {
 		}
 	}
 
+	// The handshake is over, and the test drives the session from here at a
+	// pace of its own.
+	_ = conn.SetDeadline(time.Time{})
+
 	return c
+}
+
+// dialConn opens the connection that Dial reads the greeting on. An implicit
+// TLS server needs the handshake first, and the deadline of the context
+// covers the connection and that handshake together.
+func (s *Server) dialConn() net.Conn {
+	ctx, cancel := context.WithTimeout(context.Background(), handshakeTimeout)
+	defer cancel()
+
+	if s.transport == implicitTLS {
+		d := tls.Dialer{Config: s.ClientTLSConfig()}
+
+		conn, err := d.DialContext(ctx, "tcp", s.Addr)
+		if err != nil {
+			panic(fmt.Sprintf("smtptest: TLS dial %s: %v", s.Addr, err))
+		}
+		return conn
+	}
+
+	var d net.Dialer
+
+	conn, err := d.DialContext(ctx, "tcp", s.Addr)
+	if err != nil {
+		panic(fmt.Sprintf("smtptest: dial %s: %v", s.Addr, err))
+	}
+	return conn
 }
 
 // Close stops the server and waits for the sessions that are still open. The

--- a/smtptest/smtptest.go
+++ b/smtptest/smtptest.go
@@ -185,12 +185,14 @@ func (s *Server) Dial() *smtp.Client {
 	default:
 	}
 
-	conn := s.dialConn()
-
-	// The deadline covers the greeting and the STARTTLS handshake below. A
+	// One deadline covers the part of the session that comes before the test:
+	// the connection, the greeting, and the STARTTLS handshake below. A
 	// server that answers nothing would hold the client until the whole test
 	// run times out.
-	_ = conn.SetDeadline(time.Now().Add(handshakeTimeout))
+	deadline := time.Now().Add(handshakeTimeout)
+
+	conn := s.dialConn(deadline)
+	_ = conn.SetDeadline(deadline)
 
 	c, err := smtp.NewClient(conn, s.Host)
 	if err != nil {
@@ -213,10 +215,13 @@ func (s *Server) Dial() *smtp.Client {
 }
 
 // dialConn opens the connection that Dial reads the greeting on. An implicit
-// TLS server needs the handshake first, and the deadline of the context
-// covers the connection and that handshake together.
-func (s *Server) dialConn() net.Conn {
-	ctx, cancel := context.WithTimeout(context.Background(), handshakeTimeout)
+// TLS server needs the handshake first, and the deadline covers the
+// connection and that handshake.
+//
+// The deadline comes from the caller, because the greeting after this takes
+// what is left of it.
+func (s *Server) dialConn(deadline time.Time) net.Conn {
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
 	defer cancel()
 
 	if s.transport == implicitTLS {


### PR DESCRIPTION
Follow-up to #57, where `TestServerDialAfterServeError` failed in CI. The test
is fixed there. This is the hole under it.

`smtptest.Server.Dial` waited for the greeting with no deadline. A server that
takes a connection and answers nothing held the client for as long as the test
run, and the run then failed on its own timeout, with no line to name the
cause.

A listener that nobody accepts on does that: the connection reaches the queue
of the listener and waits there. Two ways to reach one:

- A server that stopped between the listen and the accept loop. The listener
  of `NewUnstartedServer` is open from the call, and `Serve` closes it on the
  way out, so a dial in that window waits for a greeting that never comes.
- A hook of a middleware that blocks, which is how the test in this PR builds
  one.

Dial now gives the connection, the greeting, and the TLS handshake of a
transport that needs one, ten seconds together:

```go
conn := s.dialConn()
_ = conn.SetDeadline(time.Now().Add(handshakeTimeout))
// the greeting, and STARTTLS where the transport asks for it
_ = conn.SetDeadline(time.Time{})
```

The deadline comes off once the handshake is over, so a test that drives a
slow session keeps its own pace. A test that pauses in the middle of a
transaction sees no change.

`TestDialGivesUpOnASilentServer` shortens the deadline and holds a session in
a `CheckConnection` hook. Without the deadline that test does not fail, it
hangs.
