### PR TITLE
fix: end a race between Shutdown and the STARTTLS upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `Server.Shutdown` closes the connection that the listener gave, and not the
+  one that the session holds. `STARTTLS` puts a TLS connection in the place of
+  that one, on the goroutine of the session. `Shutdown` read the same field
+  from the goroutine of its caller, and nothing ordered the two.
+
+  The TLS connection reads and writes through the connection of the listener,
+  so a close of that connection ends an upgraded session as well.
+
 ## [2.4.0] - 2026-08-22
 
 ### Security

--- a/session.go
+++ b/session.go
@@ -22,6 +22,15 @@ type session struct {
 
 	conn net.Conn
 
+	// rawConn is the connection as it came from the listener. STARTTLS puts a
+	// TLS connection in the place of conn, and this field keeps the one that
+	// holds the socket, which closes the session either way.
+	//
+	// Shutdown reads it from the goroutine of its caller, so it is set before
+	// the session is tracked and never written again. Reading conn there
+	// would race with the STARTTLS upgrade.
+	rawConn net.Conn
+
 	reader *bufio.Reader
 	writer *bufio.Writer
 
@@ -63,10 +72,11 @@ func (s *session) setErr(err error) {
 func (srv *Server) newSession(ctx context.Context, c net.Conn) (context.Context, *session) {
 
 	s := &session{
-		server: srv,
-		conn:   c,
-		reader: bufio.NewReader(c),
-		writer: bufio.NewWriter(c),
+		server:  srv,
+		conn:    c,
+		rawConn: c,
+		reader:  bufio.NewReader(c),
+		writer:  bufio.NewWriter(c),
 		peer: Peer{
 			Addr:       c.RemoteAddr(),
 			ServerName: srv.Hostname,

--- a/smtpd.go
+++ b/smtpd.go
@@ -716,10 +716,12 @@ func (srv *Server) Shutdown(ctx context.Context) error {
 		return lnerr
 	case <-ctx.Done():
 		// Deadline hit - force-close remaining conns so blocked network
-		// I/O returns and sessions exit.
+		// I/O returns and sessions exit. Closing the connection of the
+		// listener ends a session that upgraded to TLS as well, because the
+		// TLS connection reads and writes through this one.
 		srv.mu.Lock()
 		for s := range srv.active {
-			_ = s.conn.Close()
+			_ = s.rawConn.Close()
 		}
 		srv.mu.Unlock()
 		<-done

--- a/starttls_test.go
+++ b/starttls_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -253,5 +254,123 @@ func TestSTARTTLSDiscardsPipelinedPlaintext(t *testing.T) {
 	}
 	if len(senders) != 1 || senders[0] != "legit@example.org" {
 		t.Fatalf("senders = %v, want [legit@example.org]", senders)
+	}
+}
+
+// TestShutdownClosesAnUpgradedSession verifies that Shutdown reaches a session
+// that ran STARTTLS. The upgrade puts a TLS connection in the place of the one
+// that the session started with, and Shutdown closes the connection of every
+// session that is still there at its deadline.
+func TestShutdownClosesAnUpgradedSession(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, &smtpd.Server{Logger: testLogger(t)}, nil)
+	ts.StartSTARTTLS()
+
+	c := dialRaw(t, ts.Addr)
+	c.send("EHLO before-tls.example")
+	c.startTLS()
+	if reply := c.send("EHLO after-tls.example"); !strings.HasPrefix(reply, "250") {
+		t.Fatalf("EHLO after TLS = %q, want 250", reply)
+	}
+
+	// The client holds the session open, so Shutdown runs to its deadline and
+	// closes the connection there.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	if err := ts.Config.Shutdown(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Shutdown() = %v, want %v", err, context.DeadlineExceeded)
+	}
+
+	// The connection is gone, so the read of the client ends instead of
+	// waiting for the deadline below.
+	_ = c.conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	if _, err := c.br.ReadString('\n'); err == nil {
+		t.Fatal("the client read a line from a connection that Shutdown closed")
+	}
+}
+
+// upgradeAndIdle runs EHLO and STARTTLS on one connection and then waits. It
+// drops every error: the caller closes these connections while they are still
+// in use, so a client that stops early is an ordinary outcome here.
+func upgradeAndIdle(addr string) {
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		return
+	}
+	defer func() { _ = conn.Close() }()
+
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+	br := bufio.NewReader(conn)
+
+	if _, err := br.ReadString('\n'); err != nil {
+		return
+	}
+	if _, err := fmt.Fprint(conn, "EHLO probe.example\r\n"); err != nil {
+		return
+	}
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			return
+		}
+		if len(line) < 4 || line[3] != '-' {
+			break
+		}
+	}
+	if _, err := fmt.Fprint(conn, "STARTTLS\r\n"); err != nil {
+		return
+	}
+	if _, err := br.ReadString('\n'); err != nil {
+		return
+	}
+
+	tconn := tls.Client(conn, &tls.Config{InsecureSkipVerify: true})
+	if err := tconn.HandshakeContext(context.Background()); err != nil {
+		return
+	}
+
+	// Hold the session, so that Shutdown finds it and closes it.
+	_, _ = tconn.Read(make([]byte, 1))
+}
+
+// TestShutdownDuringSTARTTLSUpgrade runs the STARTTLS upgrade while Shutdown
+// closes the sessions. The upgrade replaces the connection of the session on
+// the goroutine of that session, and Shutdown reaches the connection of every
+// live session from the goroutine of its caller. The two must not meet on a
+// field that the upgrade writes.
+//
+// The fault this guards against is a data race, so it shows under the race
+// detector alone. The staggered starts spread the upgrades over a window, and
+// the delay before Shutdown sweeps that window, so that a close lands beside
+// an upgrade.
+func TestShutdownDuringSTARTTLSUpgrade(t *testing.T) {
+	t.Parallel()
+
+	for i := range 16 {
+		ts := newTestServer(t, &smtpd.Server{}, nil)
+		ts.StartSTARTTLS()
+
+		var wg sync.WaitGroup
+		for j := range 30 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				time.Sleep(time.Duration(j) * 200 * time.Microsecond)
+				upgradeAndIdle(ts.Addr)
+			}()
+		}
+
+		time.Sleep(time.Duration(1+i%8) * time.Millisecond)
+
+		// A deadline this short takes Shutdown to the branch that closes the
+		// connections of the sessions that are still there, which is the
+		// branch that reads them.
+		ctx, cancel := context.WithTimeout(context.Background(), time.Microsecond)
+		_ = ts.Config.Shutdown(ctx)
+		cancel()
+
+		wg.Wait()
 	}
 }


### PR DESCRIPTION
`Server.Shutdown` closes the connection of every session that is still there
at its deadline. It read `session.conn`, which the `STARTTLS` upgrade writes
on the goroutine of the session. Nothing ordered the two, so a `Shutdown`
beside an upgrade was a data race.

## The fix

The session keeps the connection of the listener in a field of its own. The
server sets that field when the session begins, and nothing writes to it
again, so `Shutdown` reads a value that stands still.

The TLS connection reads and writes through the connection of the listener.
A close of that connection therefore ends an upgraded session as well. A
session that ends with `QUIT` still closes the TLS connection itself.

A field that never changes was the better answer here. A lock would need
every one of the call sites that read the connection, and the next one added
would take the fault back.

## Tests

`TestShutdownClosesAnUpgradedSession` holds an upgraded session open and asks
that `Shutdown` reach it. This is the part that the fix rests on.

`TestShutdownDuringSTARTTLSUpgrade` runs the upgrade beside the close. The
staggered starts spread the upgrades over a window, and the delay before
`Shutdown` sweeps that window. It reported the race on every run against the
old code, and it is quiet with the fix.
