### PR TITLE
feat: take a header of version 2 of the PROXY protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,8 +65,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   A header that the server cannot read ends the session without a reply, which
   the specification asks for, and the `Disconnect` hooks read a `ProxyError`
-  with the reason. The values that a proxy writes after the addresses stay
-  unread.
+  with the reason. A header that stops in the middle gives the same error, and
+  `ProxyError.Err` carries the error of the read. The values that a proxy
+  writes after the addresses stay unread.
 
 - `Server.LMTP` serves the Local Mail Transfer Protocol of RFC 2033 in the
   place of SMTP. Such a server takes `LHLO` as the greeting and answers `500`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unspecified transport protocol carries no address of a client, and the
   addresses of the connection stay.
 
+  A header of version 2 is the first line of the session in the same way as a
+  header of version 1, so a `PROXY` command after one gets a `503` reply.
+
   A header that the server cannot read ends the session without a reply, which
   the specification asks for, and the `Disconnect` hooks read a `ProxyError`
   with the reason. A header that stops in the middle gives the same error, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the specification asks for, and the `Disconnect` hooks read a `ProxyError`
   with the reason. A header that stops in the middle gives the same error, and
   `ProxyError.Err` carries the error of the read. The values that a proxy
-  writes after the addresses stay unread.
+  writes after the addresses come off the stream with the rest of the header,
+  and the server looks at none of them.
 
 - `Server.LMTP` serves the Local Mail Transfer Protocol of RFC 2033 in the
   place of SMTP. Such a server takes `LHLO` as the greeting and answers `500`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The read of a PROXY protocol header takes `Server.ReadTimeout`. A server
+  with `Server.EnableProxyProtocol` holds the greeting back until the header
+  arrives, and no deadline stood on that read before. A connection that sent
+  nothing therefore held a goroutine of the server for as long as it stayed
+  open.
+
 - The readers of an SMTP keyword take the letters of US-ASCII, where they took
   `strings.EqualFold` before. That function folds the case of Unicode, and two
   runes fold to a letter of US-ASCII: U+017F to `s` and U+212A to `k`.
@@ -46,6 +52,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whole.
 
 ### Added
+
+- `Server.EnableProxyProtocol` takes a header of version 2 of the PROXY
+  protocol, next to the version 1 that it took before. Version 2 is binary,
+  and the first octet of the stream tells the two versions apart.
+
+  The address of the client goes on `Peer.Addr`: a `*net.TCPAddr` for the IPv4
+  and the IPv6 families, and a `*net.UnixAddr` for a unix socket. A header of
+  the `LOCAL` command, of the unspecified address family, or of the
+  unspecified transport protocol carries no address of a client, and the
+  addresses of the connection stay.
+
+  A header that the server cannot read ends the session without a reply, which
+  the specification asks for, and the `Disconnect` hooks read a `ProxyError`
+  with the reason. The values that a proxy writes after the addresses stay
+  unread.
 
 - `Server.LMTP` serves the Local Mail Transfer Protocol of RFC 2033 in the
   place of SMTP. Such a server takes `LHLO` as the greeting and answers `500`

--- a/README.md
+++ b/README.md
@@ -291,9 +291,10 @@ read gets a `501` reply.
 
 A header of version 2 carries the address family. `Peer.Addr` holds a
 `*net.TCPAddr` for the IPv4 and the IPv6 families, and a `*net.UnixAddr` for a
-unix socket. The values that follow the addresses stay unread. They carry what
-the proxy knows about the connection, such as the name that the client asked
-for in a TLS handshake.
+unix socket. The values that follow the addresses come off the stream with the
+rest of the header, and the server looks at none of them. They carry what the
+proxy knows about the connection, such as the name that the client asked for
+in a TLS handshake.
 
 Two headers of version 2 carry no address of a client, and the addresses of
 the connection stay on the peer: the `LOCAL` command, which a proxy writes for

