### PR TITLE
fix: take the PROXY command as the first line of a session only

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,9 @@ name: smtpd
 
 on:
   push:
-    branches: [ master ]
+    branches: [ v1 ]
   pull_request:
-    branches: [ master ]
+    branches: [ v1 ]
 
 jobs:
   lint:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Features
 
 * STARTTLS (using `crypto/tls`)
 * Authentication (PLAIN/LOGIN, only after STARTTLS)
-* [XCLIENT](http://www.postfix.org/XCLIENT_README.html) and [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) (for running behind a proxy)
+* [XCLIENT](http://www.postfix.org/XCLIENT_README.html) and [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) (for running behind a proxy). The `PROXY` command comes first in a session, and a later one gets a `503` reply.
 * Connection, HELO, sender and recipient checks for rejecting e-mails using callbacks
 * Configurable limits for: connection count, message size and recipient count
 * Hands incoming e-mail off to a configured callback function

--- a/protocol.go
+++ b/protocol.go
@@ -61,6 +61,10 @@ func parseLine(line string) (cmd command) {
 
 func (session *session) handle(line string) {
 
+	// The PROXY header of a proxy stands first in the session, so every
+	// command closes the window for it. See handlePROXY.
+	defer func() { session.ranCommand = true }()
+
 	cmd := parseLine(line)
 
 	// Commands are dispatched to the appropriate handler functions.
@@ -614,6 +618,15 @@ func (session *session) handlePROXY(cmd command) {
 
 	if !session.server.EnableProxyProtocol {
 		session.reply(550, "Proxy Protocol not enabled")
+		return
+	}
+
+	// The proxy writes its header before it passes on anything of the client,
+	// so a header that comes after a command comes from the client. A client
+	// that writes its own address takes the identity of another one, and the
+	// ConnectionChecker and the checkers after it all read Peer.Addr.
+	if session.ranCommand {
+		session.reply(503, "PROXY comes first in a session, before every other command")
 		return
 	}
 

--- a/smtpd.go
+++ b/smtpd.go
@@ -112,6 +112,13 @@ type session struct {
 	scanner *bufio.Scanner
 
 	tls bool
+
+	// ranCommand says that the session ran a command already. The PROXY
+	// header of a proxy stands before everything else: the proxy writes it,
+	// and only then does it pass on what the client sends. A PROXY command
+	// that comes later therefore comes from the client behind the proxy, and
+	// it would write the address that every checker after it reads.
+	ranCommand bool
 }
 
 func (srv *Server) newSession(c net.Conn) (s *session) {

--- a/smtpd_test.go
+++ b/smtpd_test.go
@@ -1608,3 +1608,59 @@ func TestWaitFailsIfNotShutdown(t *testing.T) {
 		t.Fatalf("Wait() did not fail as expected")
 	}
 }
+
+// TestPROXYOnlyAsTheFirstLine covers a PROXY command that comes after the
+// header of the proxy. The proxy writes its header before it passes on
+// anything of the client, so a second one comes from the client behind it,
+// and the address of that client stays where it is.
+func TestPROXYOnlyAsTheFirstLine(t *testing.T) {
+
+	var seen net.Addr
+
+	addr, closer := runserver(t, &smtpd.Server{
+		EnableProxyProtocol: true,
+		SenderChecker: func(peer smtpd.Peer, _ string) error {
+			seen = peer.Addr
+			return nil
+		},
+	})
+
+	defer closer()
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+
+	defer func() { _ = conn.Close() }()
+
+	// The server holds the greeting back until the header arrives, so the
+	// session runs on a raw connection and not on an smtp.Client.
+	text := textproto.NewConn(conn)
+
+	if err := cmd(text, 220, "PROXY TCP4 42.42.42.42 5.6.7.8 4242 25"); err != nil {
+		t.Fatalf("The header of the proxy failed: %v", err)
+	}
+
+	if err := cmd(text, 250, "HELO localhost"); err != nil {
+		t.Fatalf("HELO failed: %v", err)
+	}
+
+	if err := cmd(text, 503, "PROXY TCP4 9.9.9.9 5.6.7.8 9999 25"); err != nil {
+		t.Fatalf("The second PROXY didn't 503: %v", err)
+	}
+
+	if err := cmd(text, 250, "MAIL FROM:<sender@example.org>"); err != nil {
+		t.Fatalf("MAIL failed: %v", err)
+	}
+
+	if seen == nil {
+		t.Fatal("The SenderChecker never saw Peer.Addr")
+	}
+
+	if seen.String() != "42.42.42.42:4242" {
+		t.Fatalf("Peer.Addr is %v, want the address of the header 42.42.42.42:4242", seen)
+	}
+
+	_ = cmd(text, 221, "QUIT")
+}


### PR DESCRIPTION
The backport of #64 to `v1`. The branch carries the same flaw.

A proxy writes its `PROXY` header before it passes on anything of the client,
so a `PROXY` command that comes later comes from the client behind the proxy.
`handlePROXY` took every one of them: each wrote `Peer.Addr` and ran the
`ConnectionChecker` again.

```
Proxy:  PROXY TCP4 42.42.42.42 5.6.7.8 4242 25
Server: 220 localhost ESMTP ready.
Client: PROXY TCP4 9.9.9.9 5.6.7.8 9999 25
Server: 220 localhost ESMTP ready.     <- Peer.Addr is 9.9.9.9 now
```

Every checker of the session reads `Peer.Addr`, so the client wrote its way
past each of them.

The second command now gets `503`, and the address of the header stays:

```
Client: PROXY TCP4 9.9.9.9 5.6.7.8 9999 25
Server: 503 PROXY comes first in a session, before every other command
```

**This changes behavior.** A client that sends `PROXY` twice gets a `503` for
the second one, where it got a greeting before.

## Notes for the review

- The session carries `ranCommand`, which every command sets, and
  `handlePROXY` refuses a command with it set. The v2 fix does the same.
- `TestPROXYOnlyAsTheFirstLine` is the first test of the `PROXY` command on
  this branch. It drives a raw connection, because the server holds the
  greeting back until the header arrives.
