### PR TITLE
fix: take the PROXY command as the first line of a session only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- The `PROXY` command is the first line of a session, and a later one gets a
+  `503` reply. A proxy writes its header before it passes on anything of the
+  client, so a `PROXY` command after that one comes from the client behind the
+  proxy.
+
+  The server took every `PROXY` command before, and each one wrote `Peer.Addr`
+  and ran the `CheckConnection` hooks again. A client behind the proxy could
+  therefore take the address of another one, and the greylist, the RBL check
+  and the rate limit all read that address.
+
+  **This changes behavior.** A client that sends `PROXY` twice gets a `503`
+  for the second one, where it got a greeting before.
+
 ### Fixed
 
 - The readers of an SMTP keyword take the letters of US-ASCII, where they took

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- The `PROXY` command is the first line of a session, and a later one gets a
-  `503` reply. A proxy writes its header before it passes on anything of the
-  client, so a `PROXY` command after that one comes from the client behind the
-  proxy.
+- The `PROXY` command comes first in a session, before every other command,
+  and a later one gets a `503` reply. A proxy writes its header before it
+  passes on anything of the client, so a `PROXY` command that comes after a
+  command comes from the client behind the proxy.
 
   The server took every `PROXY` command before, and each one wrote `Peer.Addr`
   and ran the `CheckConnection` hooks again. A client behind the proxy could

--- a/protocol.go
+++ b/protocol.go
@@ -23,6 +23,10 @@ func (s *session) handle(ctx context.Context, line string) context.Context {
 		}
 	}
 
+	// The PROXY header of the proxy stands first in the session, so every
+	// command closes the window for it. See handlePROXY.
+	defer func() { s.ranCommand = true }()
+
 	cmd, err := parseCommand(line)
 	if err != nil {
 		return s.replyEnhanced(ctx, 500, EnhancedCode{5, 5, 2}, "Invalid syntax.")

--- a/proxy.go
+++ b/proxy.go
@@ -14,11 +14,15 @@ func (s *session) handlePROXY(ctx context.Context, cmd *command) context.Context
 	}
 
 	// The proxy writes its header before it passes on anything of the client,
-	// so a second one comes from the client. A client that writes its own
-	// address takes the identity of another one: the greylist, the RBL check
-	// and the rate limit all read Peer.Addr.
+	// so a header that comes after a command comes from the client. A client
+	// that writes its own address takes the identity of another one: the
+	// greylist, the RBL check and the rate limit all read Peer.Addr.
+	//
+	// The message names the rule and not the command that closed the line,
+	// because every command closes it: a session that ran one takes no header
+	// at all from that point.
 	if s.ranCommand {
-		return s.replyEnhanced(ctx, 503, EnhancedCode{5, 5, 1}, "PROXY is the first line of a session, and this session has one already")
+		return s.replyEnhanced(ctx, 503, EnhancedCode{5, 5, 1}, "PROXY comes first in a session, before every other command")
 	}
 
 	if len(fields) < 5 {

--- a/proxy.go
+++ b/proxy.go
@@ -13,6 +13,14 @@ func (s *session) handlePROXY(ctx context.Context, cmd *command) context.Context
 		return s.replyEnhanced(ctx, 550, EnhancedCode{5, 7, 0}, "Proxy Protocol not enabled")
 	}
 
+	// The proxy writes its header before it passes on anything of the client,
+	// so a second one comes from the client. A client that writes its own
+	// address takes the identity of another one: the greylist, the RBL check
+	// and the rate limit all read Peer.Addr.
+	if s.ranCommand {
+		return s.replyEnhanced(ctx, 503, EnhancedCode{5, 5, 1}, "PROXY is the first line of a session, and this session has one already")
+	}
+
 	if len(fields) < 5 {
 		return s.replyEnhanced(ctx, 501, EnhancedCode{5, 5, 4}, "Couldn't decode the command.")
 	}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -116,3 +116,77 @@ func TestPROXYOverridesPeerAddr(t *testing.T) {
 	}
 	_ = smtptest.Cmd(tp, 221, "QUIT")
 }
