### PR TITLE
feat: serve LMTP with a reply for every recipient (RFC 2033)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Server.LMTP` serves the Local Mail Transfer Protocol of RFC 2033 in the
+  place of SMTP. Such a server takes `LHLO` as the greeting and answers `500`
+  to `HELO` and to `EHLO`, and `Peer.Protocol` holds `LMTP`.
+
+  `LHLO` carries the semantics of `EHLO`, so the reply lists the extensions of
+  the server, and the replies of the session carry a status code.
+
+  The server writes one reply for every recipient of a message, in the order
+  that `RCPT TO` added them, which RFC 2033 section 4.2 asks for. The last
+  chunk of a `BDAT` transfer ends a message in the same way, so it takes the
+  same replies.
+
+  `Envelope.RejectRecipient` records the answer of one recipient, by the index
+  of that recipient in `Envelope.Recipients`. A handler that takes the message
+  for some of the recipients calls it for each of the rest. A recipient
+  without an error of its own gets the reply of the message.
+
 - The server answers the `VRFY` command of RFC 5321. A `Verify` hook in the
   middleware looks the name up and gives back a `Verification` with the
   mailbox of the user, which the client reads in a `250` reply.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Features
   [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
 * `VRFY` ([RFC 5321](https://www.rfc-editor.org/rfc/rfc5321)), through a
   middleware hook
+* LMTP ([RFC 2033](https://www.rfc-editor.org/rfc/rfc2033)), with one reply
+  for every recipient of a message
 * Per-phase middleware: connection, HELO, MAIL FROM, RCPT TO, AUTH, VRFY,
   DATA, RESET, DISCONNECT
 * Streaming `Envelope.Data` as `io.ReadCloser` - no forced buffering
@@ -559,6 +561,101 @@ The server offers no `VRFY` keyword in the reply to `EHLO`. RFC 5321 section
 > can answer for an authenticated client alone, and give the zero
 > `Verification` to every other one.
 
+### LMTP
+
+Set `Server.LMTP` to serve the Local Mail Transfer Protocol of
+[RFC 2033](https://www.rfc-editor.org/rfc/rfc2033) in the place of SMTP. Such
+a server takes `LHLO` as the greeting, and it answers `500` to `HELO` and to
+`EHLO`. `Peer.Protocol` holds `LMTP` from the greeting on.
+
+`LHLO` carries the semantics of `EHLO`, so the reply lists the same
+extensions, and the replies of the session carry a status code.
+
+The server writes one reply for every recipient of a message, in the order
+that `RCPT TO` added them. Two `RCPT TO` commands for one address therefore
+take two replies:
+
+```
+S: 220 localhost.localdomain LMTP ready.
+C: LHLO client.local
+S: 250-localhost.localdomain
+S: 250-SIZE 10240000
+S: 250-8BITMIME
+S: 250-BINARYMIME
+S: 250-CHUNKING
+S: 250-PIPELINING
+S: 250 ENHANCEDSTATUSCODES
+C: MAIL FROM:<sender@example.org>
+S: 250 2.1.0 Go ahead
+C: RCPT TO:<one@example.net>
+S: 250 2.1.5 Go ahead
+C: RCPT TO:<two@example.net>
+S: 250 2.1.5 Go ahead
+C: DATA
+S: 354 Go ahead. End your data with <CR><LF>.<CR><LF>
+C: [the message, and a line with one dot on it]
+S: 250 2.0.0 Thank you.
+S: 550 5.1.1 No such user
+```
+
+A handler that takes a message for some of the recipients calls
+`Envelope.RejectRecipient` for each of the rest. The index is the one of the
+recipient in `Envelope.Recipients`:
+
+```go
+srv := &smtpd.Server{
+    LMTP: true,
+    Handler: func(ctx context.Context, peer smtpd.Peer, env *smtpd.Envelope) (context.Context, error) {
+        defer env.Data.Close()
+
+        body, err := io.ReadAll(env.Data)
+        if err != nil {
+            return ctx, err
+        }
+
+        for i, recipient := range env.Recipients {
+            if err := mailbox.Deliver(recipient, body); err != nil {
+                // The index comes from the range, so it is a recipient of
+                // the envelope and the call takes it.
+                _ = env.RejectRecipient(i, smtpd.Error{
+                    Code:     550,
+                    Enhanced: smtpd.EnhancedCode{5, 1, 1},
+                    Message:  "No such user",
+                })
+            }
+        }
+
+        return ctx, nil
+    },
+}
+```
+
+A recipient without an error of its own gets the reply of the message: the
+`250`, or the error that the handler returned. An error of the handler refuses
+the message for every recipient, because the message failed for all of them.
+
+| The client sends | The server answers |
+| --- | --- |
+| `HELO` or `EHLO` | `500`, with the name of the greeting to send |
+| `LHLO`, to a server of SMTP | `500` |
+| the last chunk of a `BDAT` transfer | one reply for every recipient |
+| a message that is larger than `MaxMessageSize` | `552` for every recipient |
+
+A message that arrives in chunks takes the same replies. The chunks before the
+last one take one reply each, because they end no message.
+
+`RejectRecipient` returns an error for an index that no recipient carries, and
+it records nothing. A server of SMTP writes one reply for the whole message
+and reads none of these errors, so a handler for both protocols reads
+`Peer.Protocol`.
+
+> [!NOTE]
+> LMTP keeps no queue. The client holds the message until the server answers
+> `250` for a recipient, and the server delivers no message on its own. RFC
+> 2033 section 5 keeps the protocol off port 25 and away from wide area
+> networks. `Serve` takes any `net.Listener`, so a unix socket or an address
+> of the loopback interface carries it.
+
 ### Panics
 
 A panic in `Server.Handler` or in a middleware hook stops that session only.
@@ -821,6 +918,10 @@ itself.
 
 If the server stopped, `Dial` panics with the reason from `Serve`. A test
 with a bad configuration reads that reason instead of a dial error.
+
+`Dial` speaks SMTP. A test of an LMTP server sets `Config.LMTP` on an
+unstarted server and drives the connection to `Addr` itself, because
+`net/smtp` sends `EHLO`.
 
 `Close` waits five seconds for the sessions that are still open, then closes
 their connections and writes one line to stderr. A test that ends with a

--- a/chunk.go
+++ b/chunk.go
@@ -303,16 +303,15 @@ func (s *session) handleBDAT(ctx context.Context, cmd *command) context.Context 
 
 	ctx, received, err := s.finishChunk(ctx)
 	if err != nil {
-		ctx = s.replyChunkError(ctx, err)
-		if s.closed {
+		if ctx, done := s.reportDeliveryPanic(ctx, err); done {
 			// A panic in the handler ended the session, and there is no
 			// transaction left to reset.
 			return ctx
 		}
-		return s.reset(ctx)
+		return s.reset(s.replyDeliveryError(ctx, err))
 	}
 
-	return s.reset(s.reply(ctx, 250, fmt.Sprintf("Message OK, %d octets received", received)))
+	return s.reset(s.replyDelivery(ctx, fmt.Sprintf("Message OK, %d octets received", received)))
 }
 
 // chunkRefusal gives the answer for a chunk that the server does not take, or
@@ -349,7 +348,13 @@ func (s *session) refuseChunk(ctx context.Context, size int64, last bool, refusa
 		return ctx
 	}
 
-	ctx = s.replyError(ctx, refusal)
+	if last {
+		// The answer to the last chunk is the answer to the end of the
+		// message, and LMTP writes one of those for every recipient.
+		ctx = s.replyDeliveryError(ctx, refusal)
+	} else {
+		ctx = s.replyError(ctx, refusal)
+	}
 
 	if !read {
 		return s.close(ctx)
@@ -401,14 +406,26 @@ func (s *session) reportChunkPanic(ctx context.Context, result *deliverResult) (
 	return s.close(ctx), true
 }
 
-// replyChunkError answers a handler that ended with an error. A panic ends the
-// session, in the same way as a panic in the handler of a DATA message.
+// replyChunkError answers a handler that ended with an error while the
+// message was still arriving. A panic ends the session, in the same way as a
+// panic in the handler of a DATA message.
 func (s *session) replyChunkError(ctx context.Context, err error) context.Context {
-	var panicErr PanicError
-	if errors.As(err, &panicErr) {
-		ctx = s.reportPanic(ctx, panicErr)
-		return s.close(ctx)
+	if ctx, done := s.reportDeliveryPanic(ctx, err); done {
+		return ctx
 	}
 
 	return s.replyError(ctx, err)
+}
+
+// reportDeliveryPanic answers a handler that ended in a panic with the 421
+// that a panic in the handler of a DATA message also gives, and closes the
+// session. done says that the panic was there and that the session is over.
+func (s *session) reportDeliveryPanic(ctx context.Context, err error) (context.Context, bool) {
+	var panicErr PanicError
+	if !errors.As(err, &panicErr) {
+		return ctx, false
+	}
+
+	ctx = s.reportPanic(ctx, panicErr)
+	return s.close(ctx), true
 }

--- a/data.go
+++ b/data.go
@@ -47,10 +47,14 @@ func (s *session) handleDATA(ctx context.Context, cmd *command) context.Context 
 	_ = body.Close()
 
 	if body.tooBig {
-		ctx = s.replyEnhanced(ctx, 552, EnhancedCode{5, 3, 4}, fmt.Sprintf(
-			"Message exceeded max message size of %d bytes",
-			s.server.MaxMessageSize,
-		))
+		ctx = s.replyDeliveryError(ctx, Error{
+			Code:     552,
+			Enhanced: EnhancedCode{5, 3, 4},
+			Message: fmt.Sprintf(
+				"Message exceeded max message size of %d bytes",
+				s.server.MaxMessageSize,
+			),
+		})
 
 		// The client was still sending when the drain gave up, so the rest
 		// of the message is on the wire. Reading it costs without bound, and
@@ -73,10 +77,10 @@ func (s *session) handleDATA(ctx context.Context, cmd *command) context.Context 
 	}
 
 	if deliverErr != nil {
-		return s.reset(s.replyError(ctx, deliverErr))
+		return s.reset(s.replyDeliveryError(ctx, deliverErr))
 	}
 
-	return s.reset(s.reply(ctx, 250, "Thank you."))
+	return s.reset(s.replyDelivery(ctx, "Thank you."))
 
 }
 

--- a/envelope.go
+++ b/envelope.go
@@ -63,4 +63,10 @@ type Envelope struct {
 	// without Server.EnableDSN, and nil when the client sent none of the
 	// parameters.
 	DSN *DSN
+
+	// recipientErrs holds the answer that each recipient of an LMTP delivery
+	// gets, as RejectRecipient recorded it. Index i belongs to address i of
+	// Recipients, and nil there gives that recipient the reply of the
+	// message.
+	recipientErrs []error
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -217,6 +217,23 @@ func (c *rawClient) write(b []byte) {
 	}
 }
 
+// replies reads n complete replies. LMTP writes one for every recipient of a
+// message (RFC 2033 section 4.2), and each of them is a reply of its own and
+// not a continuation line of the one before it.
+func (c *rawClient) replies(n int) []string {
+	c.t.Helper()
+
+	replies := make([]string, 0, n)
+	for len(replies) < n {
+		line := c.line()
+		if len(line) >= 4 && line[3] == '-' {
+			continue
+		}
+		replies = append(replies, line)
+	}
+	return replies
+}
+
 // message is what a handler read off an envelope.
 type message struct {
 	sender     string

--- a/lmtp.go
+++ b/lmtp.go
@@ -1,6 +1,9 @@
 package smtpd
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // handleLHLO runs the LHLO command of RFC 2033 section 4.1. It is the
 // greeting of LMTP, in the place of HELO and of EHLO, and it carries the
@@ -21,4 +24,91 @@ func (s *session) replyWrongGreeting(ctx context.Context) context.Context {
 		return s.replyEnhanced(ctx, 500, EnhancedCode{5, 5, 1}, "This server speaks LMTP. Send LHLO.")
 	}
 	return s.replyEnhanced(ctx, 500, EnhancedCode{5, 5, 1}, "This server speaks SMTP. Send EHLO.")
+}
+
+// RejectRecipient records the answer that one recipient of an LMTP delivery
+// gets. i is the index of the recipient in Recipients.
+//
+// LMTP writes one reply for every recipient of a message, in the order that
+// RCPT TO added them (RFC 2033 section 4.2), so a handler can take a message
+// for some of the recipients and refuse it for the rest. A recipient that
+// carries no error of its own gets the reply of the message: the error that
+// the handler returned, or 250 where it returned none.
+//
+// err takes the form of the error of a Handler: an Error goes on the wire
+// with its code and its message, and every other error becomes a 502. An err
+// of nil gives the recipient the reply of the message again.
+//
+// Call it from a Handler, and before that handler returns. The session writes
+// the replies as soon as the last handler of the message ends.
+//
+// A session of SMTP writes one reply for the whole message and reads none of
+// these errors, because the client there has one address for the message.
+// A handler tells the two apart by Peer.Protocol.
+//
+// It returns an error for an index that no recipient carries, and records
+// nothing.
+func (e *Envelope) RejectRecipient(i int, err error) error {
+	if i < 0 || i >= len(e.Recipients) {
+		return fmt.Errorf("smtpd: no recipient at index %d, the envelope carries %d", i, len(e.Recipients))
+	}
+
+	for len(e.recipientErrs) < len(e.Recipients) {
+		e.recipientErrs = append(e.recipientErrs, nil)
+	}
+
+	e.recipientErrs[i] = err
+	return nil
+}
+
+// recipientErr gives the answer that a handler recorded for recipient i, and
+// nil where it recorded none.
+func (e *Envelope) recipientErr(i int) error {
+	if i >= len(e.recipientErrs) {
+		return nil
+	}
+	return e.recipientErrs[i]
+}
+
+// perRecipient reports whether the answer to the end of a message goes to
+// every recipient: a server of LMTP with a transaction that has recipients.
+func (s *session) perRecipient() bool {
+	return s.server.LMTP && s.envelope != nil && len(s.envelope.Recipients) > 0
+}
+
+// replyDelivery answers the end of a message that the server took. message is
+// the text of the reply for a recipient that it holds the message for.
+//
+// SMTP takes one reply for the whole message. LMTP takes one for every
+// recipient, and a recipient that the handler refused with RejectRecipient
+// gets that answer in the place of this one.
+func (s *session) replyDelivery(ctx context.Context, message string) context.Context {
+	if !s.perRecipient() {
+		return s.reply(ctx, 250, message)
+	}
+
+	for i := range s.envelope.Recipients {
+		if err := s.envelope.recipientErr(i); err != nil {
+			ctx = s.replyError(ctx, err)
+			continue
+		}
+		ctx = s.reply(ctx, 250, message)
+	}
+
+	return ctx
+}
+
+// replyDeliveryError answers the end of a message that the server did not
+// take. In LMTP every recipient gets the same answer, because the message
+// failed for all of them.
+func (s *session) replyDeliveryError(ctx context.Context, err error) context.Context {
+	if !s.perRecipient() {
+		return s.replyError(ctx, err)
+	}
+
+	for range s.envelope.Recipients {
+		ctx = s.replyError(ctx, err)
+	}
+
+	return ctx
 }

--- a/lmtp.go
+++ b/lmtp.go
@@ -1,0 +1,24 @@
+package smtpd
+
+import "context"
+
+// handleLHLO runs the LHLO command of RFC 2033 section 4.1. It is the
+// greeting of LMTP, in the place of HELO and of EHLO, and it carries the
+// semantics of EHLO: the reply lists the extensions that the server offers.
+func (s *session) handleLHLO(ctx context.Context, cmd *command) context.Context {
+	ctx, _ = phasedLoggerFromContext(ctx, "lhlo")
+	return s.greetExtended(ctx, cmd, LMTP)
+}
+
+// replyWrongGreeting answers the greeting of the other protocol. RFC 2033
+// section 4.1 asks an LMTP server for a reply that is not a completion to
+// HELO and to EHLO, and an SMTP server knows no LHLO.
+//
+// The message names the greeting to send, because a client that sends the
+// wrong one reaches a server of the other protocol.
+func (s *session) replyWrongGreeting(ctx context.Context) context.Context {
+	if s.server.LMTP {
+		return s.replyEnhanced(ctx, 500, EnhancedCode{5, 5, 1}, "This server speaks LMTP. Send LHLO.")
+	}
+	return s.replyEnhanced(ctx, 500, EnhancedCode{5, 5, 1}, "This server speaks SMTP. Send EHLO.")
+}

--- a/lmtp.go
+++ b/lmtp.go
@@ -42,9 +42,9 @@ func (s *session) replyWrongGreeting(ctx context.Context) context.Context {
 // Call it from a Handler, and before that handler returns. The session writes
 // the replies as soon as the last handler of the message ends.
 //
-// A session of SMTP writes one reply for the whole message and reads none of
-// these errors, because the client there has one address for the message.
-// A handler tells the two apart by Peer.Protocol.
+// A session of SMTP takes as many recipients as an LMTP one, and it writes
+// one reply for all of them: that reply answers for the message, and it reads
+// none of these errors. A handler tells the two apart by Peer.Protocol.
 //
 // It returns an error for an index that no recipient carries, and records
 // nothing.

--- a/lmtp_test.go
+++ b/lmtp_test.go
@@ -1,6 +1,8 @@
 package smtpd_test
 
 import (
+	"context"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -15,6 +17,37 @@ func lmtpserver(t *testing.T, srv *smtpd.Server, mws ...smtpd.Middleware) *smtpt
 	srv.LMTP = true
 	srv.Logger = testLogger(t)
 	return runserver(t, srv, mws...)
+}
+
+// openLMTP greets the server with LHLO and sends MAIL FROM and one RCPT TO
+// for every recipient, so that the next command carries the message.
+func openLMTP(t *testing.T, c *rawClient, recipients ...string) {
+	t.Helper()
+
+	if reply := c.send("LHLO localhost"); !strings.HasPrefix(reply, "250") {
+		t.Fatalf("LHLO reply = %q, want 250", reply)
+	}
+	if reply := c.send("MAIL FROM:<sender@example.org>"); !strings.HasPrefix(reply, "250") {
+		t.Fatalf("MAIL reply = %q, want 250", reply)
+	}
+	for _, recipient := range recipients {
+		if reply := c.send("RCPT TO:<%s>", recipient); !strings.HasPrefix(reply, "250") {
+			t.Fatalf("RCPT reply for %s = %q, want 250", recipient, reply)
+		}
+	}
+}
+
+// rejectRecipientAt returns a Handler that refuses the recipient at index i
+// and takes the message for every other recipient.
+func rejectRecipientAt(t *testing.T, i int, err error) smtpd.Handler {
+	return func(ctx context.Context, _ smtpd.Peer, env *smtpd.Envelope) (context.Context, error) {
+		t.Helper()
+
+		if rejectErr := env.RejectRecipient(i, err); rejectErr != nil {
+			t.Errorf("RejectRecipient(%d) failed: %v", i, rejectErr)
+		}
+		return ctx, nil
+	}
 }
 
 // TestLMTPGreeting covers the LHLO command of RFC 2033 section 4.1: it has
@@ -89,5 +122,301 @@ func TestLMTPGreetingOfTheOtherProtocol(t *testing.T) {
 				t.Errorf("reply to %q = %q, want %q", tc.command, reply, tc.want)
 			}
 		})
+	}
+}
+
+// TestLMTPRepliesForEveryRecipient covers RFC 2033 section 4.2: after the
+// final dot the server writes one reply for every recipient that RCPT TO
+// added, in the order that the commands arrived.
+func TestLMTPRepliesForEveryRecipient(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		recipients []string
+		handler    smtpd.Handler
+		want       []string
+	}{
+		{
+			name:       "one reply for each recipient",
+			recipients: []string{"one@example.net", "two@example.net"},
+			want:       []string{"250 2.0.0 Thank you.", "250 2.0.0 Thank you."},
+		},
+		{
+			name:       "the same address twice",
+			recipients: []string{"one@example.net", "one@example.net"},
+			want:       []string{"250 2.0.0 Thank you.", "250 2.0.0 Thank you."},
+		},
+		{
+			name:       "one recipient of three refused",
+			recipients: []string{"one@example.net", "two@example.net", "three@example.net"},
+			handler:    rejectRecipientAt(t, 1, smtpd.Error{Code: 550, Enhanced: smtpd.EnhancedCode{5, 1, 1}, Message: "No such user"}),
+			want: []string{
+				"250 2.0.0 Thank you.",
+				"550 5.1.1 No such user",
+				"250 2.0.0 Thank you.",
+			},
+		},
+		{
+			name:       "the message refused for all of them",
+			recipients: []string{"one@example.net", "two@example.net"},
+			handler: func(ctx context.Context, _ smtpd.Peer, _ *smtpd.Envelope) (context.Context, error) {
+				return ctx, smtpd.Error{Code: 451, Enhanced: smtpd.EnhancedCode{4, 3, 0}, Message: "Try later"}
+			},
+			want: []string{"451 4.3.0 Try later", "451 4.3.0 Try later"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := lmtpserver(t, &smtpd.Server{Handler: tc.handler})
+			c := dialRaw(t, srv.Addr)
+
+			openLMTP(t, c, tc.recipients...)
+
+			if reply := c.send("DATA"); !strings.HasPrefix(reply, "354") {
+				t.Fatalf("DATA reply = %q, want 354", reply)
+			}
+			c.write([]byte("Subject: one\r\n\r\nA short body.\r\n.\r\n"))
+
+			if got := c.replies(len(tc.want)); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("replies = %q, want %q", got, tc.want)
+			}
+
+			// The transaction wrote as many replies as the client expects,
+			// and no reply of it is left for the command that follows.
+			if reply := c.send("NOOP"); reply != "250 2.0.0 Go ahead" {
+				t.Errorf("NOOP reply = %q, want the answer to that command", reply)
+			}
+		})
+	}
+}
+
+// TestLMTPRepliesForEveryRecipientBDAT covers the same rule for a message
+// that arrives in chunks: the last chunk ends the message, so its reply is
+// the one that every recipient gets.
+func TestLMTPRepliesForEveryRecipientBDAT(t *testing.T) {
+	t.Parallel()
+
+	srv := lmtpserver(t, &smtpd.Server{
+		Handler: rejectRecipientAt(t, 0, smtpd.Error{Code: 550, Enhanced: smtpd.EnhancedCode{5, 1, 1}, Message: "No such user"}),
+	})
+	c := dialRaw(t, srv.Addr)
+
+	openLMTP(t, c, "one@example.net", "two@example.net")
+
+	// A chunk that is not the last one ends no message, so it takes one
+	// reply of its own.
+	c.write([]byte("BDAT 6\r\nfirst "))
+	if reply := c.line(); reply != "250 2.0.0 6 octets received" {
+		t.Errorf("reply to the first chunk = %q, want one reply for the chunk", reply)
+	}
+
+	c.write([]byte("BDAT 6 LAST\r\nsecond"))
+
+	want := []string{
+		"550 5.1.1 No such user",
+		"250 2.0.0 Message OK, 12 octets received",
+	}
+	if got := c.replies(len(want)); !reflect.DeepEqual(got, want) {
+		t.Errorf("replies = %q, want %q", got, want)
+	}
+
+	if reply := c.send("NOOP"); reply != "250 2.0.0 Go ahead" {
+		t.Errorf("NOOP reply = %q, want the answer to that command", reply)
+	}
+}
+
+// TestLMTPRepliesForEveryRecipientRefusal covers a message that the server
+// refuses on its own, without a handler: every recipient still gets a reply,
+// because the client counts them.
+func TestLMTPRepliesForEveryRecipientRefusal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// send writes the message and the command that carries it.
+		send func(t *testing.T, c *rawClient)
+		want []string
+	}{
+		{
+			name: "a DATA message that is too large",
+			send: func(t *testing.T, c *rawClient) {
+				t.Helper()
+
+				if reply := c.send("DATA"); !strings.HasPrefix(reply, "354") {
+					t.Fatalf("DATA reply = %q, want 354", reply)
+				}
+				c.write([]byte(strings.Repeat("a", 150) + "\r\n.\r\n"))
+			},
+			want: []string{
+				"552 5.3.4 Message exceeded max message size of 100 bytes",
+				"552 5.3.4 Message exceeded max message size of 100 bytes",
+			},
+		},
+		{
+			name: "a last chunk that is too large",
+			send: func(t *testing.T, c *rawClient) {
+				t.Helper()
+
+				c.write([]byte("BDAT 150 LAST\r\n" + strings.Repeat("a", 150)))
+			},
+			want: []string{
+				"552 5.3.4 Message exceeded max message size of 100 bytes",
+				"552 5.3.4 Message exceeded max message size of 100 bytes",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := lmtpserver(t, &smtpd.Server{MaxMessageSize: 100})
+			c := dialRaw(t, srv.Addr)
+
+			openLMTP(t, c, "one@example.net", "two@example.net")
+			tc.send(t, c)
+
+			if got := c.replies(len(tc.want)); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("replies = %q, want %q", got, tc.want)
+			}
+
+			if reply := c.send("NOOP"); reply != "250 2.0.0 Go ahead" {
+				t.Errorf("NOOP reply = %q, want the answer to that command", reply)
+			}
+		})
+	}
+}
+
+// TestLMTPTakesMailParameters covers the parameters of MAIL FROM and RCPT TO
+// on an LMTP session. LHLO offers the extensions of the server in the same
+// way as EHLO, so the parameters of those extensions arrive.
+func TestLMTPTakesMailParameters(t *testing.T) {
+	t.Parallel()
+
+	got := make(chan *smtpd.DSN, 1)
+	srv := lmtpserver(t, &smtpd.Server{EnableDSN: true, Handler: dsnCapture(got)})
+	c := dialRaw(t, srv.Addr)
+
+	if reply := c.send("LHLO localhost"); !strings.HasPrefix(reply, "250") {
+		t.Fatalf("LHLO reply = %q, want 250", reply)
+	}
+	if reply := c.send("MAIL FROM:<sender@example.org> BODY=8BITMIME SIZE=100 RET=HDRS"); reply != "250 2.1.0 Go ahead" {
+		t.Fatalf("MAIL reply = %q, want 250", reply)
+	}
+	if reply := c.send("RCPT TO:<one@example.net> NOTIFY=SUCCESS"); reply != "250 2.1.5 Go ahead" {
+		t.Fatalf("RCPT reply = %q, want 250", reply)
+	}
+	if reply := c.send("DATA"); !strings.HasPrefix(reply, "354") {
+		t.Fatalf("DATA reply = %q, want 354", reply)
+	}
+	c.write([]byte("body\r\n.\r\n"))
+	c.replies(1)
+
+	dsn := <-got
+	if dsn == nil {
+		t.Fatal("the envelope carries no DSN parameters")
+	}
+	if dsn.Return != smtpd.DSNReturnHeaders {
+		t.Errorf("DSN.Return = %q, want %q", dsn.Return, smtpd.DSNReturnHeaders)
+	}
+}
+
+// TestLMTPPeerProtocol covers what a hook and a handler read off the peer of
+// an LMTP session.
+func TestLMTPPeerProtocol(t *testing.T) {
+	t.Parallel()
+
+	got := make(chan smtpd.Protocol, 1)
+	srv := lmtpserver(t, &smtpd.Server{
+		Handler: func(ctx context.Context, peer smtpd.Peer, _ *smtpd.Envelope) (context.Context, error) {
+			got <- peer.Protocol
+			return ctx, nil
+		},
+	})
+
+	c := dialRaw(t, srv.Addr)
+	openLMTP(t, c, "one@example.net")
+
+	if reply := c.send("DATA"); !strings.HasPrefix(reply, "354") {
+		t.Fatalf("DATA reply = %q, want 354", reply)
+	}
+	c.write([]byte("body\r\n.\r\n"))
+	c.replies(1)
+
+	if protocol := <-got; protocol != smtpd.LMTP {
+		t.Errorf("Peer.Protocol = %q, want %q", protocol, smtpd.LMTP)
+	}
+}
+
+// TestRejectRecipientIndex covers the index that the caller gives.
+func TestRejectRecipientIndex(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		index   int
+		wantErr bool
+	}{
+		{name: "the first recipient", index: 0},
+		{name: "the last recipient", index: 1},
+		{name: "one past the last", index: 2, wantErr: true},
+		{name: "a negative index", index: -1, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			env := &smtpd.Envelope{Recipients: []string{"one@example.net", "two@example.net"}}
+
+			err := env.RejectRecipient(tc.index, smtpd.Error{Code: 550, Message: "No such user"})
+			if tc.wantErr && err == nil {
+				t.Fatalf("RejectRecipient(%d) = nil, want an error", tc.index)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("RejectRecipient(%d) failed: %v", tc.index, err)
+			}
+		})
+	}
+}
+
+// TestSMTPWritesOneReply covers a server of SMTP: the client there has one
+// address for the message, so a recipient that a handler refused on its own
+// changes nothing on the wire.
+func TestSMTPWritesOneReply(t *testing.T) {
+	t.Parallel()
+
+	srv := runserver(t, &smtpd.Server{
+		Logger:  testLogger(t),
+		Handler: rejectRecipientAt(t, 1, smtpd.Error{Code: 550, Message: "No such user"}),
+	})
+	c := dialRaw(t, srv.Addr)
+
+	if reply := c.send("EHLO localhost"); !strings.HasPrefix(reply, "250") {
+		t.Fatalf("EHLO reply = %q, want 250", reply)
+	}
+	if reply := c.send("MAIL FROM:<sender@example.org>"); !strings.HasPrefix(reply, "250") {
+		t.Fatalf("MAIL reply = %q, want 250", reply)
+	}
+	for _, recipient := range []string{"one@example.net", "two@example.net"} {
+		if reply := c.send("RCPT TO:<%s>", recipient); !strings.HasPrefix(reply, "250") {
+			t.Fatalf("RCPT reply = %q, want 250", reply)
+		}
+	}
+	if reply := c.send("DATA"); !strings.HasPrefix(reply, "354") {
+		t.Fatalf("DATA reply = %q, want 354", reply)
+	}
+
+	c.write([]byte("body\r\n.\r\n"))
+	if reply := c.line(); reply != "250 2.0.0 Thank you." {
+		t.Errorf("reply to the message = %q, want one reply for the whole message", reply)
+	}
+
+	if reply := c.send("NOOP"); reply != "250 2.0.0 Go ahead" {
+		t.Errorf("NOOP reply = %q, want the answer to that command", reply)
 	}
 }

--- a/lmtp_test.go
+++ b/lmtp_test.go
@@ -1,0 +1,93 @@
+package smtpd_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chrj/smtpd/v2"
+	"github.com/chrj/smtpd/v2/smtptest"
+)
+
+// lmtpserver starts a server that speaks LMTP and gives the messages to h.
+func lmtpserver(t *testing.T, srv *smtpd.Server, mws ...smtpd.Middleware) *smtptest.Server {
+	t.Helper()
+
+	srv.LMTP = true
+	srv.Logger = testLogger(t)
+	return runserver(t, srv, mws...)
+}
+
+// TestLMTPGreeting covers the LHLO command of RFC 2033 section 4.1: it has
+// the semantics of EHLO, so the reply carries the extensions of the server.
+func TestLMTPGreeting(t *testing.T) {
+	t.Parallel()
+
+	srv := lmtpserver(t, &smtpd.Server{})
+	c := dialRaw(t, srv.Addr)
+
+	if !strings.HasSuffix(c.banner, "LMTP ready.") {
+		t.Errorf("banner = %q, want it to end with %q", c.banner, "LMTP ready.")
+	}
+
+	lines := c.replyLines("LHLO localhost")
+	if !strings.HasPrefix(lines[0], "250") {
+		t.Fatalf("LHLO reply = %q, want 250", lines[0])
+	}
+
+	for _, keyword := range []string{"CHUNKING", "PIPELINING", "ENHANCEDSTATUSCODES"} {
+		if !strings.Contains(strings.Join(lines, "\n"), keyword) {
+			t.Errorf("the reply to LHLO does not offer %s: %q", keyword, lines)
+		}
+	}
+
+	// The extension of RFC 2034 is in the reply, so the replies that follow
+	// carry a status code.
+	if reply := c.send("NOOP"); reply != "250 2.0.0 Go ahead" {
+		t.Errorf("NOOP reply = %q, want a status code with it", reply)
+	}
+}
+
+// TestLMTPGreetingOfTheOtherProtocol covers the greeting that the server does
+// not speak. RFC 2033 section 4.1 asks an LMTP server for a reply that is not
+// a completion to HELO and to EHLO.
+func TestLMTPGreetingOfTheOtherProtocol(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		lmtp    bool
+		command string
+		want    string
+	}{
+		{
+			name:    "HELO on a server of LMTP",
+			lmtp:    true,
+			command: "HELO localhost",
+			want:    "500 This server speaks LMTP. Send LHLO.",
+		},
+		{
+			name:    "EHLO on a server of LMTP",
+			lmtp:    true,
+			command: "EHLO localhost",
+			want:    "500 This server speaks LMTP. Send LHLO.",
+		},
+		{
+			name:    "LHLO on a server of SMTP",
+			command: "LHLO localhost",
+			want:    "500 This server speaks SMTP. Send EHLO.",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := runserver(t, &smtpd.Server{LMTP: tc.lmtp, Logger: testLogger(t)})
+			c := dialRaw(t, srv.Addr)
+
+			if reply := c.send("%s", tc.command); reply != tc.want {
+				t.Errorf("reply to %q = %q, want %q", tc.command, reply, tc.want)
+			}
+		})
+	}
+}

--- a/mail.go
+++ b/mail.go
@@ -28,7 +28,7 @@ func (s *session) parseMailParams(params map[string]string) (mailParams, error) 
 	if len(params) == 0 {
 		return out, nil
 	}
-	if s.peer.Protocol != ESMTP {
+	if !s.peer.Protocol.extended() {
 		return mailParams{}, errMailParams
 	}
 

--- a/protocol.go
+++ b/protocol.go
@@ -38,10 +38,22 @@ func (s *session) handle(ctx context.Context, line string) context.Context {
 		return s.handlePROXY(ctx, cmd)
 
 	case "HELO":
+		if s.server.LMTP {
+			return s.replyWrongGreeting(ctx)
+		}
 		return s.handleHELO(ctx, cmd)
 
 	case "EHLO":
+		if s.server.LMTP {
+			return s.replyWrongGreeting(ctx)
+		}
 		return s.handleEHLO(ctx, cmd)
+
+	case "LHLO":
+		if !s.server.LMTP {
+			return s.replyWrongGreeting(ctx)
+		}
+		return s.handleLHLO(ctx, cmd)
 
 	case "MAIL":
 		return s.handleMAIL(ctx, cmd)
@@ -109,14 +121,20 @@ func (s *session) handleHELO(ctx context.Context, cmd *command) context.Context 
 
 func (s *session) handleEHLO(ctx context.Context, cmd *command) context.Context {
 	ctx, _ = phasedLoggerFromContext(ctx, "ehlo")
+	return s.greetExtended(ctx, cmd, ESMTP)
+}
 
+// greetExtended answers a greeting that carries the extensions of the server:
+// EHLO of RFC 5321, and the LHLO of RFC 2033 section 4.1, which has the same
+// semantics. protocol is what the greeting puts on Peer.Protocol.
+func (s *session) greetExtended(ctx context.Context, cmd *command, protocol Protocol) context.Context {
 	name, ok := cmd.singleArg()
 	if !ok {
 		return s.reply(ctx, 501, "Missing parameter")
 	}
 
 	if s.peer.HeloName != "" {
-		// Reset envelope in case of duplicate EHLO
+		// Reset envelope in case of a duplicate greeting
 		ctx = s.reset(ctx)
 	}
 
@@ -127,7 +145,7 @@ func (s *session) handleEHLO(ctx context.Context, cmd *command) context.Context 
 	}
 
 	s.peer.HeloName = name
-	s.peer.Protocol = ESMTP
+	s.peer.Protocol = protocol
 
 	return s.replyMultiline(ctx, 250, s.server.Hostname, s.extensions()...)
 

--- a/rcpt.go
+++ b/rcpt.go
@@ -19,7 +19,7 @@ func (s *session) parseRcptParams(params map[string]string, smtputf8 bool) (Reci
 	if len(params) == 0 {
 		return rcpt, nil
 	}
-	if s.peer.Protocol != ESMTP || !s.server.EnableDSN {
+	if !s.peer.Protocol.extended() || !s.server.EnableDSN {
 		return RecipientDSN{}, errRcptParams
 	}
 

--- a/reply.go
+++ b/reply.go
@@ -115,10 +115,11 @@ func isControl(c byte) bool {
 // empty when the client did not send EHLO.
 //
 // RFC 2034 makes the status code part of an extension, and the server
-// offers that extension in the reply to EHLO. A client that sent HELO never
-// saw the offer, so it gets the replies that it expects from RFC 5321.
+// offers that extension in the reply to EHLO and to LHLO. A client that sent
+// HELO never saw the offer, so it gets the replies that it expects from RFC
+// 5321.
 func (s *session) status(enhanced EnhancedCode) string {
-	if s.peer.Protocol != ESMTP {
+	if !s.peer.Protocol.extended() {
 		return ""
 	}
 	return enhanced.String()

--- a/smtpd.go
+++ b/smtpd.go
@@ -1,7 +1,7 @@
 // Package smtpd implements an SMTP server with support for STARTTLS, authentication (PLAIN/LOGIN), XCLIENT and optional restrictions on the different stages of the SMTP session.
 //
 // Server.LMTP serves the Local Mail Transfer Protocol of RFC 2033 in the
-// place of SMTP.
+// place of SMTP, with one reply for every recipient of a message.
 package smtpd
 
 import (
@@ -211,6 +211,11 @@ type Server struct {
 	// LMTP serves the Local Mail Transfer Protocol of RFC 2033 in the place
 	// of SMTP. Such a server takes LHLO as the greeting and answers 500 to
 	// HELO and to EHLO, and Peer.Protocol holds LMTP.
+	//
+	// The server writes one reply for every recipient of a message, in the
+	// order that RCPT TO added them, so the client learns which of them the
+	// server holds the message for. A handler that takes a message for some
+	// of the recipients calls Envelope.RejectRecipient for each of the rest.
 	//
 	// LMTP keeps no queue: a client holds the message until the server
 	// answers 250 for a recipient, and it delivers no message on its own.

--- a/smtpd.go
+++ b/smtpd.go
@@ -1,4 +1,7 @@
 // Package smtpd implements an SMTP server with support for STARTTLS, authentication (PLAIN/LOGIN), XCLIENT and optional restrictions on the different stages of the SMTP session.
+//
+// Server.LMTP serves the Local Mail Transfer Protocol of RFC 2033 in the
+// place of SMTP.
 package smtpd
 
 import (
@@ -17,9 +20,9 @@ import (
 // ErrServerClosed is returned by Serve/ListenAndServe after Shutdown.
 var ErrServerClosed = errors.New("smtpd: server closed")
 
-// Protocol identifies the SMTP variant selected by the client's greeting:
-// SMTP after HELO, ESMTP after EHLO. Read it from Peer.Protocol in phase
-// hooks and handlers.
+// Protocol identifies the variant that the greeting of the client selected:
+// SMTP after HELO, ESMTP after EHLO, LMTP after LHLO. Read it from
+// Peer.Protocol in phase hooks and handlers.
 type Protocol string
 
 const (
@@ -28,7 +31,20 @@ const (
 	// ESMTP is set on Peer.Protocol after an EHLO greeting, which also
 	// enables extensions advertised in the 250 response.
 	ESMTP Protocol = "ESMTP"
+	// LMTP is set on Peer.Protocol after an LHLO greeting, which a server
+	// of Server.LMTP takes in the place of HELO and of EHLO. It enables the
+	// same extensions as ESMTP, and the server writes one reply for every
+	// recipient of a message.
+	LMTP Protocol = "LMTP"
 )
+
+// extended reports whether the greeting of the client came with the
+// extensions of ESMTP. RFC 5321 gives them to a client that sent EHLO, and
+// RFC 2033 section 4.1 gives the same to a client that sent LHLO. A client
+// that sent HELO saw no offer of them, so it reads the replies of RFC 5321.
+func (p Protocol) extended() bool {
+	return p == ESMTP || p == LMTP
+}
 
 // Peer describes the remote client. Fields are populated progressively as
 // the SMTP session advances: Addr and ServerName are set at connection
@@ -190,7 +206,19 @@ type Middleware struct {
 type Server struct {
 	// Identity
 	Hostname       string // default: "localhost.localdomain"
-	WelcomeMessage string // default: "{Hostname} ESMTP ready."
+	WelcomeMessage string // default: "{Hostname} ESMTP ready.", and "{Hostname} LMTP ready." with LMTP
+
+	// LMTP serves the Local Mail Transfer Protocol of RFC 2033 in the place
+	// of SMTP. Such a server takes LHLO as the greeting and answers 500 to
+	// HELO and to EHLO, and Peer.Protocol holds LMTP.
+	//
+	// LMTP keeps no queue: a client holds the message until the server
+	// answers 250 for a recipient, and it delivers no message on its own.
+	// Serve it where the local mail system reaches it and nothing else, such
+	// as a unix socket or an address of the loopback interface. RFC 2033
+	// section 5 keeps the protocol off port 25 and away from wide area
+	// networks.
+	LMTP bool
 
 	// Timeouts
 	ReadTimeout  time.Duration // per-read; default 60s
@@ -479,7 +507,11 @@ func (srv *Server) configureDefaults() error {
 		srv.Hostname = "localhost.localdomain"
 	}
 	if srv.WelcomeMessage == "" {
-		srv.WelcomeMessage = fmt.Sprintf("%s ESMTP ready.", srv.Hostname)
+		protocol := ESMTP
+		if srv.LMTP {
+			protocol = LMTP
+		}
+		srv.WelcomeMessage = fmt.Sprintf("%s %s ready.", srv.Hostname, protocol)
 	}
 	return nil
 }


### PR DESCRIPTION
`Server.LMTP` serves the Local Mail Transfer Protocol of
[RFC 2033](https://www.rfc-editor.org/rfc/rfc2033) in the place of SMTP. The
protocol is the one that a local delivery agent takes: the client holds the
message until the server answers for a recipient, and the server writes one
reply for every recipient of a message.

## The greeting

Such a server takes `LHLO` as the greeting, and it answers `500` to `HELO` and
to `EHLO`, which section 4.1 asks for. A server of SMTP answers `LHLO` in the
same way. Both messages name the greeting to send.

`LHLO` carries the semantics of `EHLO`, so the reply lists the extensions of
the server. `Peer.Protocol` holds `LMTP`, and the replies of the session carry
a status code and take the parameters of the extensions.

## One reply for every recipient

Section 4.2 asks for one reply for each recipient that `RCPT TO` added, in the
order that the commands arrived. The final dot of a `DATA` message ends a
message, and so does the last chunk of a `BDAT` transfer, so both take these
replies. A refusal of the message takes them as well: the client counts the
replies, and one of them leaves the session out of step.

```
C: RCPT TO:<one@example.net>
S: 250 2.1.5 Go ahead
C: RCPT TO:<two@example.net>
S: 250 2.1.5 Go ahead
C: DATA
S: 354 Go ahead. End your data with <CR><LF>.<CR><LF>
C: [the message, and a line with one dot on it]
S: 250 2.0.0 Thank you.
S: 550 5.1.1 No such user
```

`Envelope.RejectRecipient` records the answer of a single recipient, by the
index of that recipient in `Envelope.Recipients`. A handler that takes the
message for some of the recipients calls it for each of the rest. A recipient
without an error of its own gets the reply of the message: the `250`, or the
error that the handler returned.

A session of SMTP writes one reply for the whole message and reads none of
these errors, because the client there has one address for the message.

## Notes for the review

- The commits are three: the greeting, the replies for every recipient, and
  the documentation.
- `handleEHLO` and `handleLHLO` share `greetExtended`, because the two
  greetings differ in the protocol alone.
- The tests drive a raw connection, because `net/smtp` sends `EHLO`. They
  cover the greeting of both protocols, the replies of a `DATA` message and of
  a `BDAT` transfer, a message that is too large, the parameters of `MAIL
  FROM` over LMTP, and a server of SMTP that keeps its one reply.
- The branch sits on `main`, after the two refactors of #60 and #61.
