### PR TITLE
chore: release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-08-22
+
 ### Security
 
 - The `PROXY` command comes first in a session, before every other command,
@@ -472,7 +474,8 @@ walkthrough.
 - `Peer.Password` — the password is still passed to the `Authenticate` hook but
   is no longer stored on `Peer`.
 
-[Unreleased]: https://github.com/chrj/smtpd/compare/v2.3.1...main
+[Unreleased]: https://github.com/chrj/smtpd/compare/v2.4.0...main
+[2.4.0]: https://github.com/chrj/smtpd/releases/tag/v2.4.0
 [2.3.1]: https://github.com/chrj/smtpd/releases/tag/v2.3.1
 [2.3.0]: https://github.com/chrj/smtpd/releases/tag/v2.3.0
 [2.2.0]: https://github.com/chrj/smtpd/releases/tag/v2.2.0

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Versions
 
 | Version | Status | Branch | Tag | Docs |
 |---------|--------|--------|-----|------|
-| v1 | stable | [`v1`](https://github.com/chrj/smtpd/tree/v1) | [`v1.0.0`](https://github.com/chrj/smtpd/releases/tag/v1.0.0) | [godoc](https://pkg.go.dev/github.com/chrj/smtpd) |
+| v1 | stable | [`v1`](https://github.com/chrj/smtpd/tree/v1) | [`v1.0.1`](https://github.com/chrj/smtpd/releases/tag/v1.0.1) | [godoc](https://pkg.go.dev/github.com/chrj/smtpd) |
 | v2 | stable | [`main`](https://github.com/chrj/smtpd/tree/main) | [`v2.4.0`](https://github.com/chrj/smtpd/releases/tag/v2.4.0) | [godoc](https://pkg.go.dev/github.com/chrj/smtpd/v2) |
 
 v1 is the original battle-tested API.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Versions
 | Version | Status | Branch | Tag | Docs |
 |---------|--------|--------|-----|------|
 | v1 | stable | [`v1`](https://github.com/chrj/smtpd/tree/v1) | [`v1.0.0`](https://github.com/chrj/smtpd/releases/tag/v1.0.0) | [godoc](https://pkg.go.dev/github.com/chrj/smtpd) |
-| v2 | stable | [`main`](https://github.com/chrj/smtpd/tree/main) | [`v2.3.0`](https://github.com/chrj/smtpd/releases/tag/v2.3.0) | [godoc](https://pkg.go.dev/github.com/chrj/smtpd/v2) |
+| v2 | stable | [`main`](https://github.com/chrj/smtpd/tree/main) | [`v2.4.0`](https://github.com/chrj/smtpd/releases/tag/v2.4.0) | [godoc](https://pkg.go.dev/github.com/chrj/smtpd/v2) |
 
 v1 is the original battle-tested API.
 


### PR DESCRIPTION
The release of v2.4.0. The changelog moves its Unreleased section under a
2.4.0 heading with the date, and the table of versions in the README names the
new tag. It named 2.3.0 before, so it missed the 2.3.1 release.

The version is a minor one: the release adds fields and types, and it takes
none away.

## What the release carries

**Security**

- The `PROXY` command comes first in a session, and a later one gets a `503`
  reply (#64). A client behind the proxy could take the address of another
  one before, and the greylist, the RBL check and the rate limit all read
  `Peer.Addr`.

**Added**

- `Server.LMTP` serves the Local Mail Transfer Protocol of RFC 2033, with one
  reply for every recipient of a message (#62).
- `Server.EnableProxyProtocol` takes a header of version 2 of the PROXY
  protocol (#63).
- The `VRFY` command of RFC 5321, through a `Verify` hook.
- `Server.EnableSMTPUTF8` for the addresses of Unicode of RFC 6531.
- `CHUNKING` with `BDAT`, and `BINARYMIME`, of RFC 3030.
- `Server.EnableDSN` for the parameters of RFC 3461.
- `ENHANCEDSTATUSCODES` of RFC 2034, and `EnhancedCode` with it.

**Fixed**

- An SMTP keyword reads as US-ASCII, where `strings.EqualFold` read two runes
  of Unicode as letters of it.
- A control character in the message of a reply becomes a space, so a
  middleware cannot end a reply early with what a client sent it.
- The read of a PROXY protocol header takes `Server.ReadTimeout`.

The changelog carries the whole list, with the `Changed` section as well.
