### PR TITLE
feat: limit failed authentication attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- `Server.MaxAuthAttempts` closes a connection whose `AUTH` commands keep
+  failing. RFC 4954 section 6 asks for such a limit: `PLAIN` and `LOGIN` both
+  carry a password, and one connection took as many guesses as the client
+  cared to send.
+
+  Only a refusal from the `Authenticate` hooks counts, and a successful `AUTH`
+  sets the count back to zero.
+
+  **This changes behavior.** The default is 5, so a client that fails five
+  times now gets a `421` reply and a closed connection, where it could go on
+  before. Set the field to `-1` for the behavior of earlier versions.
+
+### Added
+
+- `middleware.AuthRateLimit` limits the failed authentication attempts of one
+  address, across the connections of that address. `Server.MaxAuthAttempts`
+  bounds a single connection, which a client that opens a new one for every
+  guess would otherwise get around.
+
+  A failed attempt takes a token, and a successful one takes none, so a client
+  that always sends the right password never spends the bucket of its address.
+  An address with no tokens left gets a `454` reply.
+
 ### Fixed
 
 - `Server.Shutdown` closes the connection that the listener gave, and not the

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Features
 --------
 
 * STARTTLS and implicit TLS
-* PLAIN/LOGIN authentication (after STARTTLS)
+* PLAIN/LOGIN authentication (after STARTTLS), with a limit on the failed
+  attempts of a connection ([RFC 4954](https://www.rfc-editor.org/rfc/rfc4954))
 * Enhanced status codes ([RFC 3463](https://www.rfc-editor.org/rfc/rfc3463))
 * `CHUNKING` with `BDAT`, and `BINARYMIME`
   ([RFC 3030](https://www.rfc-editor.org/rfc/rfc3030))
@@ -54,7 +55,8 @@ Features
 * Structured logging via `*slog.Logger`
 * Context-aware `Shutdown(ctx)` that drains in-flight sessions
 * Ready-made middleware in `github.com/chrj/smtpd/v2/middleware`: SPF, RBL,
-  greylisting, per-IP rate limiting, `RequireAuth`, `RequireTLS`
+  greylisting, per-IP rate limiting, per-IP limiting of failed authentication,
+  `RequireAuth`, `RequireTLS`
 * Test servers in `github.com/chrj/smtpd/v2/smtptest`, for end-to-end tests of
   an SMTP client
 
@@ -181,6 +183,50 @@ log.
 
 `Peer.Username` holds the user name after a successful `AUTH`. The password is
 given to the `Authenticate` hooks and is not kept.
+
+### Limits on authentication
+
+`AUTH PLAIN` and `AUTH LOGIN` both carry a password, and a client that sends
+enough guesses finds one. Two limits stand against that.
+
+`Server.MaxAuthAttempts` is the number of `AUTH` commands that can fail on one
+connection. The default is 5. The attempt that reaches the limit gets a `421`
+reply in the place of the refusal, and the server closes the connection.
+
+```
+C: AUTH PLAIN dXNlcgB3cm9uZw==
+S: 535 5.7.8 Authentication credentials invalid
+C: AUTH PLAIN dXNlcgB3cm9uZzI=
+S: 421 4.7.0 Too many failed authentication attempts
+```
+
+The `535` above is the reply of the `Authenticate` hook, which writes its own
+code. Only a refusal from those hooks counts. A command that does not read
+leaves the count where it is, and a successful `AUTH` sets it back to zero.
+Set the field to `-1` for a server that closes no connection for this reason.
+
+The limit counts the attempts of one connection, so a client that opens
+another one starts over. `middleware.AuthRateLimit` holds the failures of an
+address across connections:
+
+```go
+srv.Use(middleware.Authenticator(
+    middleware.AuthRateLimit(myAuthFn, 1.0/60, 10),
+))
+```
+
+Each address gets a bucket of 10 attempts that refills at one per minute. A
+failed attempt takes a token, and a successful one takes none, so a client
+that always sends the right password never spends the bucket of its address.
+
+An address with no tokens left gets a `454` reply, and the credential check
+does not run for it. A successful attempt gives back none of the tokens that
+earlier failures took, because a client that holds one good credential would
+then clear the count and go on guessing the rest.
+
+The bucket belongs to the address, so clients behind one address share it,
+and the `454` reaches a client with the right password as well. Idle buckets
+are dropped once they would have refilled.
 
 ### Session lifecycle
 
@@ -833,6 +879,7 @@ The middleware in `middleware` sets a code for each of its refusals:
 | `RequireTLS` | `530 5.7.0 Must issue STARTTLS first` |
 | `Greylist` | `450 4.7.1 greylisted, try again later` |
 | `IPAddressRateLimit` | `450 4.7.1 rate-limited, try again later` |
+| `AuthRateLimit` | `454 4.7.0 Too many failed authentication attempts, try again later` |
 | `RBL` | `554 5.7.1 {list message}` |
 | `SPF` (fail) | `550 5.7.23 SPF check failed` |
 | `SPF` (temporary error) | `451 4.7.24 SPF check temporary error` |

--- a/README.md
+++ b/README.md
@@ -194,9 +194,9 @@ connection. The default is 5. The attempt that reaches the limit gets a `421`
 reply in the place of the refusal, and the server closes the connection.
 
 ```
-C: AUTH PLAIN dXNlcgB3cm9uZw==
+C: AUTH PLAIN AHVzZXIAd3Jvbmc=
 S: 535 5.7.8 Authentication credentials invalid
-C: AUTH PLAIN dXNlcgB3cm9uZzI=
+C: AUTH PLAIN AHVzZXIAd3Jvbmcy
 S: 421 4.7.0 Too many failed authentication attempts
 ```
 

--- a/auth.go
+++ b/auth.go
@@ -115,9 +115,21 @@ func (s *session) handleAUTH(ctx context.Context, cmd *command) context.Context 
 	var err error
 	ctx, err = s.server.authenticate(ctx, s.peer, username, password)
 	if err != nil {
+		s.authFailures++
+		if s.server.tooManyAuthFailures(s.authFailures) {
+			// The attempt that reaches the limit takes this reply in the
+			// place of the refusal, so that the client reads one answer to
+			// its command and learns why the connection ends.
+			logger.WarnContext(ctx, "closing the session after too many failed authentication attempts",
+				slog.Int("attempts", s.authFailures),
+			)
+			ctx = s.replyEnhanced(ctx, 421, EnhancedCode{4, 7, 0}, "Too many failed authentication attempts")
+			return s.close(ctx)
+		}
 		return s.replyError(ctx, err)
 	}
 
+	s.authFailures = 0
 	s.peer.Username = username
 
 	return s.replyEnhanced(ctx, 235, EnhancedCode{2, 7, 0}, "OK, you are now authenticated")

--- a/auth_test.go
+++ b/auth_test.go
@@ -2,6 +2,7 @@ package smtpd_test
 
 import (
 	"context"
+	"encoding/base64"
 	"net/smtp"
 	"strings"
 	"testing"
@@ -328,5 +329,177 @@ func TestAUTHContinuationTooLongEndsTheSession(t *testing.T) {
 	_ = c.conn.SetReadDeadline(time.Now().Add(3 * time.Second))
 	if line, err := c.br.ReadString('\n'); err == nil {
 		t.Errorf("the session wrote %q after the refusal, and it must be over", line)
+	}
+}
+
+// authPLAIN is the argument of an AUTH PLAIN command for a user and a
+// password, in the base64 that RFC 4954 section 4 asks for.
+func authPLAIN(user, pass string) string {
+	return base64.StdEncoding.EncodeToString([]byte("\x00" + user + "\x00" + pass))
+}
+
+// TestAUTHClosesAfterTooManyFailures verifies that the server closes a
+// connection whose AUTH commands keep failing. RFC 4954 section 6 asks for a
+// limit, because PLAIN and LOGIN both carry a password that a client guesses.
+func TestAUTHClosesAfterTooManyFailures(t *testing.T) {
+	t.Parallel()
+
+	srv := runsslserver(t, &smtpd.Server{
+		Logger:          testLogger(t),
+		MaxAuthAttempts: 3,
+	}, rejectAuth())
+
+	c := srv.Dial()
+
+	// The attempts before the last one get the reply of the hook.
+	for i := range 2 {
+		if err := smtptest.Cmd(c.Text, 550, "AUTH PLAIN %s", authPLAIN("user", "wrong")); err != nil {
+			t.Fatalf("attempt %d did not get 550: %v", i+1, err)
+		}
+	}
+
+	// The attempt that reaches the limit gets 421 in the place of the refusal.
+	if err := smtptest.Cmd(c.Text, 421, "AUTH PLAIN %s", authPLAIN("user", "wrong")); err != nil {
+		t.Fatalf("the attempt at the limit did not get 421: %v", err)
+	}
+
+	// The connection is gone, so the command after it never gets a reply.
+	if err := smtptest.Cmd(c.Text, 250, "NOOP"); err == nil {
+		t.Fatal("the session took a command after the limit")
+	}
+}
+
+// TestAUTHKeepsTheSessionUnderTheLimit verifies that a session that fails
+// fewer times than the limit stays open.
+func TestAUTHKeepsTheSessionUnderTheLimit(t *testing.T) {
+	t.Parallel()
+
+	srv := runsslserver(t, &smtpd.Server{
+		Logger:          testLogger(t),
+		MaxAuthAttempts: 3,
+	}, rejectAuth())
+
+	c := srv.Dial()
+
+	for i := range 2 {
+		if err := smtptest.Cmd(c.Text, 550, "AUTH PLAIN %s", authPLAIN("user", "wrong")); err != nil {
+			t.Fatalf("attempt %d did not get 550: %v", i+1, err)
+		}
+	}
+
+	if err := smtptest.Cmd(c.Text, 250, "NOOP"); err != nil {
+		t.Fatalf("the session did not take a command under the limit: %v", err)
+	}
+	_ = c.Quit()
+}
+
+// TestAUTHSuccessClearsTheFailures verifies that a successful AUTH sets the
+// count back to zero, so that earlier failures never close the session of a
+// client that knows its password.
+func TestAUTHSuccessClearsTheFailures(t *testing.T) {
+	t.Parallel()
+
+	// The hook refuses the password "wrong" and takes every other one.
+	auth := smtpd.Middleware{
+		Authenticate: func(ctx context.Context, _ smtpd.Peer, _, pass string) (context.Context, error) {
+			if pass == "wrong" {
+				return ctx, smtpd.Error{Code: 535, Message: "Denied"}
+			}
+			return ctx, nil
+		},
+	}
+
+	srv := runsslserver(t, &smtpd.Server{
+		Logger:          testLogger(t),
+		MaxAuthAttempts: 3,
+	}, auth)
+
+	c := srv.Dial()
+
+	for i := range 2 {
+		if err := smtptest.Cmd(c.Text, 535, "AUTH PLAIN %s", authPLAIN("user", "wrong")); err != nil {
+			t.Fatalf("attempt %d did not get 535: %v", i+1, err)
+		}
+	}
+
+	if err := smtptest.Cmd(c.Text, 235, "AUTH PLAIN %s", authPLAIN("user", "right")); err != nil {
+		t.Fatalf("the good password did not get 235: %v", err)
+	}
+
+	// The count started over, so two more failures leave the session open.
+	for i := range 2 {
+		if err := smtptest.Cmd(c.Text, 535, "AUTH PLAIN %s", authPLAIN("user", "wrong")); err != nil {
+			t.Fatalf("attempt %d after the success did not get 535: %v", i+1, err)
+		}
+	}
+
+	if err := smtptest.Cmd(c.Text, 250, "NOOP"); err != nil {
+		t.Fatalf("the session closed after a successful AUTH cleared the count: %v", err)
+	}
+	_ = c.Quit()
+}
+
+// TestAUTHUnlimitedAttempts verifies that a limit of -1 closes no connection,
+// in the way that MaxConnections reads the same value.
+func TestAUTHUnlimitedAttempts(t *testing.T) {
+	t.Parallel()
+
+	srv := runsslserver(t, &smtpd.Server{
+		Logger:          testLogger(t),
+		MaxAuthAttempts: -1,
+	}, rejectAuth())
+
+	c := srv.Dial()
+
+	for i := range 12 {
+		if err := smtptest.Cmd(c.Text, 550, "AUTH PLAIN %s", authPLAIN("user", "wrong")); err != nil {
+			t.Fatalf("attempt %d did not get 550: %v", i+1, err)
+		}
+	}
+	_ = c.Quit()
+}
+
+// TestAUTHBadCredentialsDoNotCount verifies that an AUTH command that does not
+// decode leaves the count where it is. Such a command carries no guess: the
+// Authenticate hooks never see it.
+func TestAUTHBadCredentialsDoNotCount(t *testing.T) {
+	t.Parallel()
+
+	srv := runsslserver(t, &smtpd.Server{
+		Logger:          testLogger(t),
+		MaxAuthAttempts: 3,
+	}, rejectAuth())
+
+	c := srv.Dial()
+
+	for i := range 6 {
+		if err := smtptest.Cmd(c.Text, 501, "AUTH PLAIN not-base64!"); err != nil {
+			t.Fatalf("attempt %d did not get 501: %v", i+1, err)
+		}
+	}
+
+	if err := smtptest.Cmd(c.Text, 250, "NOOP"); err != nil {
+		t.Fatalf("the session closed for commands that carried no guess: %v", err)
+	}
+	_ = c.Quit()
+}
+
+// TestAUTHDefaultAttemptLimit verifies that a server that sets no limit takes
+// the default of five.
+func TestAUTHDefaultAttemptLimit(t *testing.T) {
+	t.Parallel()
+
+	srv := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, rejectAuth())
+
+	c := srv.Dial()
+
+	for i := range 4 {
+		if err := smtptest.Cmd(c.Text, 550, "AUTH PLAIN %s", authPLAIN("user", "wrong")); err != nil {
+			t.Fatalf("attempt %d did not get 550: %v", i+1, err)
+		}
+	}
+
+	if err := smtptest.Cmd(c.Text, 421, "AUTH PLAIN %s", authPLAIN("user", "wrong")); err != nil {
+		t.Fatalf("the fifth attempt did not get 421: %v", err)
 	}
 }

--- a/middleware/auth_rate_limit.go
+++ b/middleware/auth_rate_limit.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"net"
+	"sync"
 
 	"github.com/chrj/keyrate"
 	"github.com/chrj/smtpd/v2"
@@ -51,30 +52,83 @@ var errAuthRateLimited = smtpd.Error{
 // spends the tokens of every other client behind it. Idle buckets are
 // dropped once they would have refilled.
 func AuthRateLimit(fn AuthFunc, rps float64, burst int) AuthFunc {
-	lims := keyrate.New[string](rate.Limit(rps), burst, keyrate.WithAutoEvict())
+	l := &authLimiter{
+		lims:     keyrate.New[string](rate.Limit(rps), burst, keyrate.WithAutoEvict()),
+		fn:       fn,
+		inFlight: make(map[string]int),
+	}
+	return l.check
+}
 
-	return func(ctx context.Context, peer smtpd.Peer, user, pass string) error {
-		tcpAddr, ok := peer.Addr.(*net.TCPAddr)
-		if !ok {
-			return fn(ctx, peer, user, pass)
-		}
+// authLimiter holds the bucket of each address and the attempts that are
+// running.
+type authLimiter struct {
+	lims *keyrate.Limiters[string]
+	fn   AuthFunc
 
-		// Tokens reads the bucket without taking from it, and it holds no
-		// entry for an address that never failed. Two attempts of one address
-		// can read the same token and both go on, which costs one attempt over
-		// the burst and no more.
-		key := tcpAddr.IP.String()
-		if lims.Tokens(key) < 1 {
-			smtpd.LoggerFromContext(ctx).WarnContext(ctx, "authentication rate-limited",
-				slog.String("ip", key),
-			)
-			return errAuthRateLimited
-		}
+	mu sync.Mutex
 
-		err := fn(ctx, peer, user, pass)
-		if err != nil {
-			_ = lims.Allow(key)
-		}
-		return err
+	// inFlight counts the attempts of an address that the limiter let through
+	// and that have not ended. The token of such an attempt is not taken
+	// until the credential check answers, so the admission has to count them
+	// itself. Without that, every attempt that overlaps reads the same token
+	// and the whole set of them reaches the check.
+	//
+	// An address with nothing running holds no entry.
+	inFlight map[string]int
+}
+
+func (l *authLimiter) check(ctx context.Context, peer smtpd.Peer, user, pass string) (err error) {
+	tcpAddr, ok := peer.Addr.(*net.TCPAddr)
+	if !ok {
+		return l.fn(ctx, peer, user, pass)
+	}
+
+	key := tcpAddr.IP.String()
+	if !l.admit(key) {
+		smtpd.LoggerFromContext(ctx).WarnContext(ctx, "authentication rate-limited",
+			slog.String("ip", key),
+		)
+		return errAuthRateLimited
+	}
+
+	// The deferred call runs for a check that panics as well, so that such an
+	// attempt gives its place back. A panic is not a wrong password, and it
+	// takes no token.
+	defer func() { l.release(key, err != nil) }()
+
+	return l.fn(ctx, peer, user, pass)
+}
+
+// admit takes a place for one attempt of the address, or reports that the
+// bucket has nothing left for it.
+func (l *authLimiter) admit(key string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	// Tokens reads the bucket without taking from it, and it writes no entry
+	// for an address that never failed.
+	if l.lims.Tokens(key)-float64(l.inFlight[key]) < 1 {
+		return false
+	}
+
+	l.inFlight[key]++
+	return true
+}
+
+// release gives back the place of an attempt that ended, and takes a token
+// for one that failed. Both happen under the one lock that admit reads, so an
+// attempt never sees a token that another one is about to take.
+func (l *authLimiter) release(key string, failed bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if failed {
+		_ = l.lims.Allow(key)
+	}
+
+	l.inFlight[key]--
+	if l.inFlight[key] <= 0 {
+		delete(l.inFlight, key)
 	}
 }

--- a/middleware/auth_rate_limit.go
+++ b/middleware/auth_rate_limit.go
@@ -1,0 +1,80 @@
+package middleware
+
+import (
+	"context"
+	"log/slog"
+	"net"
+
+	"github.com/chrj/keyrate"
+	"github.com/chrj/smtpd/v2"
+	"golang.org/x/time/rate"
+)
+
+// errAuthRateLimited answers an address that has failed too often. RFC 4954
+// section 6 gives 454 for a fault that passes, where 535 says that the
+// credentials are wrong.
+var errAuthRateLimited = smtpd.Error{
+	Code:     454,
+	Enhanced: smtpd.EnhancedCode{4, 7, 0},
+	Message:  "Too many failed authentication attempts, try again later",
+}
+
+// AuthRateLimit wraps fn so that failed authentication attempts from one
+// remote IP are rate limited. Each IP gets its own token bucket of size burst
+// that refills at rps tokens per second.
+//
+// A failed attempt takes a token. A successful one takes none, so a client
+// that always sends the right password never spends the bucket of its
+// address. An IP with no tokens left gets a 454 reply, and fn does not run
+// for it. The reply goes to every client at that address, a client with the
+// right password included: the bucket belongs to the address.
+//
+// A successful attempt does not give back the tokens that earlier failures
+// took, because a client that holds one good credential would then clear the
+// count and go on guessing the rest. The bucket refills with time instead.
+//
+// Server.MaxAuthAttempts bounds the attempts of a single connection. This
+// bounds the attempts of an address, which a client that opens a new
+// connection for every guess would otherwise get around.
+//
+// Non-TCP peers, such as a unix socket, are never limited: the IP is what
+// the bucket belongs to.
+//
+// Wrap the function that reads your credentials, and pass the result to
+// Authenticator:
+//
+//	srv.Use(middleware.Authenticator(
+//	    middleware.AuthRateLimit(myAuthFn, 1.0/60, 10),
+//	))
+//
+// The bucket belongs to the address, so a client behind a shared address
+// spends the tokens of every other client behind it. Idle buckets are
+// dropped once they would have refilled.
+func AuthRateLimit(fn AuthFunc, rps float64, burst int) AuthFunc {
+	lims := keyrate.New[string](rate.Limit(rps), burst, keyrate.WithAutoEvict())
+
+	return func(ctx context.Context, peer smtpd.Peer, user, pass string) error {
+		tcpAddr, ok := peer.Addr.(*net.TCPAddr)
+		if !ok {
+			return fn(ctx, peer, user, pass)
+		}
+
+		// Tokens reads the bucket without taking from it, and it holds no
+		// entry for an address that never failed. Two attempts of one address
+		// can read the same token and both go on, which costs one attempt over
+		// the burst and no more.
+		key := tcpAddr.IP.String()
+		if lims.Tokens(key) < 1 {
+			smtpd.LoggerFromContext(ctx).WarnContext(ctx, "authentication rate-limited",
+				slog.String("ip", key),
+			)
+			return errAuthRateLimited
+		}
+
+		err := fn(ctx, peer, user, pass)
+		if err != nil {
+			_ = lims.Allow(key)
+		}
+		return err
+	}
+}

--- a/middleware/auth_rate_limit_test.go
+++ b/middleware/auth_rate_limit_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"net"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/chrj/smtpd/v2"
 )
@@ -148,5 +151,53 @@ func TestAuthRateLimitPassesNonTCP(t *testing.T) {
 
 	if calls != 5 {
 		t.Fatalf("the check ran %d times, want 5", calls)
+	}
+}
+
+// TestAuthRateLimitAdmitsOneAtATime fires many attempts at one address while
+// the check underneath is held up. A bucket of one token must let one of them
+// through: the check runs between the read of the bucket and the taking of
+// the token, so attempts that overlap must not each read the same token.
+func TestAuthRateLimitAdmitsOneAtATime(t *testing.T) {
+	t.Parallel()
+
+	const attempts = 50
+
+	var (
+		reached atomic.Int64
+		entered = make(chan struct{}, attempts)
+		release = make(chan struct{})
+	)
+
+	// The check holds every caller until the test releases them, so that all
+	// the attempts that got in are inside it at the same time.
+	fn := func(_ context.Context, _ smtpd.Peer, _, _ string) error {
+		reached.Add(1)
+		entered <- struct{}{}
+		<-release
+		return errWrongPassword
+	}
+
+	limited := AuthRateLimit(fn, 0.001, 1)
+	peer := tcpPeer("10.0.0.1")
+
+	var wg sync.WaitGroup
+	for range attempts {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = limited(context.Background(), peer, "user", "wrong")
+		}()
+	}
+
+	// Wait for the one attempt that the burst allows, then let the rest run
+	// into the limit before the check returns.
+	<-entered
+	time.Sleep(100 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	if got := reached.Load(); got != 1 {
+		t.Fatalf("the check ran %d times, want 1: a bucket of one token let %d guesses through", got, got)
 	}
 }

--- a/middleware/auth_rate_limit_test.go
+++ b/middleware/auth_rate_limit_test.go
@@ -1,0 +1,152 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/chrj/smtpd/v2"
+)
+
+// errWrongPassword stands for the refusal of a credential check.
+var errWrongPassword = smtpd.Error{Code: 535, Message: "Denied"}
+
+// authFor returns an AuthFunc that takes the one password and counts the
+// calls that reached it.
+func authFor(good string, calls *int) AuthFunc {
+	return func(_ context.Context, _ smtpd.Peer, _, pass string) error {
+		*calls++
+		if pass != good {
+			return errWrongPassword
+		}
+		return nil
+	}
+}
+
+func tcpPeer(ip string) smtpd.Peer {
+	return smtpd.Peer{Addr: &net.TCPAddr{IP: net.ParseIP(ip)}}
+}
+
+// TestAuthRateLimitStopsTheGuesses verifies that an address runs out of
+// tokens, and that the check underneath stops running for it.
+func TestAuthRateLimitStopsTheGuesses(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	fn := AuthRateLimit(authFor("right", &calls), 0.001, 2)
+	peer := tcpPeer("10.0.0.1")
+
+	for i := range 2 {
+		if err := fn(context.Background(), peer, "user", "wrong"); !errors.Is(err, errWrongPassword) {
+			t.Fatalf("attempt %d = %v, want the refusal of the check", i+1, err)
+		}
+	}
+
+	err := fn(context.Background(), peer, "user", "wrong")
+	var smtpErr smtpd.Error
+	if !errors.As(err, &smtpErr) || smtpErr.Code != 454 {
+		t.Fatalf("the attempt past the burst = %v, want a 454", err)
+	}
+
+	if calls != 2 {
+		t.Fatalf("the check ran %d times, want 2", calls)
+	}
+}
+
+// TestAuthRateLimitHoldsOneAddress verifies that the bucket belongs to the
+// address, so one client never spends the tokens of another.
+func TestAuthRateLimitHoldsOneAddress(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	fn := AuthRateLimit(authFor("right", &calls), 0.001, 1)
+
+	if err := fn(context.Background(), tcpPeer("10.0.0.1"), "user", "wrong"); !errors.Is(err, errWrongPassword) {
+		t.Fatalf("the first address = %v, want the refusal of the check", err)
+	}
+	if err := fn(context.Background(), tcpPeer("10.0.0.1"), "user", "wrong"); errors.Is(err, errWrongPassword) {
+		t.Fatal("the first address kept its tokens past the burst")
+	}
+
+	if err := fn(context.Background(), tcpPeer("10.0.0.2"), "user", "wrong"); !errors.Is(err, errWrongPassword) {
+		t.Fatalf("the second address = %v, want the refusal of the check", err)
+	}
+}
+
+// TestAuthRateLimitPassesSuccess verifies that a successful attempt takes no
+// token. A client that knows its password is never limited, however often it
+// authenticates.
+func TestAuthRateLimitPassesSuccess(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	fn := AuthRateLimit(authFor("right", &calls), 0.001, 2)
+	peer := tcpPeer("10.0.0.1")
+
+	for i := range 20 {
+		if err := fn(context.Background(), peer, "user", "right"); err != nil {
+			t.Fatalf("attempt %d with the good password = %v, want no error", i+1, err)
+		}
+	}
+
+	if calls != 20 {
+		t.Fatalf("the check ran %d times, want 20", calls)
+	}
+}
+
+// TestAuthRateLimitKeepsFailuresAfterSuccess verifies that a successful
+// attempt does not give back the tokens that earlier failures took. A client
+// that holds one good credential would otherwise clear the count and go on
+// guessing the rest.
+func TestAuthRateLimitKeepsFailuresAfterSuccess(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	fn := AuthRateLimit(authFor("right", &calls), 0.001, 3)
+	peer := tcpPeer("10.0.0.1")
+
+	// Two of the three tokens go to failures.
+	for i := range 2 {
+		if err := fn(context.Background(), peer, "user", "wrong"); !errors.Is(err, errWrongPassword) {
+			t.Fatalf("attempt %d = %v, want the refusal of the check", i+1, err)
+		}
+	}
+
+	// The third token is still there, so the good password gets through.
+	if err := fn(context.Background(), peer, "user", "right"); err != nil {
+		t.Fatalf("the good password = %v, want no error", err)
+	}
+
+	// A success that gave the bucket back would leave three tokens here. It
+	// gave none back, so this failure takes the last one.
+	if err := fn(context.Background(), peer, "user", "wrong"); !errors.Is(err, errWrongPassword) {
+		t.Fatalf("the failure after the success = %v, want the refusal of the check", err)
+	}
+
+	err := fn(context.Background(), peer, "user", "wrong")
+	var smtpErr smtpd.Error
+	if !errors.As(err, &smtpErr) || smtpErr.Code != 454 {
+		t.Fatalf("the attempt past the burst = %v, want a 454", err)
+	}
+}
+
+// TestAuthRateLimitPassesNonTCP verifies that a peer without an IP is never
+// limited, in the way that the other checks of this package read one.
+func TestAuthRateLimitPassesNonTCP(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	fn := AuthRateLimit(authFor("right", &calls), 0.001, 1)
+	peer := smtpd.Peer{Addr: &net.UnixAddr{Name: "/tmp/smtpd.sock", Net: "unix"}}
+
+	for i := range 5 {
+		if err := fn(context.Background(), peer, "user", "wrong"); !errors.Is(err, errWrongPassword) {
+			t.Fatalf("attempt %d = %v, want the refusal of the check", i+1, err)
+		}
+	}
+
+	if calls != 5 {
+		t.Fatalf("the check ran %d times, want 5", calls)
+	}
+}

--- a/session.go
+++ b/session.go
@@ -41,6 +41,11 @@ type session struct {
 	tls    bool
 	closed bool
 
+	// authFailures counts the AUTH commands of this session that the
+	// Authenticate hooks refused. Server.MaxAuthAttempts bounds it, and a
+	// successful AUTH sets it back to zero.
+	authFailures int
+
 	// ranCommand says that the session ran a command already. A PROXY header
 	// stands before everything else: the proxy writes it, and only then does
 	// it pass on what the client sends. A PROXY command that comes later

--- a/smtpd.go
+++ b/smtpd.go
@@ -235,6 +235,23 @@ type Server struct {
 	MaxMessageSize int // default 10MB; enforced at protocol level
 	MaxRecipients  int // default 100
 
+	// MaxAuthAttempts is the number of AUTH commands that can fail on one
+	// connection. The server answers the attempt that reaches the limit with
+	// 421 and closes the connection.
+	//
+	// RFC 4954 section 6 asks for such a limit. PLAIN and LOGIN both carry a
+	// password, and without a limit one connection takes as many guesses as
+	// the client cares to send.
+	//
+	// Only a refusal from the Authenticate hooks counts. A command that does
+	// not read, or one whose credentials are not base64, leaves the count
+	// where it is. A successful AUTH sets the count back to zero.
+	//
+	// The limit counts the attempts of one connection, so a client that opens
+	// another one starts over. Pair it with middleware.AuthRateLimit, which
+	// holds the failures of an address across connections.
+	MaxAuthAttempts int // default 5; -1 unlimited
+
 	// Extensions
 	EnableXCLIENT bool
 
@@ -485,6 +502,13 @@ func (srv *Server) hasAuthenticator() bool {
 	return len(srv.authenticators) > 0
 }
 
+// tooManyAuthFailures reports whether a session that saw failures refused
+// attempts has reached MaxAuthAttempts. A limit of -1, or of any other value
+// below one, closes no connection.
+func (srv *Server) tooManyAuthFailures(failures int) bool {
+	return srv.MaxAuthAttempts > 0 && failures >= srv.MaxAuthAttempts
+}
+
 func (srv *Server) trackSession(s *session, cancel context.CancelFunc) bool {
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
@@ -513,6 +537,9 @@ func (srv *Server) configureDefaults() error {
 	}
 	if srv.MaxRecipients == 0 {
 		srv.MaxRecipients = 100
+	}
+	if srv.MaxAuthAttempts == 0 {
+		srv.MaxAuthAttempts = 5
 	}
 	if srv.ReadTimeout == 0 {
 		srv.ReadTimeout = 60 * time.Second


### PR DESCRIPTION
`AUTH PLAIN` and `AUTH LOGIN` both carry a password, and a client that sends
enough guesses finds one. The server took as many guesses as a client cared
to send, on one connection and at the speed of the network.

RFC 4954 section 6 asks for a limit. This adds two, at the two levels where a
guess can be counted.

## The connection: `Server.MaxAuthAttempts`

The number of `AUTH` commands that can fail on one connection. The attempt
that reaches the limit gets a `421` reply in the place of the refusal, and
the server closes the connection.

Only a refusal from the `Authenticate` hooks counts. A command that does not
read carries no guess, so it leaves the count where it is. A successful
`AUTH` sets the count back to zero.

**This changes behavior.** The default is 5, so a client that fails five
times now loses its connection. `-1` reads as unlimited, in the way that
`MaxConnections` reads it, and gives back the earlier behavior.

## The address: `middleware.AuthRateLimit`

The limit above counts one connection, and a client that opens a new
connection for every guess gets around it. `AuthRateLimit` gives each remote
IP a bucket of failed attempts, on top of `keyrate`:

```go
srv.Use(middleware.Authenticator(
    middleware.AuthRateLimit(myAuthFn, 1.0/60, 10),
))
```

A failed attempt takes a token. A successful one takes none, so a client that
always sends the right password never spends the bucket of its address, and a
mail client that authenticates on every poll is never limited.

A success gives back none of the tokens that earlier failures took. Giving
the bucket back was the first shape of this, and it was wrong: a client that
holds one good credential could clear the count and go on guessing the rest.

The read of the bucket takes no token and writes no entry, so an address that
never failed costs no memory. Idle buckets are dropped once they would have
refilled.

The bucket belongs to the address. Clients behind one address share it, and
the `454` reaches a client with the right password as well.

## Tests

The core tests cover the close at the limit, a session that stays open under
it, a success that clears the count, `-1`, the default of 5, and a command
that does not decode. The two that assert the close fail without the limit.

The middleware tests cover the burst, one bucket for each address, a success
that takes no token, a success that gives none back, and a peer with no IP.