+
+// TestPROXYOnlyAsTheFirstLine covers a PROXY command that comes after the
+// header of the proxy. The proxy writes its header before it passes on
+// anything of the client, so a second one comes from the client behind it,
+// and the address of that client stays where it is.
+func TestPROXYOnlyAsTheFirstLine(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// between are the commands that the client sends after the header of
+		// the proxy and before the PROXY command of its own.
+		between []string
+	}{
+		{
+			name: "right after the header",
+		},
+		{
+			name:    "after a greeting",
+			between: []string{"HELO localhost"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			addr := &capturedAddr{}
+			srv := runserver(t, &smtpd.Server{
+				EnableProxyProtocol: true,
+				Logger:              testLogger(t),
+			}, capturePeerAddr(addr))
+
+			conn, err := net.Dial("tcp", srv.Addr)
+			if err != nil {
+				t.Fatalf("Dial failed: %v", err)
+			}
+			defer func() { _ = conn.Close() }()
+
+			tp := textproto.NewConn(conn)
+			if err := smtptest.Cmd(tp, 220, "PROXY TCP4 42.42.42.42 5.6.7.8 4242 25"); err != nil {
+				t.Fatalf("the header of the proxy failed: %v", err)
+			}
+
+			for _, command := range tc.between {
+				if err := smtptest.Cmd(tp, 250, "%s", command); err != nil {
+					t.Fatalf("%s failed: %v", command, err)
+				}
+			}
+
+			if err := smtptest.Cmd(tp, 503, "PROXY TCP4 9.9.9.9 5.6.7.8 9999 25"); err != nil {
+				t.Fatalf("the second PROXY didn't 503: %v", err)
+			}
+
+			// The session goes on with the address of the header, and the
+			// hooks read that one.
+			if err := smtptest.Cmd(tp, 250, "HELO localhost"); err != nil {
+				t.Fatalf("HELO failed: %v", err)
+			}
+			if err := smtptest.Cmd(tp, 250, "MAIL FROM:<sender@example.org>"); err != nil {
+				t.Fatalf("MAIL failed: %v", err)
+			}
+
+			if addr.got == nil {
+				t.Fatal("CheckSender never saw peer.Addr")
+			}
+			if addr.got.String() != "42.42.42.42:4242" {
+				t.Errorf("peer.Addr = %s, want the address of the header 42.42.42.42:4242", addr.got)
+			}
+
+			_ = smtptest.Cmd(tp, 221, "QUIT")
+		})
+	}
+}

--- a/session.go
+++ b/session.go
@@ -32,6 +32,13 @@ type session struct {
 	tls    bool
 	closed bool
 
+	// ranCommand says that the session ran a command already. A PROXY header
+	// stands before everything else: the proxy writes it, and only then does
+	// it pass on what the client sends. A PROXY command that comes later
+	// therefore comes from the client behind the proxy, and it would write
+	// the address that every hook after it reads.
+	ranCommand bool
+
 	// readErr holds the error that ended the reading of the connection. A
 	// read that failed once fails from then on, in the way that a
 	// bufio.Scanner stops for good. Without that, an AUTH command whose


### PR DESCRIPTION
A proxy writes its `PROXY` header before it passes on anything of the client,
so a `PROXY` command that comes later comes from the client behind the proxy.

The server took every one of them. Each wrote `Peer.Addr` and ran the
`CheckConnection` hooks again, so a client behind the proxy could take the
address of another one:

```
Proxy:  PROXY TCP4 42.42.42.42 5.6.7.8 4242 25
Server: 220 localhost.localdomain ESMTP ready.
Client: PROXY TCP4 9.9.9.9 5.6.7.8 9999 25
Server: 220 localhost.localdomain ESMTP ready.     <- Peer.Addr is 9.9.9.9 now
```

The greylist, the RBL check and the rate limit all read `Peer.Addr`, so the
client wrote its way past each of them.

The second command now gets `503`, and the address of the header stays:

```
Client: PROXY TCP4 9.9.9.9 5.6.7.8 9999 25
Server: 503 5.5.1 PROXY comes first in a session, before every other command
```

**This changes behavior.** A client that sends `PROXY` twice gets a `503` for
the second one, where it got a greeting before.

## Notes for the review

- The session carries `ranCommand`, which every command sets. `handlePROXY`
  refuses a command with it set, so the header keeps its place at the front of
  the session.
- The tests send the second `PROXY` right after the header and after a
  greeting, and read `Peer.Addr` in a `CheckSender` hook afterwards.
- This one goes first, and #63 sits behind it: a header of version 2 has to
  close the same window.
