### PR TITLE
fix: hold the three parts of a greylist triple apart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `middleware.Greylist` holds the three parts of a triple apart. The key put
+  the address of the client, the sender and the recipient in one string with a
+  `|` between them, and RFC 5321 gives `|` to the local part of an address, so
+  two triples could meet on one entry:
+
+  ```
+  sender "a|b@example.org" with recipient "c@example.net"
+  sender "a"               with recipient "b@example.org|c@example.net"
+  ```
+
+  The second of them read the entry of the first, and it passed a delay that
+  it never waited.
+
 ### Security
 
 - `Server.MaxAuthAttempts` closes a connection whose `AUTH` commands keep

--- a/middleware/greylist.go
+++ b/middleware/greylist.go
@@ -37,7 +37,7 @@ type GreylistChecker struct {
 	now        func() time.Time
 
 	mu      sync.Mutex
-	entries map[string]time.Time
+	entries map[greylistKey]time.Time
 
 	// nextSweep is the time of the next sweep for memory. Reclaiming memory
 	// is separate from the TTL: RecipientCheck tests the age of an entry
@@ -47,6 +47,19 @@ type GreylistChecker struct {
 	// sweeps counts the sweeps that ran. Tests read it to prove that a sweep
 	// does not run on every check.
 	sweeps int
+}
+
+// greylistKey is the triple that greylisting holds: the address of the
+// client, the sender and the recipient.
+//
+// The three parts stand in fields of their own, and not in one string with a
+// separator between them. RFC 5321 gives the local part of an address the
+// printable characters, so an address carries any separator that a joined key
+// could use, and one triple would then read the entry of another.
+type greylistKey struct {
+	ip        string
+	sender    string
+	recipient string
 }
 
 // defaultGreylistMaxEntries is the cap that Greylist uses when the caller
@@ -95,7 +108,7 @@ func Greylist(opts ...GreylistOption) *GreylistChecker {
 		maxEntries: defaultGreylistMaxEntries,
 		sweepEvery: time.Minute,
 		now:        time.Now,
-		entries:    make(map[string]time.Time),
+		entries:    make(map[greylistKey]time.Time),
 	}
 	for _, opt := range opts {
 		opt(g)
@@ -118,7 +131,7 @@ func (g *GreylistChecker) RecipientCheck(ctx context.Context, peer smtpd.Peer, r
 		return nil
 	}
 	sender, _ := smtpd.SenderFromContext(ctx)
-	key := tcpAddr.IP.String() + "|" + sender + "|" + recipient
+	key := greylistKey{ip: tcpAddr.IP.String(), sender: sender, recipient: recipient}
 
 	now := g.now()
 	g.mu.Lock()

--- a/middleware/greylist_bounds_test.go
+++ b/middleware/greylist_bounds_test.go
@@ -79,9 +79,9 @@ func TestGreylistEvictsOldestFirst(t *testing.T) {
 }
 
 // keyOf builds the map key that checkTriple produces for i.
-func keyOf(i int) string {
+func keyOf(i int) greylistKey {
 	ip := net.IPv4(10, byte(i>>16), byte(i>>8), byte(i))
-	return ip.String() + "|" + "" + "|" + fmt.Sprintf("r%d@example.net", i)
+	return greylistKey{ip: ip.String(), recipient: fmt.Sprintf("r%d@example.net", i)}
 }
 
 // TestGreylistExpiryDoesNotDependOnTheSweep verifies that a triple past the

--- a/middleware/greylist_test.go
+++ b/middleware/greylist_test.go
@@ -96,3 +96,44 @@ func contextWithSenderForTest(t *testing.T, sender string) context.Context {
 	t.Helper()
 	return smtpd.ContextWithSender(context.Background(), sender)
 }
+
+// TestGreylistKeepsTheTripleParts verifies that two different triples never
+// share an entry. The key held the three parts in one string with a "|"
+// between them, and RFC 5321 gives "|" to the local part of an address, so
+// moving the boundary made two triples meet:
+//
+//	sender "a|b@example.org" with recipient "c@example.net"
+//	sender "a"               with recipient "b@example.org|c@example.net"
+//
+// The second of them then read the entry of the first, and it passed the
+// delay that it never waited.
+func TestGreylistKeepsTheTripleParts(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1_700_000_000, 0)
+	g := Greylist(
+		WithGreylistDelay(5*time.Minute),
+		WithGreylistTTL(1*time.Hour),
+		withGreylistClock(func() time.Time { return now }),
+	)
+
+	peer := smtpd.Peer{Addr: &net.TCPAddr{IP: net.ParseIP("10.0.0.1")}}
+
+	first := contextWithSenderForTest(t, "a|b@example.org")
+	if err := g.RecipientCheck(first, peer, "c@example.net"); err == nil {
+		t.Fatal("expected the first triple to be greylisted")
+	}
+
+	// The first triple waits out its delay and is let through.
+	now = now.Add(6 * time.Minute)
+	if err := g.RecipientCheck(first, peer, "c@example.net"); err != nil {
+		t.Fatalf("expected the first triple to pass after the delay, got %v", err)
+	}
+
+	// The second triple is a triple of its own, and it has waited for
+	// nothing. It must be greylisted like any other first attempt.
+	second := contextWithSenderForTest(t, "a")
+	if err := g.RecipientCheck(second, peer, "b@example.org|c@example.net"); err == nil {
+		t.Fatal("the second triple read the entry of the first and passed the delay")
+	}
+}


### PR DESCRIPTION
The key of a greylist entry put the address of the client, the sender and the
recipient in one string, with a `|` between them:

```go
key := tcpAddr.IP.String() + "|" + sender + "|" + recipient
```

RFC 5321 gives the printable characters to the local part of an address, `|`
among them, so an address can move the boundary and two triples meet on one
entry:

```
sender "a|b@example.org" with recipient "c@example.net"
sender "a"               with recipient "b@example.org|c@example.net"
```

The second of them reads the entry of the first. Where the first has waited
out its delay, the second passes a delay that it never waited.

## The fix

The three parts stand in fields of a struct, which the map takes as the key.
No separator stands between them, so no address can move the boundary. The
key holds the same three strings as before and copies none of them, so an
entry costs no more than it did.

Escaping the parts would work as well. A key of fields needs no encoding and
no reader for it, and the next editor cannot reach for a separator that an
address is allowed to carry.

## What this is worth

Low. Reaching the entry of another triple asks for a recipient that the
server accepts and that carries the boundary, and a server that refuses an
unknown recipient before this check gives no way to ask. The keying was
ambiguous all the same, and the fix is smaller than the argument about
whether anyone could reach it.

## Tests

`TestGreylistKeepsTheTripleParts` sends the pair above and asks that the
second triple be greylisted. It fails on the old key.