--- a/README.md
+++ b/README.md
@@ -320,10 +320,14 @@ smtpd.Middleware{
 }
 ```
 
+The header is the first line of the session, in both versions. A `PROXY`
+command after it gets a `503` reply, because the proxy writes its header
+before it passes on anything of the client.
+
 > [!NOTE]
 > The server holds the greeting back until the header arrives, so give it a
-> listener that the proxy alone reaches. A client that sends a header of its
-> own writes the address that every hook then reads.
+> listener that the proxy alone reaches. A client that reaches it without a
+> proxy writes the address that every hook then reads.
 
 ### CHUNKING and BDAT
 

--- a/README.md
+++ b/README.md
@@ -303,8 +303,11 @@ family.
 A header of version 2 that the server cannot read ends the session without a
 reply, which the specification asks for. A version that is not 2, a command
 that is neither `LOCAL` nor `PROXY`, a transport protocol of datagrams, and an
-address block that is too short all end it. The `Disconnect` hooks read the
-cause as a `smtpd.ProxyError`:
+address block that is too short all end it. So does a header that stops in the
+middle, and `ProxyError.Err` carries the error of the read there.
+
+The `Disconnect` hooks read the cause as a `smtpd.ProxyError`, from the first
+octet of the header on:
 
 ```go
 smtpd.Middleware{

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Features
 * `SMTPUTF8` for addresses of Unicode
   ([RFC 6531](https://www.rfc-editor.org/rfc/rfc6531)), off by default
 * [XCLIENT](http://www.postfix.org/XCLIENT_README.html) and the
-  [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
+  [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt),
+  version 1 and version 2
 * `VRFY` ([RFC 5321](https://www.rfc-editor.org/rfc/rfc5321)), through a
   middleware hook
 * LMTP ([RFC 2033](https://www.rfc-editor.org/rfc/rfc2033)), with one reply
@@ -266,6 +267,60 @@ encoding still arrives whole.
 
 The values `[UNAVAILABLE]` and `[TEMPUNAVAIL]` say that the proxy has no
 information for that attribute, and leave it as it was.
+
+### PROXY protocol
+
+Set `Server.EnableProxyProtocol` to take the header that a proxy such as
+HAProxy writes ahead of the session. The address of the client goes on
+`Peer.Addr`, so the middleware that reads it sees the client and not the
+proxy.
+
+The server takes both versions of the
+[protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt).
+Version 1 is a line of text, and version 2 is binary. The first octet of the
+stream tells them apart, so a proxy of either version needs no setting of its
+own.
+
+```
+C: PROXY TCP4 42.42.42.42 5.6.7.8 4242 25
+S: 220 localhost.localdomain ESMTP ready.
+```
+
+A header of version 1 arrives as the `PROXY` command, so a line that does not
+read gets a `501` reply.
+
+A header of version 2 carries the address family. `Peer.Addr` holds a
+`*net.TCPAddr` for the IPv4 and the IPv6 families, and a `*net.UnixAddr` for a
+unix socket. The values that follow the addresses stay unread. They carry what
+the proxy knows about the connection, such as the name that the client asked
+for in a TLS handshake.
+
+Two headers of version 2 carry no address of a client, and the addresses of
+the connection stay on the peer: the `LOCAL` command, which a proxy writes for
+a connection of its own such as a health check, and the unspecified address
+family.
+
+A header of version 2 that the server cannot read ends the session without a
+reply, which the specification asks for. A version that is not 2, a command
+that is neither `LOCAL` nor `PROXY`, a transport protocol of datagrams, and an
+address block that is too short all end it. The `Disconnect` hooks read the
+cause as a `smtpd.ProxyError`:
+
+```go
+smtpd.Middleware{
+    Disconnect: func(ctx context.Context, peer smtpd.Peer, err error) {
+        var proxyErr smtpd.ProxyError
+        if errors.As(err, &proxyErr) {
+            log.Printf("%s sent a bad PROXY header: %s", peer.Addr, proxyErr.Reason)
+        }
+    },
+}
+```
+
+> [!NOTE]
+> The server holds the greeting back until the header arrives, so give it a
+> listener that the proxy alone reaches. A client that sends a header of its
+> own writes the address that every hook then reads.
 
 ### CHUNKING and BDAT
 

--- a/proxy.go
+++ b/proxy.go
@@ -1,9 +1,14 @@
 package smtpd
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
 	"net"
 	"strconv"
+	"time"
 )
 
 func (s *session) handlePROXY(ctx context.Context, cmd *command) context.Context {
@@ -58,4 +63,199 @@ func (s *session) handlePROXY(ctx context.Context, cmd *command) context.Context
 
 	return s.welcome(ctx)
 
+}
+
+// ProxyError reports a PROXY protocol header that the server refused. Reason
+// says what was wrong with it, such as a version that the server does not
+// take. The session ends without a reply, and the Disconnect hooks read the
+// error through their err argument.
+type ProxyError struct {
+	Reason string
+}
+
+func (e ProxyError) Error() string {
+	return fmt.Sprintf("smtpd: the PROXY header could not be read: %s", e.Reason)
+}
+
+// proxyV2Signature is the first 12 octets of a PROXY protocol v2 header. The
+// protocol takes these octets because no header of version 1 and no SMTP
+// command begins with them, so the first octet alone tells the two apart.
+var proxyV2Signature = []byte{0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A}
+
+// proxyV2HeaderLen is the length of the part of a v2 header that every one of
+// them carries: the signature, the version with the command, the address
+// family with the transport protocol, and the length of the rest.
+const proxyV2HeaderLen = 16
+
+// The commands of a v2 header. LOCAL comes from the proxy itself, such as for
+// a health check, and PROXY comes from a client behind it.
+const (
+	proxyV2Local = 0x0
+	proxyV2Proxy = 0x1
+)
+
+// The address families of a v2 header.
+const (
+	proxyAFUnspec = 0x0
+	proxyAFInet   = 0x1
+	proxyAFInet6  = 0x2
+	proxyAFUnix   = 0x3
+)
+
+// The transport protocols of a v2 header.
+const (
+	proxyTransportUnspec = 0x0
+	proxyTransportStream = 0x1
+	proxyTransportDgram  = 0x2
+)
+
+// The length of the address block of each family.
+const (
+	proxyAddrLenInet  = 12
+	proxyAddrLenInet6 = 36
+	proxyAddrLenUnix  = 216
+)
+
+// proxyUnixPathLen is the length of one path in the address block of the UNIX
+// family. The path ends at the first NUL octet, and the rest of the field is
+// NUL as well.
+const proxyUnixPathLen = 108
+
+// readProxyV2 reads a PROXY protocol v2 header and puts the address of the
+// client on the peer. found says that the header was there.
+//
+// A stream that begins with another octet stays where it is. A header of
+// version 1 is a line of text, and the command loop reads that one as the
+// PROXY command.
+//
+// A header takes no reply, because the sender of it is a proxy and not a
+// client. A header that the server cannot read therefore ends the session,
+// which the specification asks for: the address of the client is unknown from
+// that point, and a session that goes on carries the address of the proxy in
+// its place.
+func (s *session) readProxyV2() (found bool, err error) {
+	// The proxy writes the header before anything else, so it is there at the
+	// speed of the connection and not at the speed of a client.
+	_ = s.conn.SetReadDeadline(time.Now().Add(s.server.ReadTimeout))
+
+	first, err := s.reader.Peek(1)
+	if err != nil {
+		return false, err
+	}
+	if first[0] != proxyV2Signature[0] {
+		return false, nil
+	}
+
+	header := make([]byte, proxyV2HeaderLen)
+	if _, err := io.ReadFull(s.reader, header); err != nil {
+		return false, err
+	}
+
+	// The octets are gone from the stream at this point, and nothing else
+	// begins with them, so a signature that does not read ends the session.
+	if !bytes.Equal(header[:len(proxyV2Signature)], proxyV2Signature) {
+		return true, ProxyError{Reason: "the signature does not read"}
+	}
+
+	if version := header[12] >> 4; version != 2 {
+		return true, ProxyError{Reason: fmt.Sprintf("version %d is not version 2", version)}
+	}
+
+	// The length covers the addresses and the values that follow them. It is
+	// an unsigned 16-bit number, so the read below is bounded.
+	block := make([]byte, binary.BigEndian.Uint16(header[14:16]))
+	if _, err := io.ReadFull(s.reader, block); err != nil {
+		return true, err
+	}
+
+	switch command := header[12] & 0x0F; command {
+	case proxyV2Local:
+		// The proxy opened this connection for itself, and the addresses of
+		// the connection are the ones of the session.
+		return true, nil
+	case proxyV2Proxy:
+	default:
+		return true, ProxyError{Reason: fmt.Sprintf("command %d is neither LOCAL nor PROXY", command)}
+	}
+
+	addr, err := parseProxyV2Addr(header[13], block)
+	if err != nil {
+		return true, err
+	}
+
+	// A header of the unspecified family carries no address, and the ones of
+	// the connection stay.
+	if addr != nil {
+		s.peer.Addr = addr
+	}
+
+	return true, nil
+}
+
+// parseProxyV2Addr reads the address of the client out of the address block
+// of a v2 header. famProto is the octet that carries the address family and
+// the transport protocol.
+//
+// A block of the unspecified family or the unspecified protocol gives a nil
+// address, which leaves the addresses of the connection where they are.
+//
+// The values that a proxy writes after the addresses stay unread. They carry
+// what the proxy knows about the connection, such as the name that the client
+// asked for in a TLS handshake.
+func parseProxyV2Addr(famProto byte, block []byte) (net.Addr, error) {
+	family := famProto >> 4
+	transport := famProto & 0x0F
+
+	if family == proxyAFUnspec || transport == proxyTransportUnspec {
+		return nil, nil
+	}
+
+	// SMTP runs on a stream, so a header for datagrams describes another
+	// connection than the one that the server took.
+	if transport == proxyTransportDgram {
+		return nil, ProxyError{Reason: "the transport protocol is datagram, and SMTP takes a stream"}
+	}
+	if transport != proxyTransportStream {
+		return nil, ProxyError{Reason: fmt.Sprintf("transport protocol %d is not one of the protocols", transport)}
+	}
+
+	switch family {
+	case proxyAFInet:
+		if len(block) < proxyAddrLenInet {
+			return nil, ProxyError{Reason: fmt.Sprintf("an address block of %d octets is too short for IPv4", len(block))}
+		}
+		return &net.TCPAddr{
+			IP:   copyIP(block[0:4]),
+			Port: int(binary.BigEndian.Uint16(block[8:10])),
+		}, nil
+
+	case proxyAFInet6:
+		if len(block) < proxyAddrLenInet6 {
+			return nil, ProxyError{Reason: fmt.Sprintf("an address block of %d octets is too short for IPv6", len(block))}
+		}
+		return &net.TCPAddr{
+			IP:   copyIP(block[0:16]),
+			Port: int(binary.BigEndian.Uint16(block[32:34])),
+		}, nil
+
+	case proxyAFUnix:
+		if len(block) < proxyAddrLenUnix {
+			return nil, ProxyError{Reason: fmt.Sprintf("an address block of %d octets is too short for a unix socket", len(block))}
+		}
+		path := block[:proxyUnixPathLen]
+		if end := bytes.IndexByte(path, 0); end >= 0 {
+			path = path[:end]
+		}
+		return &net.UnixAddr{Name: string(path), Net: "unix"}, nil
+	}
+
+	return nil, ProxyError{Reason: fmt.Sprintf("address family %d is not one of the families", family)}
+}
+
+// copyIP takes the address out of the block, so that the address on the peer
+// holds no window into a buffer of the session.
+func copyIP(src []byte) net.IP {
+	ip := make(net.IP, len(src))
+	copy(ip, src)
+	return ip
 }

--- a/proxy.go
+++ b/proxy.go
@@ -225,13 +225,34 @@ func (s *session) readProxyV2() (found bool, err error) {
 // A block of the unspecified family or the unspecified protocol gives a nil
 // address, which leaves the addresses of the connection where they are.
 //
-// The values that a proxy writes after the addresses stay unread. They carry
-// what the proxy knows about the connection, such as the name that the client
-// asked for in a TLS handshake.
+// The values that a proxy writes after the addresses come off the stream with
+// the block, and nothing here looks at them. They carry what the proxy knows
+// about the connection, such as the name that the client asked for in a TLS
+// handshake.
 func parseProxyV2Addr(famProto byte, block []byte) (net.Addr, error) {
 	family := famProto >> 4
 	transport := famProto & 0x0F
 
+	// The specification gives four families and three protocols, and it asks
+	// the receiver to refuse every other value. This stands before the
+	// unspecified value below, because one half of the octet says nothing
+	// about the other half: 0xF0 carries a family that no version of the
+	// protocol has, next to a protocol that says nothing.
+	switch family {
+	case proxyAFUnspec, proxyAFInet, proxyAFInet6, proxyAFUnix:
+	default:
+		return nil, ProxyError{Reason: fmt.Sprintf("address family %d is not one of the four families", family)}
+	}
+
+	switch transport {
+	case proxyTransportUnspec, proxyTransportStream, proxyTransportDgram:
+	default:
+		return nil, ProxyError{Reason: fmt.Sprintf("transport protocol %d is not one of the three protocols", transport)}
+	}
+
+	// A family or a protocol that says nothing carries no address of a
+	// client. The specification asks the receiver to read no address out of
+	// such a block, so the addresses of the connection stay.
 	if family == proxyAFUnspec || transport == proxyTransportUnspec {
 		return nil, nil
 	}
@@ -240,9 +261,6 @@ func parseProxyV2Addr(famProto byte, block []byte) (net.Addr, error) {
 	// connection than the one that the server took.
 	if transport == proxyTransportDgram {
 		return nil, ProxyError{Reason: "the transport protocol is datagram, and SMTP takes a stream"}
-	}
-	if transport != proxyTransportStream {
-		return nil, ProxyError{Reason: fmt.Sprintf("transport protocol %d is not one of the protocols", transport)}
 	}
 
 	switch family {
@@ -275,7 +293,9 @@ func parseProxyV2Addr(famProto byte, block []byte) (net.Addr, error) {
 		return &net.UnixAddr{Name: string(path), Net: "unix"}, nil
 	}
 
-	return nil, ProxyError{Reason: fmt.Sprintf("address family %d is not one of the families", family)}
+	// The families above are the ones that the switch at the top lets
+	// through, so nothing reaches this line.
+	return nil, ProxyError{Reason: fmt.Sprintf("address family %d carries no address", family)}
 }
 
 // copyIP takes the address out of the block, so that the address on the peer

--- a/proxy.go
+++ b/proxy.go
@@ -69,13 +69,29 @@ func (s *session) handlePROXY(ctx context.Context, cmd *command) context.Context
 // says what was wrong with it, such as a version that the server does not
 // take. The session ends without a reply, and the Disconnect hooks read the
 // error through their err argument.
+//
+// Err holds the error that ended the read, where a read ended one: a header
+// that stopped in the middle carries io.ErrUnexpectedEOF there, and one that
+// stopped for the deadline of Server.ReadTimeout carries the error of the
+// connection. errors.Is reads through it.
+//
+// Every header that the server could not read gives this error, from the
+// first octet of the signature on. A caller therefore reads one type for a
+// header that is not whole and for a header that says something the server
+// does not take.
 type ProxyError struct {
 	Reason string
+	Err    error
 }
 
 func (e ProxyError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("smtpd: the PROXY header could not be read: %s: %v", e.Reason, e.Err)
+	}
 	return fmt.Sprintf("smtpd: the PROXY header could not be read: %s", e.Reason)
 }
+
+func (e ProxyError) Unwrap() error { return e.Err }
 
 // proxyV2Signature is the first 12 octets of a PROXY protocol v2 header. The
 // protocol takes these octets because no header of version 1 and no SMTP
@@ -146,9 +162,16 @@ func (s *session) readProxyV2() (found bool, err error) {
 		return false, nil
 	}
 
+	// The first octet belongs to a header of version 2 and to nothing else,
+	// so the session takes one from here on. A read that fails now is a
+	// header that the server could not read, and not a stream of another
+	// kind.
 	header := make([]byte, proxyV2HeaderLen)
-	if _, err := io.ReadFull(s.reader, header); err != nil {
-		return false, err
+	if n, err := io.ReadFull(s.reader, header); err != nil {
+		return true, ProxyError{
+			Reason: fmt.Sprintf("the header takes %d octets and gave %d", proxyV2HeaderLen, n),
+			Err:    err,
+		}
 	}
 
 	// The octets are gone from the stream at this point, and nothing else
@@ -164,8 +187,11 @@ func (s *session) readProxyV2() (found bool, err error) {
 	// The length covers the addresses and the values that follow them. It is
 	// an unsigned 16-bit number, so the read below is bounded.
 	block := make([]byte, binary.BigEndian.Uint16(header[14:16]))
-	if _, err := io.ReadFull(s.reader, block); err != nil {
-		return true, err
+	if n, err := io.ReadFull(s.reader, block); err != nil {
+		return true, ProxyError{
+			Reason: fmt.Sprintf("the header says %d octets follow it and gave %d", len(block), n),
+			Err:    err,
+		}
 	}
 
 	switch command := header[12] & 0x0F; command {

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -331,6 +331,18 @@ func TestPROXYV2Refused(t *testing.T) {
 			name:   "an address block that is too short",
 			header: proxyV2Header(0x1, 0x11, []byte{1, 2, 3, 4}),
 		},
+		{
+			// The protocol says nothing here, and the family carries a value
+			// that no version of the protocol has.
+			name:   "an address family that is not one of the four",
+			header: proxyV2Header(0x1, 0xF0, nil),
+		},
+		{
+			// The family says nothing here, and the protocol carries a value
+			// that no version of the protocol has.
+			name:   "a transport protocol that is not one of the three",
+			header: proxyV2Header(0x1, 0x0F, nil),
+		},
 	}
 
 	for _, tc := range tests {

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1,10 +1,14 @@
 package smtpd_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
+	"errors"
 	"net"
 	"net/textproto"
 	"testing"
+	"time"
 
 	"github.com/chrj/smtpd/v2"
 	"github.com/chrj/smtpd/v2/smtptest"
@@ -115,6 +119,257 @@ func TestPROXYOverridesPeerAddr(t *testing.T) {
 		t.Fatalf("peer.Addr after PROXY = %s, want 42.42.42.42:4242", cap.got)
 	}
 	_ = smtptest.Cmd(tp, 221, "QUIT")
+}
+
+// proxyV2Header builds a header of the PROXY protocol version 2. command is
+// the low half of the version octet, and famProto carries the address family
+// and the transport protocol.
+func proxyV2Header(command, famProto byte, block []byte) []byte {
+	header := []byte{0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A}
+	header = append(header, 0x20|command, famProto, 0, 0)
+	binary.BigEndian.PutUint16(header[14:16], uint16(len(block)))
+	return append(header, block...)
+}
+
+// proxyV2Addrs builds the address block of the IPv4 or the IPv6 family: the
+// two addresses first, and the two ports after them.
+func proxyV2Addrs(src, dst string, srcPort, dstPort uint16) []byte {
+	srcIP, dstIP := net.ParseIP(src), net.ParseIP(dst)
+	if v4 := srcIP.To4(); v4 != nil {
+		srcIP, dstIP = v4, dstIP.To4()
+	}
+
+	block := append(append([]byte{}, srcIP...), dstIP...)
+	block = binary.BigEndian.AppendUint16(block, srcPort)
+	return binary.BigEndian.AppendUint16(block, dstPort)
+}
+
+// proxyV2Unix builds the address block of the UNIX family: two paths of 108
+// octets each, with NUL after the path.
+func proxyV2Unix(src, dst string) []byte {
+	block := make([]byte, 216)
+	copy(block[:108], src)
+	copy(block[108:], dst)
+	return block
+}
+
+// proxyV2Dial opens a connection, writes a header of version 2, and reads the
+// greeting that follows it.
+func proxyV2Dial(t *testing.T, addr string, header []byte) (*textproto.Conn, net.Conn) {
+	t.Helper()
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	if _, err := conn.Write(header); err != nil {
+		t.Fatalf("the header could not be written: %v", err)
+	}
+
+	tp := textproto.NewConn(conn)
+	if _, _, err := tp.ReadResponse(220); err != nil {
+		t.Fatalf("the greeting after the header failed: %v", err)
+	}
+
+	return tp, conn
+}
+
+// proxyV2Sender opens a transaction, so that the CheckSender hook reads the
+// address of the peer.
+func proxyV2Sender(t *testing.T, tp *textproto.Conn) {
+	t.Helper()
+
+	if err := smtptest.Cmd(tp, 250, "HELO localhost"); err != nil {
+		t.Fatalf("HELO failed: %v", err)
+	}
+	if err := smtptest.Cmd(tp, 250, "MAIL FROM:<sender@example.org>"); err != nil {
+		t.Fatalf("MAIL failed: %v", err)
+	}
+}
+
+// TestPROXYV2OverridesPeerAddr covers the address that a header of version 2
+// puts on the peer.
+func TestPROXYV2OverridesPeerAddr(t *testing.T) {
+	t.Parallel()
+
+	// A value of the protocol that a proxy writes after the addresses. The
+	// server reads the addresses and leaves this one where it is.
+	tlv := []byte{0x02, 0x00, 0x02, 0x41, 0x42}
+
+	tests := []struct {
+		name   string
+		header []byte
+		want   string
+	}{
+		{
+			name:   "IPv4",
+			header: proxyV2Header(0x1, 0x11, proxyV2Addrs("42.42.42.42", "5.6.7.8", 4242, 25)),
+			want:   "42.42.42.42:4242",
+		},
+		{
+			name:   "IPv6",
+			header: proxyV2Header(0x1, 0x21, proxyV2Addrs("2001:db8::1", "2001:db8::2", 4242, 25)),
+			want:   "[2001:db8::1]:4242",
+		},
+		{
+			name:   "IPv4 with a value after the addresses",
+			header: proxyV2Header(0x1, 0x11, append(proxyV2Addrs("42.42.42.42", "5.6.7.8", 4242, 25), tlv...)),
+			want:   "42.42.42.42:4242",
+		},
+		{
+			name:   "a unix socket",
+			header: proxyV2Header(0x1, 0x31, proxyV2Unix("/var/run/haproxy.sock", "/var/run/smtpd.sock")),
+			want:   "/var/run/haproxy.sock",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			addr := &capturedAddr{}
+			srv := runserver(t, &smtpd.Server{
+				EnableProxyProtocol: true,
+				Logger:              testLogger(t),
+			}, capturePeerAddr(addr))
+
+			tp, _ := proxyV2Dial(t, srv.Addr, tc.header)
+			proxyV2Sender(t, tp)
+
+			if addr.got == nil {
+				t.Fatal("CheckSender never saw peer.Addr")
+			}
+			if addr.got.String() != tc.want {
+				t.Errorf("peer.Addr = %s, want %s", addr.got, tc.want)
+			}
+
+			_ = smtptest.Cmd(tp, 221, "QUIT")
+		})
+	}
+}
+
+// TestPROXYV2KeepsTheConnectionAddress covers the headers that carry no
+// address of a client: the addresses of the connection stay on the peer.
+func TestPROXYV2KeepsTheConnectionAddress(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		header []byte
+	}{
+		{
+			name: "a connection of the proxy itself",
+			// The LOCAL command comes with an address block that the server
+			// reads no address out of.
+			header: proxyV2Header(0x0, 0x11, proxyV2Addrs("42.42.42.42", "5.6.7.8", 4242, 25)),
+		},
+		{
+			name:   "an unspecified address family",
+			header: proxyV2Header(0x1, 0x00, nil),
+		},
+		{
+			name:   "an unspecified transport protocol",
+			header: proxyV2Header(0x1, 0x10, nil),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			addr := &capturedAddr{}
+			srv := runserver(t, &smtpd.Server{
+				EnableProxyProtocol: true,
+				Logger:              testLogger(t),
+			}, capturePeerAddr(addr))
+
+			tp, conn := proxyV2Dial(t, srv.Addr, tc.header)
+			proxyV2Sender(t, tp)
+
+			if addr.got == nil {
+				t.Fatal("CheckSender never saw peer.Addr")
+			}
+			if addr.got.String() != conn.LocalAddr().String() {
+				t.Errorf("peer.Addr = %s, want the address of the connection %s", addr.got, conn.LocalAddr())
+			}
+
+			_ = smtptest.Cmd(tp, 221, "QUIT")
+		})
+	}
+}
+
+// TestPROXYV2Refused covers a header that the server cannot read. The session
+// ends without a greeting, and the Disconnect hooks read a ProxyError.
+func TestPROXYV2Refused(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		header []byte
+	}{
+		{
+			name:   "a signature that does not read",
+			header: append([]byte{0x0D}, bytes.Repeat([]byte{0x2A}, 31)...),
+		},
+		{
+			name:   "a version that is not 2",
+			header: append(append([]byte{}, proxyV2Header(0x1, 0x11, nil)[:12]...), 0x11, 0x11, 0x00, 0x00),
+		},
+		{
+			name:   "a command that is neither LOCAL nor PROXY",
+			header: proxyV2Header(0xF, 0x11, proxyV2Addrs("42.42.42.42", "5.6.7.8", 4242, 25)),
+		},
+		{
+			name:   "a transport protocol of datagrams",
+			header: proxyV2Header(0x1, 0x12, proxyV2Addrs("42.42.42.42", "5.6.7.8", 4242, 25)),
+		},
+		{
+			name:   "an address block that is too short",
+			header: proxyV2Header(0x1, 0x11, []byte{1, 2, 3, 4}),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			record := &disconnectRecord{}
+			srv := runserver(t, &smtpd.Server{
+				EnableProxyProtocol: true,
+				Logger:              testLogger(t),
+			}, disconnectCounter(record))
+
+			conn, err := net.Dial("tcp", srv.Addr)
+			if err != nil {
+				t.Fatalf("Dial failed: %v", err)
+			}
+			defer func() { _ = conn.Close() }()
+
+			if _, err := conn.Write(tc.header); err != nil {
+				t.Fatalf("the header could not be written: %v", err)
+			}
+
+			_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+			if line, err := textproto.NewConn(conn).ReadLine(); err == nil {
+				t.Fatalf("the server answered %q, want a session that ends", line)
+			}
+
+			count, lastErr := waitDisconnect(record, 3*time.Second)
+			if count != 1 {
+				t.Fatalf("the Disconnect hook ran %d times, want 1", count)
+			}
+
+			var proxyErr smtpd.ProxyError
+			if !errors.As(lastErr, &proxyErr) {
+				t.Fatalf("the Disconnect hook read %v, want a ProxyError", lastErr)
+			}
+			if proxyErr.Reason == "" {
+				t.Error("the ProxyError carries no reason")
+			}
+		})
+	}
 }
 
 // TestPROXYOnlyAsTheFirstLine covers a PROXY command that comes after the

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"io"
 	"net"
 	"net/textproto"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/chrj/smtpd/v2"
@@ -412,6 +414,118 @@ func TestPROXYV1SplitHeader(t *testing.T) {
 	}
 
 	_ = smtptest.Cmd(tp, 221, "QUIT")
+}
+
+// TestPROXYV2Truncated covers a header of version 2 that stops in the middle.
+// The first octet says that a header of that version follows, so what comes
+// after it is a header that the server could not read, and the ProxyError
+// carries the error of the read.
+func TestPROXYV2Truncated(t *testing.T) {
+	t.Parallel()
+
+	// A whole header of the IPv4 family: 16 octets, and 12 after them.
+	whole := proxyV2Header(0x1, 0x11, proxyV2Addrs("42.42.42.42", "5.6.7.8", 4242, 25))
+
+	tests := []struct {
+		name   string
+		header []byte
+	}{
+		{
+			name:   "inside the first 16 octets",
+			header: whole[:8],
+		},
+		{
+			name:   "inside the address block",
+			header: whole[:20],
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			record := &disconnectRecord{}
+			srv := runserver(t, &smtpd.Server{
+				EnableProxyProtocol: true,
+				Logger:              testLogger(t),
+			}, disconnectCounter(record))
+
+			conn, err := net.Dial("tcp", srv.Addr)
+			if err != nil {
+				t.Fatalf("Dial failed: %v", err)
+			}
+			defer func() { _ = conn.Close() }()
+
+			if _, err := conn.Write(tc.header); err != nil {
+				t.Fatalf("the header could not be written: %v", err)
+			}
+
+			// The end of the stream is what tells the server that no more of
+			// the header follows.
+			if err := conn.(*net.TCPConn).CloseWrite(); err != nil {
+				t.Fatalf("the write side could not be closed: %v", err)
+			}
+
+			count, lastErr := waitDisconnect(record, 3*time.Second)
+			if count != 1 {
+				t.Fatalf("the Disconnect hook ran %d times, want 1", count)
+			}
+
+			var proxyErr smtpd.ProxyError
+			if !errors.As(lastErr, &proxyErr) {
+				t.Fatalf("the Disconnect hook read %v, want a ProxyError", lastErr)
+			}
+			if !errors.Is(lastErr, io.ErrUnexpectedEOF) {
+				t.Errorf("the ProxyError carries %v, want the error of the read", proxyErr.Err)
+			}
+		})
+	}
+}
+
+// TestPROXYIdleConnectionTimesOut covers a connection that sends no header at
+// all. The server holds the greeting back until one arrives, and the read of
+// it takes ReadTimeout, so the session ends and gives its slot in
+// MaxConnections back.
+func TestPROXYIdleConnectionTimesOut(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		l := runpipeserver(t, &smtpd.Server{
+			EnableProxyProtocol: true,
+			MaxConnections:      1,
+			ReadTimeout:         time.Second,
+			WriteTimeout:        time.Second,
+			Logger:              testLogger(t),
+		})
+		defer func() { _ = l.Close() }()
+
+		idle := l.dial(t)
+
+		// The connection sends nothing, so the read of the header runs into
+		// the deadline.
+		time.Sleep(2 * time.Second)
+		synctest.Wait()
+
+		if _, err := idle.Read(make([]byte, 1)); err == nil {
+			t.Fatal("the idle connection is open, want a session that ended")
+		}
+
+		// The session gave its slot back, so the connection that follows
+		// takes one and runs. The header is of version 2, because a header of
+		// version 1 needs an address of TCP and this listener has none.
+		conn := l.dial(t)
+		header := proxyV2Header(0x1, 0x11, proxyV2Addrs("42.42.42.42", "5.6.7.8", 4242, 25))
+		if _, err := conn.Write(header); err != nil {
+			t.Fatalf("the header could not be written: %v", err)
+		}
+
+		tp := textproto.NewConn(conn)
+		if _, _, err := tp.ReadResponse(220); err != nil {
+			t.Fatalf("the greeting after the header failed: %v", err)
+		}
+
+		_ = smtptest.Cmd(tp, 221, "QUIT")
+	})
 }
 
 // TestPROXYOnlyAsTheFirstLine covers a PROXY command that comes after the

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -372,6 +372,48 @@ func TestPROXYV2Refused(t *testing.T) {
 	}
 }
 
+// TestPROXYV1SplitHeader covers a header of version 1 that arrives in pieces.
+// The server reads the first octet of the stream to tell the two versions
+// apart, and that read must take no more of the header than the one octet.
+func TestPROXYV1SplitHeader(t *testing.T) {
+	t.Parallel()
+
+	addr := &capturedAddr{}
+	srv := runserver(t, &smtpd.Server{
+		EnableProxyProtocol: true,
+		Logger:              testLogger(t),
+	}, capturePeerAddr(addr))
+
+	conn, err := net.Dial("tcp", srv.Addr)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	for _, part := range []string{"P", "ROXY TCP4 42.42.42.42 5.6", ".7.8 4242 25\r\n"} {
+		if _, err := conn.Write([]byte(part)); err != nil {
+			t.Fatalf("the header could not be written: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	tp := textproto.NewConn(conn)
+	if _, _, err := tp.ReadResponse(220); err != nil {
+		t.Fatalf("the greeting after the header failed: %v", err)
+	}
+
+	proxyV2Sender(t, tp)
+
+	if addr.got == nil {
+		t.Fatal("CheckSender never saw peer.Addr")
+	}
+	if addr.got.String() != "42.42.42.42:4242" {
+		t.Errorf("peer.Addr = %s, want 42.42.42.42:4242", addr.got)
+	}
+
+	_ = smtptest.Cmd(tp, 221, "QUIT")
+}
+
 // TestPROXYOnlyAsTheFirstLine covers a PROXY command that comes after the
 // header of the proxy. The proxy writes its header before it passes on
 // anything of the client, so a second one comes from the client behind it,

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -601,3 +601,34 @@ func TestPROXYOnlyAsTheFirstLine(t *testing.T) {
 		})
 	}
 }
+
+// TestPROXYV2ClosesTheFirstLine covers a PROXY command that follows a header
+// of version 2. The header is the first line of the session, so the command
+// after it comes from the client behind the proxy.
+func TestPROXYV2ClosesTheFirstLine(t *testing.T) {
+	t.Parallel()
+
+	addr := &capturedAddr{}
+	srv := runserver(t, &smtpd.Server{
+		EnableProxyProtocol: true,
+		Logger:              testLogger(t),
+	}, capturePeerAddr(addr))
+
+	header := proxyV2Header(0x1, 0x11, proxyV2Addrs("42.42.42.42", "5.6.7.8", 4242, 25))
+	tp, _ := proxyV2Dial(t, srv.Addr, header)
+
+	if err := smtptest.Cmd(tp, 503, "PROXY TCP4 9.9.9.9 5.6.7.8 9999 25"); err != nil {
+		t.Fatalf("the PROXY command after the header didn't 503: %v", err)
+	}
+
+	proxyV2Sender(t, tp)
+
+	if addr.got == nil {
+		t.Fatal("CheckSender never saw peer.Addr")
+	}
+	if addr.got.String() != "42.42.42.42:4242" {
+		t.Errorf("peer.Addr = %s, want the address of the header 42.42.42.42:4242", addr.got)
+	}
+
+	_ = smtptest.Cmd(tp, 221, "QUIT")
+}

--- a/session.go
+++ b/session.go
@@ -191,7 +191,28 @@ func (s *session) serve(ctx context.Context) {
 
 	logger := LoggerFromContext(ctx)
 
-	if !s.server.EnableProxyProtocol {
+	if s.server.EnableProxyProtocol {
+		// A header of version 2 is binary and carries no line break, so it
+		// comes off the stream here. A header of version 1 is a line, and the
+		// loop below reads it as the PROXY command.
+		found, err := s.readProxyV2()
+		if err != nil {
+			var proxyErr ProxyError
+			if errors.As(err, &proxyErr) {
+				logger.ErrorContext(ctx, "refused a PROXY header",
+					slog.String("reason", proxyErr.Reason),
+				)
+			}
+
+			// The deferred close reports the cause to the Disconnect hooks.
+			s.setErr(err)
+			return
+		}
+
+		if found {
+			ctx = s.welcome(ctx)
+		}
+	} else {
 		ctx = s.welcome(ctx)
 	}
 

--- a/session.go
+++ b/session.go
@@ -210,6 +210,9 @@ func (s *session) serve(ctx context.Context) {
 		}
 
 		if found {
+			// The header takes the place of a PROXY command, so no command
+			// that follows it is one. See handlePROXY.
+			s.ranCommand = true
 			ctx = s.welcome(ctx)
 		}
 	} else {

--- a/smtpd.go
+++ b/smtpd.go
@@ -236,7 +236,22 @@ type Server struct {
 	MaxRecipients  int // default 100
 
 	// Extensions
-	EnableXCLIENT       bool
+	EnableXCLIENT bool
+
+	// EnableProxyProtocol takes the header of the PROXY protocol of HAProxy
+	// ahead of the SMTP session, and puts the address of the client on
+	// Peer.Addr. The server takes version 1, which is a line of text, and
+	// version 2, which is binary.
+	//
+	// A server with this field holds the greeting back until the header
+	// arrives, so give it a listener that the proxy alone reaches. A client
+	// that reaches it without a proxy gets no greeting, and a client that
+	// sends a header of its own writes the address that the hooks read.
+	//
+	// A header of version 2 that the server cannot read ends the session
+	// without a reply, and the Disconnect hooks get a ProxyError. A header
+	// for a connection of the proxy itself, such as a health check, leaves
+	// the addresses of the connection where they are.
 	EnableProxyProtocol bool
 
 	// EnableDSN offers the DSN extension of RFC 3461 and takes its


### PR DESCRIPTION
`Server.EnableProxyProtocol` takes a header of version 2 of the
[PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt),
next to the version 1 that it took before. Version 2 is binary, and version 1
is a line of text. The first octet of the stream tells the two apart, so a
proxy of either version needs no setting of its own.

## What the header gives

The address of the client goes on `Peer.Addr`, so the middleware that reads
it, such as the RBL check and the rate limit, sees the client and not the
proxy.

| The header carries | `Peer.Addr` holds |
| --- | --- |
| the IPv4 or the IPv6 family | a `*net.TCPAddr` with the address and the port of the client |
| a unix socket | a `*net.UnixAddr` with the path |
| the `LOCAL` command | the address of the connection, as before the header |
| the unspecified family or protocol | the address of the connection, as before the header |

A proxy writes the `LOCAL` command for a connection of its own, such as a
health check. The values that follow the addresses stay unread. They carry
what the proxy knows about the connection, such as the name that the client
asked for in a TLS handshake.

## What ends the session

A header takes no reply, because the sender of it is a proxy and not a client.
A header that the server cannot read therefore ends the session without one,
which the specification asks for: the address of the client is unknown from
that point, and a session that goes on carries the address of the proxy in its
place.

A version that is not 2, a command that is neither `LOCAL` nor `PROXY`, a
transport protocol of datagrams, and an address block that is too short all
end it. The `Disconnect` hooks read the cause as a `smtpd.ProxyError`, which
carries the reason.

## The first line of the session

The header is the first line of the session, in both versions. A `PROXY`
command after a header of version 2 gets the same `503` as one after a header
of version 1, so a client behind the proxy writes no address of its own.

## Notes for the review

- The header comes off the stream in `serve`, before the command loop, because
  it carries no line break. A header of version 1 still arrives as the `PROXY`
  command, so nothing changes for it.
- The read of the header takes `Server.ReadTimeout`. The greeting waits for
  the header, and no deadline stood on that read before, so a connection that
  sent nothing held a goroutine of the server for as long as it stayed open.
- The tests build the headers themselves and drive a raw connection. They
  cover the four address families, the values after the addresses, the
  `LOCAL` command, the seven headers that end the session, a header of version
  1 that arrives in pieces, and a connection that sends no header at all.
- A header that the server cannot read gives a `ProxyError` from the first
  octet of it on, and `ProxyError.Err` carries the error of the read.
- This one sits on #64, which takes the `PROXY` command as the first line of a
  session, and which is merged now.
