### PR TITLE
fix: take one successful AUTH command in a session (RFC 4954)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The second of them read the entry of the first, and it passed a delay that
   it never waited.
 
+- One `AUTH` command can succeed in a session, and every `AUTH` command after
+  it gets a `503` reply. RFC 4954 section 4 asks for that. The server took
+  every one of them, so a client could take a second identity on a session
+  whose earlier commands ran under the first.
+
+  A refused `AUTH` closes no door, and a successful `STARTTLS` opens the
+  session to a new one: the handshake drops what the client sent in plain
+  text.
+
+  **This changes behavior.** A client that sends `AUTH` twice gets a `503` for
+  the second one, where the server authenticated it again before.
+
 ### Security
 
 - `Server.MaxAuthAttempts` closes a connection whose `AUTH` commands keep

--- a/README.md
+++ b/README.md
@@ -184,6 +184,14 @@ log.
 `Peer.Username` holds the user name after a successful `AUTH`. The password is
 given to the `Authenticate` hooks and is not kept.
 
+One `AUTH` command can succeed in a session. RFC 4954 section 4 gives `503` to
+every `AUTH` command after that one, so a client cannot take a second identity
+on a session whose earlier commands ran under the first. A refused `AUTH`
+closes no door: the client can try again, up to the limit below.
+
+A successful `STARTTLS` opens the session to a new `AUTH`, because the
+handshake drops everything the client sent in plain text.
+
 ### Limits on authentication
 
 `AUTH PLAIN` and `AUTH LOGIN` both carry a password, and a client that sends
@@ -284,7 +292,12 @@ terminated the session, or a `PanicError` if a hook panicked.
 Everything the client sends before the handshake goes over the wire in plain
 text, where anybody on the path can change it. RFC 3207 says the server must
 drop what it learned there, so a successful `STARTTLS` clears `Peer.HeloName`,
-`Peer.Protocol` and `Peer.Username`, and the envelope.
+`Peer.Protocol` and `Peer.Username`, and the envelope. It opens the session to
+a new `AUTH` command as well.
+
+The count of the failed `AUTH` attempts stays. It bounds what the client may
+try on this connection, and it says nothing about the client, so a client that
+could set it back would take its guesses over again.
 
 The client must send `EHLO` or `HELO` again. Without it, `MAIL FROM` is
 answered with `503`. Client libraries do this for themselves: `StartTLS` in

--- a/auth.go
+++ b/auth.go
@@ -20,6 +20,14 @@ func (s *session) handleAUTH(ctx context.Context, cmd *command) context.Context 
 		return s.replyEnhanced(ctx, 502, EnhancedCode{5, 5, 1}, "AUTH not supported.")
 	}
 
+	// RFC 4954 section 4 lets one AUTH command succeed in a session, and gives
+	// 503 to every one after it. A client that authenticated again could take
+	// a second identity on a session whose earlier commands ran under the
+	// first one.
+	if s.authenticated {
+		return s.replyEnhanced(ctx, 503, EnhancedCode{5, 5, 1}, "Already authenticated")
+	}
+
 	if s.peer.HeloName == "" {
 		return s.replyEnhanced(ctx, 503, EnhancedCode{5, 5, 1}, "Please introduce yourself first.")
 	}
@@ -130,6 +138,7 @@ func (s *session) handleAUTH(ctx context.Context, cmd *command) context.Context 
 	}
 
 	s.authFailures = 0
+	s.authenticated = true
 	s.peer.Username = username
 
 	return s.replyEnhanced(ctx, 235, EnhancedCode{2, 7, 0}, "OK, you are now authenticated")

--- a/auth_test.go
+++ b/auth_test.go
@@ -394,8 +394,11 @@ func TestAUTHKeepsTheSessionUnderTheLimit(t *testing.T) {
 }
 
 // TestAUTHSuccessClearsTheFailures verifies that a successful AUTH sets the
-// count back to zero, so that earlier failures never close the session of a
-// client that knows its password.
+// count of failures back to zero.
+//
+// RFC 4954 section 4 gives 503 to a second AUTH, so the count is read again
+// only where STARTTLS opened the session to one. The handshake drops what the
+// client sent in plain text, and an AUTH command can follow it.
 func TestAUTHSuccessClearsTheFailures(t *testing.T) {
 	t.Parallel()
 
@@ -409,34 +412,42 @@ func TestAUTHSuccessClearsTheFailures(t *testing.T) {
 		},
 	}
 
-	srv := runsslserver(t, &smtpd.Server{
+	ts := newTestServer(t, &smtpd.Server{
 		Logger:          testLogger(t),
 		MaxAuthAttempts: 3,
-	}, auth)
+		// The AUTH before the handshake needs a server that takes one.
+		AllowInsecureAuth: true,
+	}, []smtpd.Middleware{auth})
+	ts.StartSTARTTLS()
 
