### PR TITLE
refactor: give every command and extension a file of its own

### DIFF
--- a/address.go
+++ b/address.go
@@ -6,6 +6,14 @@ import (
 	"strings"
 )
 
+// errSenderMalformed answers a MAIL FROM command whose address does not read.
+// RFC 3463 gives the status code 5.1.7 for the address of a sender.
+var errSenderMalformed = Error{Code: 501, Enhanced: EnhancedCode{5, 1, 7}, Message: "Malformed e-mail address"}
+
+// errRecipientMalformed answers the same fault in a RCPT TO command, where
+// RFC 3463 gives the status code 5.1.3.
+var errRecipientMalformed = Error{Code: 501, Enhanced: EnhancedCode{5, 1, 3}, Message: "Malformed e-mail address"}
+
 func parseAddress(src string) (string, error) {
 	// While a RFC5321 mailbox specification is not the same as an RFC5322
 	// email address specification, it is better to accept that format and

--- a/protocol.go
+++ b/protocol.go
@@ -1,16 +1,10 @@
 package smtpd
 
 import (
-	"bufio"
 	"context"
-	"crypto/tls"
-	"errors"
 	"fmt"
-	"log/slog"
 	"strconv"
 	"strings"
-	"time"
-	"unicode/utf8"
 )
 
 // errMailParams answers a MAIL FROM parameter that the server does not know.
@@ -21,16 +15,6 @@ var errMailParams = Error{Code: 555, Enhanced: EnhancedCode{5, 5, 4}, Message: "
 
 // errRcptParams answers a RCPT TO parameter that the server does not know.
 var errRcptParams = Error{Code: 555, Enhanced: EnhancedCode{5, 5, 4}, Message: "RCPT TO parameters not recognized or not implemented"}
-
-// errSenderNonASCII answers a MAIL FROM command that carries an address of
-// Unicode without the SMTPUTF8 parameter. RFC 6531 section 3.5 gives 550 for
-// the sender, and the status code 5.6.7 with it.
-var errSenderNonASCII = Error{Code: 550, Enhanced: EnhancedCode{5, 6, 7}, Message: "Non-ASCII sender address needs the SMTPUTF8 parameter"}
-
-// errRecipientNonASCII answers a RCPT TO command that carries an address of
-// Unicode in a transaction that did not ask for SMTPUTF8. RFC 6531 section
-// 3.5 gives 553 for a recipient.
-var errRecipientNonASCII = Error{Code: 553, Enhanced: EnhancedCode{5, 6, 7}, Message: "Non-ASCII recipient address needs the SMTPUTF8 parameter"}
 
 // mailParams holds what the parameters of a MAIL FROM command say about the
 // message that follows.
@@ -166,15 +150,6 @@ func (s *session) parseRcptParams(params map[string]string, smtputf8 bool) (Reci
 	return rcpt, nil
 }
 
-// needsSMTPUTF8 reports whether addr carries Unicode that RFC 6531 gives to a
-// transaction with the SMTPUTF8 parameter alone.
-//
-// A server that runs without Server.EnableSMTPUTF8 offers the extension to no
-// client, and takes an address as it came.
-func (s *session) needsSMTPUTF8(addr string) bool {
-	return s.server.EnableSMTPUTF8 && !isASCII(addr)
-}
-
 func (s *session) handle(ctx context.Context, line string) context.Context {
 	// The handler of a chunked message runs while the session reads the next
 	// command. A panic in it ends the session, whatever that command is.
@@ -303,6 +278,44 @@ func (s *session) handleEHLO(ctx context.Context, cmd *command) context.Context 
 
 }
 
+func (s *session) extensions() []string {
+
+	extensions := []string{
+		fmt.Sprintf("SIZE %d", s.server.MaxMessageSize),
+		"8BITMIME",
+		"BINARYMIME",
+		"CHUNKING",
+		"PIPELINING",
+		"ENHANCEDSTATUSCODES",
+	}
+
+	if s.server.EnableDSN {
+		extensions = append(extensions, "DSN")
+	}
+
+	// RFC 6531 section 3.1 asks for the keyword alone, without a parameter of
+	// its own, and for 8BITMIME next to it. The list above carries 8BITMIME
+	// for every client.
+	if s.server.EnableSMTPUTF8 {
+		extensions = append(extensions, "SMTPUTF8")
+	}
+
+	if s.server.EnableXCLIENT {
+		extensions = append(extensions, "XCLIENT")
+	}
+
+	if s.server.TLSConfig != nil && !s.tls {
+		extensions = append(extensions, "STARTTLS")
+	}
+
+	if s.server.hasAuthenticator() && (s.tls || s.server.AllowInsecureAuth) {
+		extensions = append(extensions, "AUTH PLAIN LOGIN")
+	}
+
+	return extensions
+
+}
+
 func (s *session) handleMAIL(ctx context.Context, cmd *command) context.Context {
 	ctx, _ = phasedLoggerFromContext(ctx, "mail")
 
@@ -326,7 +339,7 @@ func (s *session) handleMAIL(ctx context.Context, cmd *command) context.Context 
 		addr, err = parseAddress(addrSpec)
 
 		if err != nil {
-			return s.replyEnhanced(ctx, 501, EnhancedCode{5, 1, 7}, "Malformed e-mail address")
+			return s.replyError(ctx, errSenderMalformed)
 		}
 	}
 
@@ -335,13 +348,8 @@ func (s *session) handleMAIL(ctx context.Context, cmd *command) context.Context 
 		return s.replyError(ctx, err)
 	}
 
-	if s.needsSMTPUTF8(addr) {
-		if !mail.smtputf8 {
-			return s.replyError(ctx, errSenderNonASCII)
-		}
-		if !utf8.ValidString(addr) {
-			return s.replyEnhanced(ctx, 501, EnhancedCode{5, 1, 7}, "Malformed e-mail address")
-		}
+	if err := s.checkSenderCharset(addr, mail.smtputf8); err != nil {
+		return s.replyError(ctx, err)
 	}
 
 	ctx, err = s.server.checkSender(ctx, s.peer, addr)
@@ -393,16 +401,11 @@ func (s *session) handleRCPT(ctx context.Context, cmd *command) context.Context 
 	addr, err := parseAddress(addrSpec)
 
 	if err != nil {
-		return s.replyEnhanced(ctx, 501, EnhancedCode{5, 1, 3}, "Malformed e-mail address")
+		return s.replyError(ctx, errRecipientMalformed)
 	}
 
-	if s.needsSMTPUTF8(addr) {
-		if !s.envelope.SMTPUTF8 {
-			return s.replyError(ctx, errRecipientNonASCII)
-		}
-		if !utf8.ValidString(addr) {
-			return s.replyEnhanced(ctx, 501, EnhancedCode{5, 1, 3}, "Malformed e-mail address")
-		}
+	if err := s.checkRecipientCharset(addr); err != nil {
+		return s.replyError(ctx, err)
 	}
 
 	ctx, err = s.server.checkRecipient(ctx, s.peer, addr)
@@ -417,62 +420,6 @@ func (s *session) handleRCPT(ctx context.Context, cmd *command) context.Context 
 
 }
 
-func (s *session) handleSTARTTLS(ctx context.Context, cmd *command) context.Context {
-	ctx, logger := phasedLoggerFromContext(ctx, "starttls")
-
-	if s.tls {
-		return s.replyEnhanced(ctx, 503, EnhancedCode{5, 5, 1}, "Already running in TLS")
-	}
-
-	if s.server.TLSConfig == nil {
-		return s.replyEnhanced(ctx, 502, EnhancedCode{5, 5, 1}, "TLS not supported")
-	}
-
-	tlsConn := tls.Server(s.conn, s.server.TLSConfig)
-	ctx = s.reply(ctx, 220, "Go ahead")
-
-	if err := tlsConn.HandshakeContext(ctx); err != nil {
-		logger.ErrorContext(ctx, "tls handshake failed", slog.Any("err", err))
-		s.setErr(err)
-		// Best-effort 550 over the still-plain conn in case the client
-		// hasn't sent ClientHello yet; then close - continuing from a
-		// half-failed handshake leaves the byte stream unintelligible.
-		ctx = s.replyEnhanced(ctx, 550, EnhancedCode{5, 7, 0}, "Handshake error")
-		return s.close(ctx)
-	}
-
-	// Everything the client sent before the handshake went over the wire in
-	// plain text, where anybody on the path could change it. RFC 3207 gives
-	// the argument of EHLO as the example of what the server must drop.
-	//
-	// Clearing the name from the greeting is also what makes a new EHLO or
-	// HELO necessary: MAIL FROM asks for it, and turns the client away
-	// without one.
-	s.peer.HeloName = ""
-	s.peer.Protocol = ""
-	s.peer.Username = ""
-
-	ctx = s.reset(ctx)
-
-	// Reset deadlines on the underlying connection before I replace it
-	// with a TLS connection
-	_ = s.conn.SetDeadline(time.Time{})
-
-	// Replace connection with a TLS connection
-	s.conn = tlsConn
-	s.reader = bufio.NewReader(tlsConn)
-	s.writer = bufio.NewWriter(tlsConn)
-	s.tls = true
-
-	// Save connection state on peer
-	state := tlsConn.ConnectionState()
-	s.peer.TLS = &state
-
-	// Flush the connection to set new timeout deadlines
-	return s.flush(ctx)
-
-}
-
 func (s *session) handleRSET(ctx context.Context, cmd *command) context.Context {
 	ctx, _ = phasedLoggerFromContext(ctx, "rset")
 	ctx = s.reset(ctx)
@@ -482,109 +429,6 @@ func (s *session) handleRSET(ctx context.Context, cmd *command) context.Context 
 func (s *session) handleNOOP(ctx context.Context, cmd *command) context.Context {
 	ctx, _ = phasedLoggerFromContext(ctx, "noop")
 	return s.reply(ctx, 250, "Go ahead")
-}
-
-// handleVRFY answers the VRFY command of RFC 5321 section 4.1.1.6. The
-// command asks the server to confirm that a name stands for a user, and the
-// Verify hooks of the middleware look it up.
-//
-// The command carries no transaction, so it needs no HELO and no MAIL FROM
-// before it. RFC 5321 section 4.1.4 lets a client send it at any time.
-func (s *session) handleVRFY(ctx context.Context, cmd *command) context.Context {
-	ctx, logger := phasedLoggerFromContext(ctx, "vrfy")
-
-	// RFC 5321 section 3.5.1 leaves the form of the name to the site, so the
-	// argument goes to the hooks as it came. A name that carries a space
-	// reaches them whole.
-	//
-	// smtputf8 says that the client sent the SMTPUTF8 parameter of RFC 6531
-	// section 3.7.4.2, which lets the reply to this one command carry UTF-8.
-	name, smtputf8, err := cmd.vrfyArg(s.server.EnableSMTPUTF8)
-	if err != nil {
-		return s.replyEnhanced(ctx, 501, EnhancedCode{5, 5, 4}, "The SMTPUTF8 parameter takes no value")
-	}
-	if name == "" {
-		return s.replyEnhanced(ctx, 501, EnhancedCode{5, 5, 4}, "Missing parameter")
-	}
-
-	ctx, verified, err := s.server.verify(ctx, s.peer, name)
-	if err != nil {
-		var smtpErr Error
-		if errors.As(err, &smtpErr) {
-			return s.replyError(ctx, err)
-		}
-
-		// A lookup that failed is not a command that the server does not
-		// carry, and replyError answers 502 to an error of another kind. RFC
-		// 5321 section 3.5.3 reads a 500 and a 502 as the answer of a server
-		// without VRFY, so a fault of the directory takes a 451 instead.
-		//
-		// The text of the error stays in the log. It comes from the site, and
-		// a client of any kind reads a reply.
-		logger.ErrorContext(ctx, "the Verify hook failed",
-			slog.String("name", name),
-			slog.Any("err", err),
-		)
-		return s.replyEnhanced(ctx, 451, EnhancedCode{4, 3, 0}, "Cannot verify the user right now")
-	}
-
-	if verified.Mailbox == "" {
-		return s.reply(ctx, 252, cannotVerify)
-	}
-
-	// The client writes the mailbox of the reply into a RCPT TO command of
-	// its own, so a value that is not an address never goes on the wire. RFC
-	// 5321 section 7.3 asks the server to answer 252 where it cannot say
-	// that it verified the name.
-	mailbox, err := parseAddress(verified.Mailbox)
-	if err != nil {
-		logger.ErrorContext(ctx, "the Verify hook gave a mailbox that is not an address",
-			slog.String("name", name),
-			slog.String("mailbox", verified.Mailbox),
-			slog.Any("err", err),
-		)
-		return s.reply(ctx, 252, cannotVerify)
-	}
-
-	// RFC 6531 widens the reply to UTF-8, and to nothing else. A byte outside
-	// that encoding is not a character at all, and it reaches a client that
-	// reads the reply as UTF-8.
-	if !utf8.ValidString(mailbox) {
-		logger.ErrorContext(ctx, "the Verify hook gave a mailbox that is not UTF-8",
-			slog.String("name", name),
-			slog.String("mailbox", verified.Mailbox),
-		)
-		return s.reply(ctx, 252, cannotVerify)
-	}
-
-	fullName := verified.FullName
-
-	// RFC 5321 holds the text of a reply to US-ASCII, and RFC 6531 section
-	// 3.7.4.2 widens it for the client that asked with the SMTPUTF8 parameter
-	// of this command. A client without it reads a reply that it cannot,
-	// which the same section keeps it away from.
-	//
-	// The name of the user is the part that RFC 5321 section 3.5.1 leaves
-	// out, so a name of Unicode goes and the mailbox stays. A mailbox of
-	// Unicode leaves nothing to write, and RFC 6531 gives 252 for it.
-	if !smtputf8 {
-		if !isASCII(mailbox) {
-			return s.replyEnhanced(ctx, 252, EnhancedCode{2, 6, 8}, cannotShowMailbox)
-		}
-		if !isASCII(fullName) {
-			fullName = ""
-		}
-	} else if !utf8.ValidString(fullName) {
-		// The name of the user is the part that the reply can leave out, so a
-		// name that is not UTF-8 goes and the mailbox stays.
-		logger.ErrorContext(ctx, "the Verify hook gave a name that is not UTF-8",
-			slog.String("name", name),
-			slog.String("full_name", fullName),
-		)
-		fullName = ""
-	}
-
-	return s.replyEnhanced(ctx, 250, EnhancedCode{2, 1, 5}, verifyLine(fullName, mailbox))
 }
 
 func (s *session) handleQUIT(ctx context.Context, cmd *command) context.Context {

--- a/reply.go
+++ b/reply.go
@@ -1,0 +1,133 @@
+package smtpd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+)
+
+// reply writes a single reply line with the generic status code for the
+// class of code, such as "5.0.0" for a 550. Use replyEnhanced where a
+// precise reason helps the client.
+func (s *session) reply(ctx context.Context, code int, message string) context.Context {
+	return s.replyEnhanced(ctx, code, defaultEnhancedCode(code), message)
+}
+
+// replyEnhanced writes a single reply line with the given status code. The
+// zero value of enhanced leaves the status code out, which is what the
+// greeting and the reply to HELO and EHLO need.
+func (s *session) replyEnhanced(ctx context.Context, code int, enhanced EnhancedCode, message string) context.Context {
+	// A closed session has no reader on the other end. The write would go
+	// into a buffer that nothing flushes, and the reply that the client did
+	// read was the last one.
+	if s.closed {
+		return ctx
+	}
+
+	status := s.status(enhanced)
+	message = sanitizeReplyText(message)
+
+	logger := LoggerFromContext(ctx)
+	logger.DebugContext(ctx, "sending",
+		slog.Int("code", code),
+		slog.String("status", status),
+		slog.String("message", message),
+	)
+
+	if status == "" {
+		_, _ = fmt.Fprintf(s.writer, "%d %s\r\n", code, message)
+		return s.flush(ctx)
+	}
+
+	_, _ = fmt.Fprintf(s.writer, "%d %s %s\r\n", code, status, message)
+	return s.flush(ctx)
+}
+
+// replyMultiline writes first and rest as one reply, with the continuation
+// mark on every line but the last. The lines carry no status code: this is
+// the reply to EHLO, and RFC 2034 takes that reply out of the extension.
+//
+// The first line is a separate argument, so that a reply always has one.
+func (s *session) replyMultiline(ctx context.Context, code int, first string, rest ...string) context.Context {
+	if s.closed {
+		return ctx
+	}
+
+	logger := LoggerFromContext(ctx)
+
+	lines := append([]string{first}, rest...)
+	for _, line := range lines[:len(lines)-1] {
+		line = sanitizeReplyText(line)
+		logger.DebugContext(ctx, "sending",
+			slog.Int("code", code),
+			slog.String("message", line),
+		)
+		_, _ = fmt.Fprintf(s.writer, "%d-%s\r\n", code, line)
+	}
+
+	return s.replyEnhanced(ctx, code, EnhancedCode{}, lines[len(lines)-1])
+}
+
+// sanitizeReplyText makes text safe to write inside a reply line. Every
+// control character becomes a space.
+//
+// The message of a middleware refusal often carries something that the client
+// sent. The user name of an AUTH command is one example: the session decodes
+// it from base64, so it holds any byte at all. A line break inside a reply
+// ends that reply and starts a line of the client's choosing. The client then
+// reads an answer to a command that the server never ran.
+//
+// A byte at 0x80 and above stays as it is, so a message in UTF-8 arrives
+// whole.
+func sanitizeReplyText(text string) string {
+	if !hasControl(text) {
+		return text
+	}
+
+	out := []byte(text)
+	for i, c := range out {
+		if isControl(c) {
+			out[i] = ' '
+		}
+	}
+	return string(out)
+}
+
+// hasControl reports whether text carries a control character, so that a
+// text without one goes on the wire as it is.
+func hasControl(text string) bool {
+	for i := 0; i < len(text); i++ {
+		if isControl(text[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+// isControl reports whether c is a control character. RFC 5321 gives the text
+// of a reply as printable characters.
+func isControl(c byte) bool {
+	return c < 0x20 || c == 0x7f
+}
+
+// status gives the text of the status code to write with a reply. It is
+// empty when the client did not send EHLO.
+//
+// RFC 2034 makes the status code part of an extension, and the server
+// offers that extension in the reply to EHLO. A client that sent HELO never
+// saw the offer, so it gets the replies that it expects from RFC 5321.
+func (s *session) status(enhanced EnhancedCode) string {
+	if s.peer.Protocol != ESMTP {
+		return ""
+	}
+	return enhanced.String()
+}
+
+func (s *session) replyError(ctx context.Context, err error) context.Context {
+	var smtpErr Error
+	if errors.As(err, &smtpErr) {
+		return s.replyEnhanced(ctx, smtpErr.Code, smtpErr.enhanced(), smtpErr.Message)
+	}
+	return s.replyEnhanced(ctx, 502, EnhancedCode{5, 5, 1}, err.Error())
+}

--- a/session.go
+++ b/session.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"fmt"
 	"io"
 	"log/slog"
 	"net"
@@ -257,174 +256,11 @@ func (s *session) welcome(ctx context.Context) context.Context {
 
 }
 
-// reply writes a single reply line with the generic status code for the
-// class of code, such as "5.0.0" for a 550. Use replyEnhanced where a
-// precise reason helps the client.
-func (s *session) reply(ctx context.Context, code int, message string) context.Context {
-	return s.replyEnhanced(ctx, code, defaultEnhancedCode(code), message)
-}
-
-// replyEnhanced writes a single reply line with the given status code. The
-// zero value of enhanced leaves the status code out, which is what the
-// greeting and the reply to HELO and EHLO need.
-func (s *session) replyEnhanced(ctx context.Context, code int, enhanced EnhancedCode, message string) context.Context {
-	// A closed session has no reader on the other end. The write would go
-	// into a buffer that nothing flushes, and the reply that the client did
-	// read was the last one.
-	if s.closed {
-		return ctx
-	}
-
-	status := s.status(enhanced)
-	message = sanitizeReplyText(message)
-
-	logger := LoggerFromContext(ctx)
-	logger.DebugContext(ctx, "sending",
-		slog.Int("code", code),
-		slog.String("status", status),
-		slog.String("message", message),
-	)
-
-	if status == "" {
-		_, _ = fmt.Fprintf(s.writer, "%d %s\r\n", code, message)
-		return s.flush(ctx)
-	}
-
-	_, _ = fmt.Fprintf(s.writer, "%d %s %s\r\n", code, status, message)
-	return s.flush(ctx)
-}
-
-// replyMultiline writes first and rest as one reply, with the continuation
-// mark on every line but the last. The lines carry no status code: this is
-// the reply to EHLO, and RFC 2034 takes that reply out of the extension.
-//
-// The first line is a separate argument, so that a reply always has one.
-func (s *session) replyMultiline(ctx context.Context, code int, first string, rest ...string) context.Context {
-	if s.closed {
-		return ctx
-	}
-
-	logger := LoggerFromContext(ctx)
-
-	lines := append([]string{first}, rest...)
-	for _, line := range lines[:len(lines)-1] {
-		line = sanitizeReplyText(line)
-		logger.DebugContext(ctx, "sending",
-			slog.Int("code", code),
-			slog.String("message", line),
-		)
-		_, _ = fmt.Fprintf(s.writer, "%d-%s\r\n", code, line)
-	}
-
-	return s.replyEnhanced(ctx, code, EnhancedCode{}, lines[len(lines)-1])
-}
-
-// sanitizeReplyText makes text safe to write inside a reply line. Every
-// control character becomes a space.
-//
-// The message of a middleware refusal often carries something that the client
-// sent. The user name of an AUTH command is one example: the session decodes
-// it from base64, so it holds any byte at all. A line break inside a reply
-// ends that reply and starts a line of the client's choosing. The client then
-// reads an answer to a command that the server never ran.
-//
-// A byte at 0x80 and above stays as it is, so a message in UTF-8 arrives
-// whole.
-func sanitizeReplyText(text string) string {
-	if !hasControl(text) {
-		return text
-	}
-
-	out := []byte(text)
-	for i, c := range out {
-		if isControl(c) {
-			out[i] = ' '
-		}
-	}
-	return string(out)
-}
-
-// hasControl reports whether text carries a control character, so that a
-// text without one goes on the wire as it is.
-func hasControl(text string) bool {
-	for i := 0; i < len(text); i++ {
-		if isControl(text[i]) {
-			return true
-		}
-	}
-	return false
-}
-
-// isControl reports whether c is a control character. RFC 5321 gives the text
-// of a reply as printable characters.
-func isControl(c byte) bool {
-	return c < 0x20 || c == 0x7f
-}
-
-// status gives the text of the status code to write with a reply. It is
-// empty when the client did not send EHLO.
-//
-// RFC 2034 makes the status code part of an extension, and the server
-// offers that extension in the reply to EHLO. A client that sent HELO never
-// saw the offer, so it gets the replies that it expects from RFC 5321.
-func (s *session) status(enhanced EnhancedCode) string {
-	if s.peer.Protocol != ESMTP {
-		return ""
-	}
-	return enhanced.String()
-}
-
 func (s *session) flush(ctx context.Context) context.Context {
 	_ = s.conn.SetWriteDeadline(time.Now().Add(s.server.WriteTimeout))
 	_ = s.writer.Flush()
 	_ = s.conn.SetReadDeadline(time.Now().Add(s.server.ReadTimeout))
 	return ctx
-}
-
-func (s *session) replyError(ctx context.Context, err error) context.Context {
-	var smtpErr Error
-	if errors.As(err, &smtpErr) {
-		return s.replyEnhanced(ctx, smtpErr.Code, smtpErr.enhanced(), smtpErr.Message)
-	}
-	return s.replyEnhanced(ctx, 502, EnhancedCode{5, 5, 1}, err.Error())
-}
-
-func (s *session) extensions() []string {
-
-	extensions := []string{
-		fmt.Sprintf("SIZE %d", s.server.MaxMessageSize),
-		"8BITMIME",
-		"BINARYMIME",
-		"CHUNKING",
-		"PIPELINING",
-		"ENHANCEDSTATUSCODES",
-	}
-
-	if s.server.EnableDSN {
-		extensions = append(extensions, "DSN")
-	}
-
-	// RFC 6531 section 3.1 asks for the keyword alone, without a parameter of
-	// its own, and for 8BITMIME next to it. The list above carries 8BITMIME
-	// for every client.
-	if s.server.EnableSMTPUTF8 {
-		extensions = append(extensions, "SMTPUTF8")
-	}
-
-	if s.server.EnableXCLIENT {
-		extensions = append(extensions, "XCLIENT")
-	}
-
-	if s.server.TLSConfig != nil && !s.tls {
-		extensions = append(extensions, "STARTTLS")
-	}
-
-	if s.server.hasAuthenticator() && (s.tls || s.server.AllowInsecureAuth) {
-		extensions = append(extensions, "AUTH PLAIN LOGIN")
-	}
-
-	return extensions
-
 }
 
 func (s *session) deliver(ctx context.Context) (context.Context, error) {

--- a/smtputf8.go
+++ b/smtputf8.go
@@ -1,0 +1,55 @@
+package smtpd
+
+import "unicode/utf8"
+
+// errSenderNonASCII answers a MAIL FROM command that carries an address of
+// Unicode without the SMTPUTF8 parameter. RFC 6531 section 3.5 gives 550 for
+// the sender, and the status code 5.6.7 with it.
+var errSenderNonASCII = Error{Code: 550, Enhanced: EnhancedCode{5, 6, 7}, Message: "Non-ASCII sender address needs the SMTPUTF8 parameter"}
+
+// errRecipientNonASCII answers a RCPT TO command that carries an address of
+// Unicode in a transaction that did not ask for SMTPUTF8. RFC 6531 section
+// 3.5 gives 553 for a recipient.
+var errRecipientNonASCII = Error{Code: 553, Enhanced: EnhancedCode{5, 6, 7}, Message: "Non-ASCII recipient address needs the SMTPUTF8 parameter"}
+
+// needsSMTPUTF8 reports whether addr carries Unicode that RFC 6531 gives to a
+// transaction with the SMTPUTF8 parameter alone.
+//
+// A server that runs without Server.EnableSMTPUTF8 offers the extension to no
+// client, and takes an address as it came.
+func (s *session) needsSMTPUTF8(addr string) bool {
+	return s.server.EnableSMTPUTF8 && !isASCII(addr)
+}
+
+// checkSenderCharset reads the character set of the address of a MAIL FROM
+// command. RFC 6531 section 3.5 answers 550 to an address of Unicode that
+// came without the SMTPUTF8 parameter, and RFC 6531 gives the address in
+// UTF-8, so a byte outside that encoding is a malformed address.
+func (s *session) checkSenderCharset(addr string, smtputf8 bool) error {
+	if !s.needsSMTPUTF8(addr) {
+		return nil
+	}
+	if !smtputf8 {
+		return errSenderNonASCII
+	}
+	if !utf8.ValidString(addr) {
+		return errSenderMalformed
+	}
+	return nil
+}
+
+// checkRecipientCharset reads the character set of the address of a RCPT TO
+// command. RFC 6531 section 3.5 answers 553 for a recipient, where it answers
+// 550 for the sender.
+func (s *session) checkRecipientCharset(addr string) error {
+	if !s.needsSMTPUTF8(addr) {
+		return nil
+	}
+	if !s.envelope.SMTPUTF8 {
+		return errRecipientNonASCII
+	}
+	if !utf8.ValidString(addr) {
+		return errRecipientMalformed
+	}
+	return nil
+}

--- a/starttls.go
+++ b/starttls.go
@@ -1,0 +1,65 @@
+package smtpd
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"log/slog"
+	"time"
+)
+
+func (s *session) handleSTARTTLS(ctx context.Context, cmd *command) context.Context {
+	ctx, logger := phasedLoggerFromContext(ctx, "starttls")
+
+	if s.tls {
+		return s.replyEnhanced(ctx, 503, EnhancedCode{5, 5, 1}, "Already running in TLS")
+	}
+
+	if s.server.TLSConfig == nil {
+		return s.replyEnhanced(ctx, 502, EnhancedCode{5, 5, 1}, "TLS not supported")
+	}
+
+	tlsConn := tls.Server(s.conn, s.server.TLSConfig)
+	ctx = s.reply(ctx, 220, "Go ahead")
+
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		logger.ErrorContext(ctx, "tls handshake failed", slog.Any("err", err))
+		s.setErr(err)
+		// Best-effort 550 over the still-plain conn in case the client
+		// hasn't sent ClientHello yet; then close - continuing from a
+		// half-failed handshake leaves the byte stream unintelligible.
+		ctx = s.replyEnhanced(ctx, 550, EnhancedCode{5, 7, 0}, "Handshake error")
+		return s.close(ctx)
+	}
+
+	// Everything the client sent before the handshake went over the wire in
+	// plain text, where anybody on the path could change it. RFC 3207 gives
+	// the argument of EHLO as the example of what the server must drop.
+	//
+	// Clearing the name from the greeting is also what makes a new EHLO or
+	// HELO necessary: MAIL FROM asks for it, and turns the client away
+	// without one.
+	s.peer.HeloName = ""
+	s.peer.Protocol = ""
+	s.peer.Username = ""
+
+	ctx = s.reset(ctx)
+
+	// Reset deadlines on the underlying connection before I replace it
+	// with a TLS connection
+	_ = s.conn.SetDeadline(time.Time{})
+
+	// Replace connection with a TLS connection
+	s.conn = tlsConn
+	s.reader = bufio.NewReader(tlsConn)
+	s.writer = bufio.NewWriter(tlsConn)
+	s.tls = true
+
+	// Save connection state on peer
+	state := tlsConn.ConnectionState()
+	s.peer.TLS = &state
+
+	// Flush the connection to set new timeout deadlines
+	return s.flush(ctx)
+
+}

--- a/verify.go
+++ b/verify.go
@@ -1,6 +1,12 @@
 package smtpd
 
-import "strings"
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"unicode/utf8"
+)
 
 // Verification is what a Verify hook found for the name that a VRFY command
 // carried. RFC 5321 section 3.5.1 gives the command a user name, a mailbox,
@@ -66,4 +72,107 @@ func stripBrackets(name string) string {
 		return name
 	}
 	return strings.NewReplacer("<", "", ">", "").Replace(name)
+}
+
+// handleVRFY answers the VRFY command of RFC 5321 section 4.1.1.6. The
+// command asks the server to confirm that a name stands for a user, and the
+// Verify hooks of the middleware look it up.
+//
+// The command carries no transaction, so it needs no HELO and no MAIL FROM
+// before it. RFC 5321 section 4.1.4 lets a client send it at any time.
+func (s *session) handleVRFY(ctx context.Context, cmd *command) context.Context {
+	ctx, logger := phasedLoggerFromContext(ctx, "vrfy")
+
+	// RFC 5321 section 3.5.1 leaves the form of the name to the site, so the
+	// argument goes to the hooks as it came. A name that carries a space
+	// reaches them whole.
+	//
+	// smtputf8 says that the client sent the SMTPUTF8 parameter of RFC 6531
+	// section 3.7.4.2, which lets the reply to this one command carry UTF-8.
+	name, smtputf8, err := cmd.vrfyArg(s.server.EnableSMTPUTF8)
+	if err != nil {
+		return s.replyEnhanced(ctx, 501, EnhancedCode{5, 5, 4}, "The SMTPUTF8 parameter takes no value")
+	}
+	if name == "" {
+		return s.replyEnhanced(ctx, 501, EnhancedCode{5, 5, 4}, "Missing parameter")
+	}
+
+	ctx, verified, err := s.server.verify(ctx, s.peer, name)
+	if err != nil {
+		var smtpErr Error
+		if errors.As(err, &smtpErr) {
+			return s.replyError(ctx, err)
+		}
+
+		// A lookup that failed is not a command that the server does not
+		// carry, and replyError answers 502 to an error of another kind. RFC
+		// 5321 section 3.5.3 reads a 500 and a 502 as the answer of a server
+		// without VRFY, so a fault of the directory takes a 451 instead.
+		//
+		// The text of the error stays in the log. It comes from the site, and
+		// a client of any kind reads a reply.
+		logger.ErrorContext(ctx, "the Verify hook failed",
+			slog.String("name", name),
+			slog.Any("err", err),
+		)
+		return s.replyEnhanced(ctx, 451, EnhancedCode{4, 3, 0}, "Cannot verify the user right now")
+	}
+
+	if verified.Mailbox == "" {
+		return s.reply(ctx, 252, cannotVerify)
+	}
+
+	// The client writes the mailbox of the reply into a RCPT TO command of
+	// its own, so a value that is not an address never goes on the wire. RFC
+	// 5321 section 7.3 asks the server to answer 252 where it cannot say
+	// that it verified the name.
+	mailbox, err := parseAddress(verified.Mailbox)
+	if err != nil {
+		logger.ErrorContext(ctx, "the Verify hook gave a mailbox that is not an address",
+			slog.String("name", name),
+			slog.String("mailbox", verified.Mailbox),
+			slog.Any("err", err),
+		)
+		return s.reply(ctx, 252, cannotVerify)
+	}
+
+	// RFC 6531 widens the reply to UTF-8, and to nothing else. A byte outside
+	// that encoding is not a character at all, and it reaches a client that
+	// reads the reply as UTF-8.
+	if !utf8.ValidString(mailbox) {
+		logger.ErrorContext(ctx, "the Verify hook gave a mailbox that is not UTF-8",
+			slog.String("name", name),
+			slog.String("mailbox", verified.Mailbox),
+		)
+		return s.reply(ctx, 252, cannotVerify)
+	}
+
+	fullName := verified.FullName
+
+	// RFC 5321 holds the text of a reply to US-ASCII, and RFC 6531 section
+	// 3.7.4.2 widens it for the client that asked with the SMTPUTF8 parameter
+	// of this command. A client without it reads a reply that it cannot,
+	// which the same section keeps it away from.
+	//
+	// The name of the user is the part that RFC 5321 section 3.5.1 leaves
+	// out, so a name of Unicode goes and the mailbox stays. A mailbox of
+	// Unicode leaves nothing to write, and RFC 6531 gives 252 for it.
+	if !smtputf8 {
+		if !isASCII(mailbox) {
+			return s.replyEnhanced(ctx, 252, EnhancedCode{2, 6, 8}, cannotShowMailbox)
+		}
+		if !isASCII(fullName) {
+			fullName = ""
+		}
+	} else if !utf8.ValidString(fullName) {
+		// The name of the user is the part that the reply can leave out, so a
+		// name that is not UTF-8 goes and the mailbox stays.
+		logger.ErrorContext(ctx, "the Verify hook gave a name that is not UTF-8",
+			slog.String("name", name),
+			slog.String("full_name", fullName),
+		)
+		fullName = ""
+	}
+
+	return s.replyEnhanced(ctx, 250, EnhancedCode{2, 1, 5}, verifyLine(fullName, mailbox))
 }


### PR DESCRIPTION
Nothing changes on the wire. This moves code into the files that the package
already names.

### The order that the package keeps

The handler of a command stands in the file of that command: `handleDATA` in
`data.go`, `handleAUTH` in `auth.go`, `handleXCLIENT` in `xclient.go`,
`handleBDAT` in `chunk.go`, `handlePROXY` in `proxy.go`. Two handlers stood
outside it, and the test files name the source files that were missing:

| The test | The file it names |
| --- | --- |
| `starttls_test.go` | `starttls.go`, new here |
| `reply_test.go` | `reply.go`, new here |
| `smtputf8_test.go` | `smtputf8.go`, new here |
| `verify_session_test.go` | `verify.go`, which now holds `handleVRFY` |

### What moved

- `handleSTARTTLS` to `starttls.go`.
- `handleVRFY` to `verify.go`, next to the `Verification` type that it reads.
- The writers of a reply to `reply.go`, with the reader of a status code and
  the guard that takes a control character out of the text. `session.go` keeps
  the session: the reads, the serve loop, and the end of a session.
- What RFC 6531 asks of an address to `smtputf8.go`. `handleMAIL` and
  `handleRCPT` carried that reading inline, and they call one function each
  now.
- `extensions()` next to `handleEHLO`, which is the one caller.
- The replies to an address that does not read to `address.go`, next to the
  reader that answers with them. The two handlers wrote the same reply in
  words of their own.

| File | Lines before | Lines after |
| --- | --- | --- |
| `protocol.go` | 594 | 438 |
| `session.go` | 490 | 326 |

### Reading the diff

Every declaration of the package is the same one in another file, but for four
that this PR adds:

```
> func (s *session) checkSenderCharset(addr string, smtputf8 bool) error
> func (s *session) checkRecipientCharset(addr string) error
> var errSenderMalformed  = Error{Code: 501, Enhanced: EnhancedCode{5, 1, 7}, ...}
> var errRecipientMalformed = Error{Code: 501, Enhanced: EnhancedCode{5, 1, 3}, ...}
```

The two functions hold the lines that `handleMAIL` and `handleRCPT` carried,
and the two values hold the replies that those handlers wrote as literals. The
codes, the status codes and the text are the ones that went on the wire
before, and the tests of the package hold them.

To read the diff as a set of moves:

```
git log -p --follow starttls.go
git diff main --stat
```

### What this PR does not do

It adds no registry of extensions and no interface for one. The hook points
differ too much for one shape: `DSN` adds parameters, `SMTPUTF8` adds a
parameter and changes how an address and a reply read, `CHUNKING` adds a verb
and a body, `XCLIENT` adds a verb alone. Four of the nine keywords in the
reply to `EHLO` need the state of the session, so a table of them would be a
table of closures.

A file for each of them is the part that pays, and it is the part that a
review can hold.

Two follow-ups from the same reading:

- `parseMailParams` and `parseRcptParams` still stand in `protocol.go`, which
  is where every new extension lands. They can take a `mail.go` and a
  `rcpt.go`.
- The package has no note that names these hook points. An `ARCHITECTURE.md`,
  or a section of a `doc.go`, would make the order above a rule that a review
  can name.