-	c := srv.Dial()
+	c := dialRaw(t, ts.Addr)
+	c.send("EHLO before-tls.example")
 
 	for i := range 2 {
-		if err := smtptest.Cmd(c.Text, 535, "AUTH PLAIN %s", authPLAIN("user", "wrong")); err != nil {
-			t.Fatalf("attempt %d did not get 535: %v", i+1, err)
+		if reply := c.send("AUTH PLAIN %s", authPLAIN("user", "wrong")); !strings.HasPrefix(reply, "535") {
+			t.Fatalf("attempt %d = %q, want 535", i+1, reply)
 		}
 	}
 
-	if err := smtptest.Cmd(c.Text, 235, "AUTH PLAIN %s", authPLAIN("user", "right")); err != nil {
-		t.Fatalf("the good password did not get 235: %v", err)
+	if reply := c.send("AUTH PLAIN %s", authPLAIN("user", "right")); !strings.HasPrefix(reply, "235") {
+		t.Fatalf("the good password = %q, want 235", reply)
 	}
+
+	c.startTLS()
+	c.send("EHLO after-tls.example")
 
 	// The count started over, so two more failures leave the session open.
+	// Without the reset the first of them would be the third failure of the
+	// session, and it would take a 421 and a closed connection.
 	for i := range 2 {
-		if err := smtptest.Cmd(c.Text, 535, "AUTH PLAIN %s", authPLAIN("user", "wrong")); err != nil {
-			t.Fatalf("attempt %d after the success did not get 535: %v", i+1, err)
+		if reply := c.send("AUTH PLAIN %s", authPLAIN("user", "wrong")); !strings.HasPrefix(reply, "535") {
+			t.Fatalf("attempt %d after the handshake = %q, want 535", i+1, reply)
 		}
 	}
 
-	if err := smtptest.Cmd(c.Text, 250, "NOOP"); err != nil {
-		t.Fatalf("the session closed after a successful AUTH cleared the count: %v", err)
+	if reply := c.send("NOOP"); !strings.HasPrefix(reply, "250") {
+		t.Fatalf("the session closed after a successful AUTH cleared the count: %q", reply)
 	}
-	_ = c.Quit()
 }
 
 // TestAUTHUnlimitedAttempts verifies that a limit of -1 closes no connection,
@@ -502,4 +513,58 @@ func TestAUTHDefaultAttemptLimit(t *testing.T) {
 	if err := smtptest.Cmd(c.Text, 421, "AUTH PLAIN %s", authPLAIN("user", "wrong")); err != nil {
 		t.Fatalf("the fifth attempt did not get 421: %v", err)
 	}
+}
+
+// TestAUTHAfterSuccessIsRefused verifies that a second AUTH gets a 503. RFC
+// 4954 section 4 asks the server to reject every AUTH command that follows a
+// successful one in the same session.
+func TestAUTHAfterSuccessIsRefused(t *testing.T) {
+	t.Parallel()
+
+	srv := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, acceptAuth())
+
+	c := srv.Dial()
+
+	if err := smtptest.Cmd(c.Text, 235, "AUTH PLAIN %s", authPLAIN("user", "pass")); err != nil {
+		t.Fatalf("the first AUTH did not get 235: %v", err)
+	}
+
+	if err := smtptest.Cmd(c.Text, 503, "AUTH PLAIN %s", authPLAIN("user", "pass")); err != nil {
+		t.Fatalf("the second AUTH did not get 503: %v", err)
+	}
+
+	// The session goes on: a refused sequence is not a reason to close it.
+	if err := smtptest.Cmd(c.Text, 250, "NOOP"); err != nil {
+		t.Fatalf("the session did not take a command after the refusal: %v", err)
+	}
+	_ = c.Quit()
+}
+
+// TestAUTHAfterFailureIsAllowed verifies that a refused AUTH leaves the
+// session able to try again. Only a successful one closes the door.
+func TestAUTHAfterFailureIsAllowed(t *testing.T) {
+	t.Parallel()
+
+	// The hook refuses the password "wrong" and takes every other one.
+	auth := smtpd.Middleware{
+		Authenticate: func(ctx context.Context, _ smtpd.Peer, _, pass string) (context.Context, error) {
+			if pass == "wrong" {
+				return ctx, smtpd.Error{Code: 535, Message: "Denied"}
+			}
+			return ctx, nil
+		},
+	}
+
+	srv := runsslserver(t, &smtpd.Server{Logger: testLogger(t)}, auth)
+
+	c := srv.Dial()
+
+	if err := smtptest.Cmd(c.Text, 535, "AUTH PLAIN %s", authPLAIN("user", "wrong")); err != nil {
+		t.Fatalf("the failed AUTH did not get 535: %v", err)
+	}
+
+	if err := smtptest.Cmd(c.Text, 235, "AUTH PLAIN %s", authPLAIN("user", "right")); err != nil {
+		t.Fatalf("the AUTH after a failure did not get 235: %v", err)
+	}
+	_ = c.Quit()
 }

--- a/session.go
+++ b/session.go
@@ -46,6 +46,14 @@ type session struct {
 	// successful AUTH sets it back to zero.
 	authFailures int
 
+	// authenticated says that an AUTH command of this session succeeded. RFC
+	// 4954 section 4 gives 503 to every AUTH command after that one.
+	//
+	// It stands apart from Peer.Username, which an XCLIENT command writes as
+	// well: the rule is about the AUTH commands of the session, and a proxy
+	// that names the user of the connection ran none.
+	authenticated bool
+
 	// ranCommand says that the session ran a command already. A PROXY header
 	// stands before everything else: the proxy writes it, and only then does
 	// it pass on what the client sends. A PROXY command that comes later

--- a/starttls.go
+++ b/starttls.go
@@ -43,6 +43,14 @@ func (s *session) handleSTARTTLS(ctx context.Context, cmd *command) context.Cont
 	s.peer.Protocol = ""
 	s.peer.Username = ""
 
+	// The session takes an AUTH command again, because the one before the
+	// handshake went over the wire in plain text.
+	//
+	// The count of the failed attempts stays. It bounds what the client may
+	// try on this connection, and it says nothing about the client, so a
+	// client that could set it back would take its guesses over again.
+	s.authenticated = false
+
 	ctx = s.reset(ctx)
 
 	// Reset deadlines on the underlying connection before I replace it

--- a/starttls_test.go
+++ b/starttls_test.go
@@ -374,3 +374,33 @@ func TestShutdownDuringSTARTTLSUpgrade(t *testing.T) {
 		wg.Wait()
 	}
 }
+
+// TestSTARTTLSTakesANewAUTH verifies that the session takes an AUTH command
+// again after the handshake. RFC 4954 section 4 gives 503 to a second AUTH,
+// and RFC 3207 section 4.2 asks the server to drop what it learned from the
+// client before TLS, so the AUTH before the handshake must not stand in the
+// way of the one after it.
+func TestSTARTTLSTakesANewAUTH(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, &smtpd.Server{
+		Logger: testLogger(t),
+		// The AUTH before the handshake needs a server that takes one.
+		AllowInsecureAuth: true,
+	}, []smtpd.Middleware{acceptAuth()})
+	ts.StartSTARTTLS()
+
+	c := dialRaw(t, ts.Addr)
+	c.send("EHLO before-tls.example")
+
+	if reply := c.send("AUTH PLAIN %s", authPLAIN("user", "pass")); !strings.HasPrefix(reply, "235") {
+		t.Fatalf("the AUTH before TLS = %q, want 235", reply)
+	}
+
+	c.startTLS()
+	c.send("EHLO after-tls.example")
+
+	if reply := c.send("AUTH PLAIN %s", authPLAIN("user", "pass")); !strings.HasPrefix(reply, "235") {
+		t.Fatalf("the AUTH after TLS = %q, want 235", reply)
+	}
+}


### PR DESCRIPTION
RFC 4954 section 4 lets one `AUTH` command succeed in a session, and asks the
server to answer `503` to every `AUTH` command after it. The server took every
one of them and wrote `Peer.Username` again.

A client could therefore take a second identity on a session whose earlier
commands ran under the first. What that is worth depends on the handler: the
hooks read `Peer.Username`, and a handler that keeps the message under the
name it reads at `MAIL FROM` sees one user where two acted.

## What changes

A second `AUTH` gets `503 5.5.1 Already authenticated`. The session goes on:
a refused sequence is no reason to close it.

A refused `AUTH` closes no door. Only a successful one does, and
`Server.MaxAuthAttempts` still bounds how many a client may send.

A successful `STARTTLS` opens the session to a new `AUTH`, because the
handshake drops everything the client sent in plain text. The count of the
failed attempts stays across the handshake: it bounds what the client may try
on this connection and says nothing about the client, so a client that could
set it back would take its guesses over again.

The session holds this state apart from `Peer.Username`, which an `XCLIENT`
command writes as well. The rule is about the `AUTH` commands of the session,
and a proxy that names the user of the connection ran none. Reading
`Peer.Username` would have made `XCLIENT LOGIN=` refuse an `AUTH` that no
specification refuses.

## One existing test moved

`TestAUTHSuccessClearsTheFailures` sent a second `AUTH` after a successful
one, which is the sequence this refuses. The reset of the count is now read
again only after a handshake, so the test goes through `STARTTLS`, which is
the path where it is still reachable.

## Tests

A second `AUTH` gets `503` and the session stays open. An `AUTH` after a
failed one is taken. An `AUTH` after `STARTTLS` is taken. The first of these
fails on the old code.

