### PR TITLE
feat: take PROXY and XCLIENT from a trusted proxy alone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- `Server.MaxAuthAttempts` closes a connection whose `AUTH` commands keep
+  failing. RFC 4954 section 6 asks for such a limit: `PLAIN` and `LOGIN` both
+  carry a password, and one connection took as many guesses as the client
+  cared to send.
+
+  Only a refusal from the `Authenticate` hooks counts, and a successful `AUTH`
+  sets the count back to zero.
+
+  **This changes behavior.** The default is 5, so a client that fails five
+  times now gets a `421` reply and a closed connection, where it could go on
+  before. Set the field to `-1` for the behavior of earlier versions.
+
 - `Server.TrustedProxies` holds the addresses that may restate the identity of
   the client, with a PROXY protocol header or an `XCLIENT` command. Both write
   `Peer.Addr`, which the greylist, the RBL check, the rate limit and the SPF
@@ -50,6 +62,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and a closed session for a `PROXY` command. A header of version 2 from one
   ends the session without a reply, and the `Disconnect` hooks read a
   `ProxyError`.
+
+  A session that took a PROXY header for a client behind the proxy answers
+  `550` to an `XCLIENT` command as well. Everything after such a header comes
+  from that client, and the address of the connection stays that of the proxy,
+  so it says nothing about who wrote the command. A header of the `LOCAL`
+  command leaves `XCLIENT` open, because the proxy opened that connection for
+  itself.
 
   **This changes behavior.** An empty list trusts the addresses that the public
   internet does not reach: the loopback addresses, the private ranges of RFC
@@ -66,20 +85,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The list replaces the default rule rather than adding to it, so a server
   that names its proxies and still takes connections over the loopback
   interface names that range too.
-
-### Security
-
-- `Server.MaxAuthAttempts` closes a connection whose `AUTH` commands keep
-  failing. RFC 4954 section 6 asks for such a limit: `PLAIN` and `LOGIN` both
-  carry a password, and one connection took as many guesses as the client
-  cared to send.
-
-  Only a refusal from the `Authenticate` hooks counts, and a successful `AUTH`
-  sets the count back to zero.
-
-  **This changes behavior.** The default is 5, so a client that fails five
-  times now gets a `421` reply and a closed connection, where it could go on
-  before. Set the field to `-1` for the behavior of earlier versions.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- `Server.TrustedProxies` holds the addresses that may restate the identity of
+  the client, with a PROXY protocol header or an `XCLIENT` command. Both write
+  `Peer.Addr`, which the greylist, the RBL check, the rate limit and the SPF
+  check all read, so a client that reached either one took the identity of any
+  client it named.
+
+  The server reads the address of the connection, and never `Peer.Addr`: a
+  header that arrived already wrote that one, so a client could otherwise name
+  a trusted address and then act on it.
+
+  A client that is not trusted gets `550` for an `XCLIENT` command, and `550`
+  and a closed session for a `PROXY` command. A header of version 2 from one
+  ends the session without a reply, and the `Disconnect` hooks read a
+  `ProxyError`.
+
+  **This changes behavior.** An empty list trusts the addresses that the public
+  internet does not reach: the loopback addresses, the private ranges of RFC
+  1918 and RFC 4193, and the link-local addresses. A proxy that reaches the
+  server from any other address, such as a load balancer with a public one,
+  has to be named:
+
+  ```go
+  srv.TrustedProxies = []netip.Prefix{
+      netip.MustParsePrefix("203.0.113.7/32"),
+  }
+  ```
+
+  The list replaces the default rule rather than adding to it, so a server
+  that names its proxies and still takes connections over the loopback
+  interface names that range too.
+
+### Security
+
 - `Server.MaxAuthAttempts` closes a connection whose `AUTH` commands keep
   failing. RFC 4954 section 6 asks for such a limit: `PLAIN` and `LOGIN` both
   carry a password, and one connection took as many guesses as the client

--- a/README.md
+++ b/README.md
@@ -350,8 +350,19 @@ The server reads the address of the connection, and never `Peer.Addr`. A
 client that could authorize itself with the address it just sent would get
 past the list in two steps.
 
-A connection that carries no IP address, such as a unix socket, is always
-trusted: a local process is at the other end of one.
+A unix socket and a pipe are always trusted: they carry no address to match,
+and a local process is at the other end of one. An address of any other kind
+that carries no IP is refused, because no prefix can name it either.
+
+A session that took a PROXY header for a client behind the proxy takes no
+`XCLIENT` command, and answers `550` to one. The proxy writes its header and
+then passes on what the client sends, so every octet after the header comes
+from that client. The address of the connection is still that of the proxy,
+so it says nothing about who wrote the command, and the client would take an
+identity of its own with it.
+
+A header of the `LOCAL` command leaves `XCLIENT` open. The proxy opened such a
+connection for itself, so the proxy is the one that speaks SMTP on it.
 
 The list bounds who may speak for another client. It does not turn the
 features on: without `Server.EnableProxyProtocol` or `Server.EnableXCLIENT`

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Features
   ([RFC 6531](https://www.rfc-editor.org/rfc/rfc6531)), off by default
 * [XCLIENT](http://www.postfix.org/XCLIENT_README.html) and the
   [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt),
-  version 1 and version 2
+  version 1 and version 2, from trusted proxies alone
 * `VRFY` ([RFC 5321](https://www.rfc-editor.org/rfc/rfc5321)), through a
   middleware hook
 * LMTP ([RFC 2033](https://www.rfc-editor.org/rfc/rfc2033)), with one reply
@@ -307,6 +307,56 @@ Commands that arrive in the same write as `STARTTLS` never run. The session
 builds a new reader on the TLS connection, so the bytes that were read into
 the buffer with `STARTTLS` are dropped.
 
+### Trusted proxies
+
+The `XCLIENT` command and the PROXY protocol both let the sender restate who
+the client is. `Peer.Addr` is what the greylist, the RBL check, the rate limit
+and the SPF check all read, so a client that reaches either one takes the
+identity of any client it names.
+
+`Server.TrustedProxies` holds the addresses that may do that. It is one list
+for both features.
+
+An empty list trusts the addresses that the public internet does not reach:
+the loopback addresses, the private ranges of
+[RFC 1918](https://www.rfc-editor.org/rfc/rfc1918) and
+[RFC 4193](https://www.rfc-editor.org/rfc/rfc4193), and the link-local
+addresses. That covers a proxy that stands beside the server or on the network
+of the server.
+
+Name the addresses where the proxy reaches the server from another network,
+such as a load balancer with a public address:
+
+```go
+srv.TrustedProxies = []netip.Prefix{
+    netip.MustParsePrefix("203.0.113.7/32"),
+}
+```
+
+The list replaces the default rule rather than adding to it. A server that
+names its proxies and still takes connections over the loopback interface
+names that range too:
+
+```go
+srv.TrustedProxies = []netip.Prefix{
+    netip.MustParsePrefix("203.0.113.7/32"),
+    netip.MustParsePrefix("127.0.0.0/8"),
+    netip.MustParsePrefix("::1/128"),
+}
+```
+
+The server reads the address of the connection, and never `Peer.Addr`. A
+`PROXY` header writes `Peer.Addr` before any `XCLIENT` command arrives, so a
+client that could authorize itself with the address it just sent would get
+past the list in two steps.
+
+A connection that carries no IP address, such as a unix socket, is always
+trusted: a local process is at the other end of one.
+
+The list bounds who may speak for another client. It does not turn the
+features on: without `Server.EnableProxyProtocol` or `Server.EnableXCLIENT`
+the server takes neither, from any address.
+
 ### XCLIENT
 
 Set `Server.EnableXCLIENT` to let a proxy in front of the server give the
@@ -314,9 +364,11 @@ identity of the client it took the connection from. `ADDR` and `PORT` replace
 `Peer.Addr`, `HELO` replaces `Peer.HeloName`, `LOGIN` replaces
 `Peer.Username`, and `PROTO` replaces `Peer.Protocol`.
 
-Turn this on only where a proxy you trust reaches the server. The command
-gives the client any identity it asks for, and middleware such as the
-greylist, the RBL check and the rate limit all read `Peer.Addr`.
+The command gives the client any identity it asks for, and middleware such as
+the greylist, the RBL check and the rate limit all read `Peer.Addr`, so only a
+trusted proxy may send one. See [Trusted proxies](#trusted-proxies). A client
+that is not trusted gets a `550`, and the session goes on with the address of
+the connection.
 
 Attribute values arrive in the xtext encoding of RFC 1891, where `+` starts a
 byte written as two hexadecimal digits. The server decodes them, so
@@ -333,6 +385,11 @@ Set `Server.EnableProxyProtocol` to take the header that a proxy such as
 HAProxy writes ahead of the session. The address of the client goes on
 `Peer.Addr`, so the middleware that reads it sees the client and not the
 proxy.
+
+Only a trusted proxy may send a header. See [Trusted
+proxies](#trusted-proxies). A `PROXY` command from an address that is not
+trusted gets a `550` and the session ends, and a header of version 2 from one
+ends the session without a reply.
 
 The server takes both versions of the
 [protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt).

--- a/proxy.go
+++ b/proxy.go
@@ -79,6 +79,10 @@ func (s *session) handlePROXY(ctx context.Context, cmd *command) context.Context
 	}
 	s.peer.Addr = updated
 
+	// The proxy passes on what the client sends from here, so no command
+	// after this one comes from the proxy.
+	s.proxied = true
+
 	return s.welcome(ctx)
 
 }
@@ -228,6 +232,9 @@ func (s *session) readProxyV2() (found bool, err error) {
 		// the connection are the ones of the session.
 		return true, nil
 	case proxyV2Proxy:
+		// A client stands behind the proxy, and the proxy passes on what that
+		// client sends from here.
+		s.proxied = true
 	default:
 		return true, ProxyError{Reason: fmt.Sprintf("command %d is neither LOCAL nor PROXY", command)}
 	}

--- a/proxy.go
+++ b/proxy.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"strconv"
 	"time"
@@ -16,6 +17,23 @@ func (s *session) handlePROXY(ctx context.Context, cmd *command) context.Context
 
 	if !s.server.EnableProxyProtocol {
 		return s.replyEnhanced(ctx, 550, EnhancedCode{5, 7, 0}, "Proxy Protocol not enabled")
+	}
+
+	// The command writes the address that every hook after it reads, so only a
+	// proxy that the server trusts may send one. The reply says no more than
+	// that the command was refused, and the log carries the address.
+	//
+	// The session ends with the reply. A server that takes the protocol holds
+	// the greeting back until a header arrives, so the sender of this command
+	// is a client on a listener that the proxy alone should reach, and it has
+	// no session to go on with.
+	if !s.server.trustsProxy(s.rawConn.RemoteAddr()) {
+		LoggerFromContext(ctx).WarnContext(ctx, "refused a PROXY command from an address that is not a trusted proxy",
+			slog.String("address", s.rawConn.RemoteAddr().String()),
+			slog.String("remedy", "add the address to Server.TrustedProxies"),
+		)
+		ctx = s.replyEnhanced(ctx, 550, EnhancedCode{5, 7, 0}, "PROXY is not accepted from this address")
+		return s.close(ctx)
 	}
 
 	// The proxy writes its header before it passes on anything of the client,
@@ -160,6 +178,16 @@ func (s *session) readProxyV2() (found bool, err error) {
 	}
 	if first[0] != proxyV2Signature[0] {
 		return false, nil
+	}
+
+	// A header stands here and nothing else does, so the trust of the sender
+	// decides before the octets come off the stream. A header takes no reply,
+	// so a sender that the server does not trust ends the session: it asked to
+	// speak for another client, and the server cannot let it.
+	if !s.server.trustsProxy(s.rawConn.RemoteAddr()) {
+		return true, ProxyError{
+			Reason: fmt.Sprintf("%s is not a trusted proxy, and only Server.TrustedProxies names one", s.rawConn.RemoteAddr()),
+		}
 	}
 
 	// The first octet belongs to a header of version 2 and to nothing else,

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -7,7 +7,9 @@ import (
 	"errors"
 	"io"
 	"net"
+	"net/netip"
 	"net/textproto"
+	"strings"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -643,4 +645,128 @@ func TestPROXYV2ClosesTheFirstLine(t *testing.T) {
 	}
 
 	_ = smtptest.Cmd(tp, 221, "QUIT")
+}
+
+// untrustedProxies names a range that holds no loopback address, so a client
+// that reaches the server over the loopback interface is not a trusted proxy.
+// It is how a test reaches the refusal without a listener off the machine.
+func untrustedProxies() []netip.Prefix {
+	return []netip.Prefix{netip.MustParsePrefix("203.0.113.0/24")}
+}
+
+// TestPROXYFromAnUntrustedAddress verifies that a PROXY command from an
+// address outside Server.TrustedProxies is refused, and that the session ends
+// with the refusal. The command writes Peer.Addr, which the greylist, the RBL
+// check and the rate limit all read.
+//
+// A server that takes the protocol holds the greeting back until a header
+// arrives, so a client that gets here has no session to go on with.
+func TestPROXYFromAnUntrustedAddress(t *testing.T) {
+	t.Parallel()
+
+	cap := &capturedAddr{}
+	srv := runserver(t, &smtpd.Server{
+		EnableProxyProtocol: true,
+		TrustedProxies:      untrustedProxies(),
+		Logger:              testLogger(t),
+	}, capturePeerAddr(cap))
+
+	tp, conn := dialRawProxy(t, srv.Addr)
+	defer func() { _ = conn.Close() }()
+
+	if err := smtptest.Cmd(tp, 550, "PROXY TCP4 42.42.42.42 5.6.7.8 4242 25"); err != nil {
+		t.Fatalf("the PROXY command from an untrusted address did not get 550: %v", err)
+	}
+
+	// The session is over, so the command after it never gets a reply.
+	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	if err := smtptest.Cmd(tp, 250, "EHLO client.example"); err == nil {
+		t.Fatal("the session took a command after the refusal")
+	}
+
+	// No hook ran, so nothing saw the address that the command carried.
+	if cap.got != nil {
+		t.Fatalf("a hook saw Peer.Addr = %v, want no hook to run", cap.got)
+	}
+}
+
+// TestPROXYFromATrustedAddress verifies that the command still works for an
+// address that the list names.
+func TestPROXYFromATrustedAddress(t *testing.T) {
+	t.Parallel()
+
+	cap := &capturedAddr{}
+	srv := runserver(t, &smtpd.Server{
+		EnableProxyProtocol: true,
+		TrustedProxies: []netip.Prefix{
+			netip.MustParsePrefix("127.0.0.0/8"),
+			netip.MustParsePrefix("::1/128"),
+		},
+		Logger: testLogger(t),
+	}, capturePeerAddr(cap))
+
+	tp, conn := dialRawProxy(t, srv.Addr)
+	defer func() { _ = conn.Close() }()
+
+	if err := smtptest.Cmd(tp, 220, "PROXY TCP4 42.42.42.42 5.6.7.8 4242 25"); err != nil {
+		t.Fatalf("the PROXY command from a trusted address failed: %v", err)
+	}
+	if err := smtptest.Cmd(tp, 250, "EHLO client.example"); err != nil {
+		t.Fatalf("EHLO failed: %v", err)
+	}
+	if err := smtptest.Cmd(tp, 250, "MAIL FROM:<sender@example.org>"); err != nil {
+		t.Fatalf("MAIL FROM failed: %v", err)
+	}
+
+	got := cap.got
+	if got == nil {
+		t.Fatal("the hook saw no address")
+	}
+	if host, _, _ := net.SplitHostPort(got.String()); host != "42.42.42.42" {
+		t.Fatalf("Peer.Addr = %v, want the address of the header", got)
+	}
+}
+
+// TestPROXYV2FromAnUntrustedAddress verifies that a header of version 2 from
+// an address outside Server.TrustedProxies ends the session. A header takes no
+// reply, so there is none to refuse it with, and the Disconnect hooks read a
+// ProxyError.
+func TestPROXYV2FromAnUntrustedAddress(t *testing.T) {
+	t.Parallel()
+
+	record := &disconnectRecord{}
+	srv := runserver(t, &smtpd.Server{
+		EnableProxyProtocol: true,
+		TrustedProxies:      untrustedProxies(),
+		Logger:              testLogger(t),
+	}, disconnectCounter(record))
+
+	conn, err := net.Dial("tcp", srv.Addr)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	header := proxyV2Header(0x1, 0x11, proxyV2Addrs("42.42.42.42", "5.6.7.8", 4242, 25))
+	if _, err := conn.Write(header); err != nil {
+		t.Fatalf("the header could not be written: %v", err)
+	}
+
+	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	if line, err := textproto.NewConn(conn).ReadLine(); err == nil {
+		t.Fatalf("the server answered %q, want a session that ends", line)
+	}
+
+	count, lastErr := waitDisconnect(record, 3*time.Second)
+	if count != 1 {
+		t.Fatalf("the Disconnect hook ran %d times, want 1", count)
+	}
+
+	var proxyErr smtpd.ProxyError
+	if !errors.As(lastErr, &proxyErr) {
+		t.Fatalf("the Disconnect hook read %v, want a ProxyError", lastErr)
+	}
+	if !strings.Contains(proxyErr.Reason, "trusted proxy") {
+		t.Errorf("the ProxyError says %q, want a reason that names the trust", proxyErr.Reason)
+	}
 }

--- a/session.go
+++ b/session.go
@@ -61,6 +61,16 @@ type session struct {
 	// the address that every hook after it reads.
 	ranCommand bool
 
+	// proxied says that a PROXY header stood for a client behind the proxy.
+	// Everything after such a header comes from that client, and the address
+	// of the connection stays that of the proxy, so it says nothing about who
+	// sent what follows. An XCLIENT command from there is a client asking for
+	// an identity of its own.
+	//
+	// A header of the LOCAL command leaves this false. The proxy opened that
+	// connection for itself, so the proxy is the one that speaks SMTP on it.
+	proxied bool
+
 	// readErr holds the error that ended the reading of the connection. A
 	// read that failed once fails from then on, in the way that a
 	// bufio.Scanner stops for good. Without that, an AUTH command whose

--- a/smtpd.go
+++ b/smtpd.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/netip"
 	"runtime/debug"
 	"sync"
 	"sync/atomic"
@@ -251,6 +252,39 @@ type Server struct {
 	// another one starts over. Pair it with middleware.AuthRateLimit, which
 	// holds the failures of an address across connections.
 	MaxAuthAttempts int // default 5; -1 unlimited
+
+	// TrustedProxies holds the addresses that may restate the identity of the
+	// client that reaches the server, with a PROXY protocol header or an
+	// XCLIENT command. Both write Peer.Addr, which the greylist, the RBL
+	// check and the rate limit all read, so a client that reaches either one
+	// takes the identity of any client it names.
+	//
+	// The server reads the address of the connection, and never Peer.Addr: a
+	// header that arrived already wrote that one.
+	//
+	// An empty list trusts the addresses that the public internet does not
+	// reach: the loopback addresses, the private ranges of RFC 1918 and RFC
+	// 4193, and the link-local addresses. That covers a proxy that stands
+	// beside the server or on the network of the server.
+	//
+	// Give the list where the proxy reaches the server from another network,
+	// such as a load balancer with a public address:
+	//
+	//	srv.TrustedProxies = []netip.Prefix{
+	//	    netip.MustParsePrefix("203.0.113.7/32"),
+	//	}
+	//
+	// A client that is not trusted gets 550 for an XCLIENT command and for a
+	// PROXY command, and its session ends without a reply for a PROXY header
+	// of version 2. The address of the connection stays on Peer.Addr.
+	//
+	// A connection that carries no IP address, such as a unix socket, is
+	// always trusted: a local process is at the other end of one.
+	//
+	// The list bounds who may speak for another client. It does not turn the
+	// extensions on: without Server.EnableProxyProtocol or
+	// Server.EnableXCLIENT the server takes neither, from any address.
+	TrustedProxies []netip.Prefix
 
 	// Extensions
 	EnableXCLIENT bool
@@ -552,6 +586,16 @@ func (srv *Server) configureDefaults() error {
 	}
 	if srv.Hostname == "" {
 		srv.Hostname = "localhost.localdomain"
+	}
+
+	// A prefix that does not read matches no address, so the server would
+	// refuse every proxy and say only that the address is not trusted. The
+	// zero value of netip.Prefix is the one that arrives here, from a
+	// netip.ParsePrefix whose error the caller passed over.
+	for i, prefix := range srv.TrustedProxies {
+		if !prefix.IsValid() {
+			return fmt.Errorf("smtpd: Server.TrustedProxies[%d] is not a prefix that reads, and it would match no address", i)
+		}
 	}
 	if srv.WelcomeMessage == "" {
 		protocol := ESMTP

--- a/smtpd.go
+++ b/smtpd.go
@@ -278,8 +278,14 @@ type Server struct {
 	// PROXY command, and its session ends without a reply for a PROXY header
 	// of version 2. The address of the connection stays on Peer.Addr.
 	//
-	// A connection that carries no IP address, such as a unix socket, is
-	// always trusted: a local process is at the other end of one.
+	// A unix socket and a pipe are always trusted: they carry no address to
+	// match, and a local process is at the other end of one. An address of any
+	// other kind that carries no IP is refused, because no prefix can name it
+	// either.
+	//
+	// A session that took a PROXY header for a client behind the proxy takes
+	// no XCLIENT command. The proxy passes on what that client sends, so the
+	// address of the connection says nothing about who wrote the command.
 	//
 	// The list bounds who may speak for another client. It does not turn the
 	// extensions on: without Server.EnableProxyProtocol or

--- a/trust.go
+++ b/trust.go
@@ -1,0 +1,62 @@
+package smtpd
+
+import (
+	"net"
+	"net/netip"
+)
+
+// connIP gives the address of a connection. ok is false for a connection that
+// carries no IP address, such as a unix socket.
+//
+// The address comes back unmapped, because netip.Prefix.Contains matches an
+// IPv4 address against an IPv4 prefix alone: the 4-in-6 form of the same
+// address matches neither that prefix nor an IPv6 one.
+func connIP(addr net.Addr) (netip.Addr, bool) {
+	tcpAddr, ok := addr.(*net.TCPAddr)
+	if !ok {
+		return netip.Addr{}, false
+	}
+
+	ip, ok := netip.AddrFromSlice(tcpAddr.IP)
+	if !ok {
+		return netip.Addr{}, false
+	}
+
+	return ip.Unmap(), true
+}
+
+// trustsProxy reports whether the client at addr may restate the identity of
+// the client behind it, with a PROXY protocol header or an XCLIENT command.
+//
+// addr is the address of the connection, and never Peer.Addr: a header that
+// arrived already wrote that one, so reading it would let a client authorize
+// itself with the address that it just sent.
+func (srv *Server) trustsProxy(addr net.Addr) bool {
+	ip, ok := connIP(addr)
+	if !ok {
+		// A connection without an IP address is a unix socket or a pipe. A
+		// local process is at the other end of one, and it reaches the server
+		// without crossing a network.
+		return true
+	}
+
+	if len(srv.TrustedProxies) == 0 {
+		return defaultTrustedIP(ip)
+	}
+
+	for _, prefix := range srv.TrustedProxies {
+		if prefix.Contains(ip) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// defaultTrustedIP reports whether an address is one that the public internet
+// does not reach. It is the rule that a server without Server.TrustedProxies
+// takes, and it covers the deployment where a proxy stands beside the server
+// or on the network of the server.
+func defaultTrustedIP(ip netip.Addr) bool {
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast()
+}

--- a/trust.go
+++ b/trust.go
@@ -34,10 +34,12 @@ func connIP(addr net.Addr) (netip.Addr, bool) {
 func (srv *Server) trustsProxy(addr net.Addr) bool {
 	ip, ok := connIP(addr)
 	if !ok {
-		// A connection without an IP address is a unix socket or a pipe. A
-		// local process is at the other end of one, and it reaches the server
-		// without crossing a network.
-		return true
+		// A unix socket and a pipe carry no address, and a local process is at
+		// the other end of one. Every other address that carries no IP is one
+		// that this reader cannot place, and a list of prefixes cannot name it
+		// either, so trusting it would put a sender past a list that names the
+		// proxies of the server.
+		return isLocalTransport(addr)
 	}
 
 	if len(srv.TrustedProxies) == 0 {
@@ -50,6 +52,22 @@ func (srv *Server) trustsProxy(addr net.Addr) bool {
 		}
 	}
 
+	return false
+}
+
+// isLocalTransport reports whether a connection reached the server without
+// crossing a network. Such a connection carries no address to match, and a
+// local process is at the other end of it.
+//
+// Server.Serve takes a listener of any kind, so an address of another kind can
+// arrive here. This reader cannot place one, and it refuses what it cannot
+// place: an address that no prefix can name must not stand where a list names
+// the proxies of the server.
+func isLocalTransport(addr net.Addr) bool {
+	switch addr.Network() {
+	case "unix", "unixgram", "unixpacket", "pipe":
+		return true
+	}
 	return false
 }
 

--- a/trust_test.go
+++ b/trust_test.go
@@ -156,3 +156,51 @@ func TestServeRefusesAnInvalidPrefix(t *testing.T) {
 		t.Fatalf("Serve() = %v, want an error that names the prefix", err)
 	}
 }
+
+// unknownAddr is a net.Addr of a kind that this package does not know. A
+// listener of the caller can hand one to Serve.
+type unknownAddr struct{}
+
+func (unknownAddr) Network() string { return "custom" }
+func (unknownAddr) String() string  { return "custom-remote" }
+
+// TestTrustsProxyRefusesAnUnknownAddress verifies that an address of a kind
+// the reader does not know is refused.
+//
+// A unix socket and a pipe carry no IP and reach the server without a
+// network, so they stand. Every other address that carries no IP is one that
+// nothing here can place, and a list of prefixes cannot describe it either,
+// so trusting it would put a client past a list that names its proxies.
+func TestTrustsProxyRefusesAnUnknownAddress(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	t.Cleanup(func() { _ = client.Close(); _ = server.Close() })
+
+	tests := []struct {
+		name string
+		addr net.Addr
+		want bool
+	}{
+		{name: "unix socket", addr: &net.UnixAddr{Name: "/run/smtpd.sock", Net: "unix"}, want: true},
+		{name: "pipe", addr: client.RemoteAddr(), want: true},
+		{name: "an address of a kind that is not known", addr: unknownAddr{}, want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// The rule holds for a server that names its proxies and for one
+			// that names none.
+			if got := (&Server{}).trustsProxy(test.addr); got != test.want {
+				t.Errorf("with no list, trustsProxy(%v) = %v, want %v", test.addr, got, test.want)
+			}
+
+			listed := &Server{TrustedProxies: []netip.Prefix{netip.MustParsePrefix("203.0.113.0/24")}}
+			if got := listed.trustsProxy(test.addr); got != test.want {
+				t.Errorf("with a list, trustsProxy(%v) = %v, want %v", test.addr, got, test.want)
+			}
+		})
+	}
+}

--- a/trust_test.go
+++ b/trust_test.go
@@ -1,0 +1,158 @@
+package smtpd
+
+import (
+	"net"
+	"net/netip"
+	"strings"
+	"testing"
+)
+
+// tcp gives a TCP address for an IP written as text.
+func tcp(ip string) net.Addr {
+	return &net.TCPAddr{IP: net.ParseIP(ip), Port: 2525}
+}
+
+// TestTrustsProxyByDefault covers the rule that a server without
+// TrustedProxies takes: an address that the public internet does not reach
+// may speak for the client behind it, and every other address may not.
+func TestTrustsProxyByDefault(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		addr net.Addr
+		want bool
+	}{
+		{name: "IPv4 loopback", addr: tcp("127.0.0.1"), want: true},
+		{name: "IPv4 loopback of the whole range", addr: tcp("127.9.9.9"), want: true},
+		{name: "IPv6 loopback", addr: tcp("::1"), want: true},
+		{name: "RFC 1918 ten", addr: tcp("10.1.2.3"), want: true},
+		{name: "RFC 1918 172.16", addr: tcp("172.16.0.1"), want: true},
+		{name: "RFC 1918 192.168", addr: tcp("192.168.1.1"), want: true},
+		{name: "RFC 4193 unique local", addr: tcp("fd00::1"), want: true},
+		{name: "IPv4 link-local", addr: tcp("169.254.1.1"), want: true},
+		{name: "IPv6 link-local", addr: tcp("fe80::1"), want: true},
+
+		{name: "public IPv4", addr: tcp("203.0.113.7"), want: false},
+		{name: "public IPv6", addr: tcp("2001:db8::1"), want: false},
+		// 172.32 stands outside the /12 of RFC 1918, which ends at 172.31.
+		{name: "just past RFC 1918 172.16/12", addr: tcp("172.32.0.1"), want: false},
+		// RFC 6598 gives this range to carrier NAT. It is not private, and a
+		// server on such a network names its proxy itself.
+		{name: "carrier NAT", addr: tcp("100.64.0.1"), want: false},
+
+		// A unix socket carries no IP, and a local process is at the far end.
+		{name: "unix socket", addr: &net.UnixAddr{Name: "/run/smtpd.sock", Net: "unix"}, want: true},
+	}
+
+	srv := &Server{}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := srv.trustsProxy(test.addr); got != test.want {
+				t.Fatalf("trustsProxy(%v) = %v, want %v", test.addr, got, test.want)
+			}
+		})
+	}
+}
+
+// TestTrustsProxyFromTheList covers a server that names its proxies. The list
+// replaces the default rule, so an address of a private range that the list
+// leaves out is refused with the rest.
+func TestTrustsProxyFromTheList(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{
+		TrustedProxies: []netip.Prefix{
+			netip.MustParsePrefix("203.0.113.0/24"),
+			netip.MustParsePrefix("2001:db8::/32"),
+		},
+	}
+
+	tests := []struct {
+		name string
+		addr net.Addr
+		want bool
+	}{
+		{name: "inside the IPv4 prefix", addr: tcp("203.0.113.7"), want: true},
+		{name: "the first address of the prefix", addr: tcp("203.0.113.0"), want: true},
+		{name: "the last address of the prefix", addr: tcp("203.0.113.255"), want: true},
+		{name: "outside the IPv4 prefix", addr: tcp("203.0.114.1"), want: false},
+		{name: "inside the IPv6 prefix", addr: tcp("2001:db8::1"), want: true},
+		{name: "outside the IPv6 prefix", addr: tcp("2001:db9::1"), want: false},
+
+		// The list replaces the default rule. A server that names its proxies
+		// says which addresses it trusts, and loopback is not one of them here.
+		{name: "loopback that the list leaves out", addr: tcp("127.0.0.1"), want: false},
+		{name: "private range that the list leaves out", addr: tcp("10.1.2.3"), want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := srv.trustsProxy(test.addr); got != test.want {
+				t.Fatalf("trustsProxy(%v) = %v, want %v", test.addr, got, test.want)
+			}
+		})
+	}
+}
+
+// TestTrustsProxyMatchesTheMappedForm verifies that an IPv4 address that
+// arrives in the 4-in-6 form matches an IPv4 prefix.
+//
+// netip.Prefix.Contains matches neither prefix for such an address, so the
+// reader takes the mapping off. A connection of a server that listens on a
+// dual-stack socket carries an address of that form.
+func TestTrustsProxyMatchesTheMappedForm(t *testing.T) {
+	t.Parallel()
+
+	// The 16-byte form of 203.0.113.7, which is what a dual-stack listener
+	// gives for a client that reaches it over IPv4.
+	mapped := &net.TCPAddr{IP: net.ParseIP("::ffff:203.0.113.7"), Port: 2525}
+	if len(mapped.IP) != 16 {
+		t.Fatalf("the test address is %d bytes, want the 16-byte form", len(mapped.IP))
+	}
+
+	srv := &Server{TrustedProxies: []netip.Prefix{netip.MustParsePrefix("203.0.113.0/24")}}
+	if !srv.trustsProxy(mapped) {
+		t.Fatal("the 4-in-6 form of a trusted address was refused")
+	}
+
+	// The same form takes the default rule as well.
+	loopback := &net.TCPAddr{IP: net.ParseIP("::ffff:127.0.0.1"), Port: 2525}
+	if !(&Server{}).trustsProxy(loopback) {
+		t.Fatal("the 4-in-6 form of the loopback address was refused")
+	}
+}
+
+// TestTrustsProxyRefusesAnEmptyPrefix verifies that a prefix that carries
+// nothing matches no address. The zero value of netip.Prefix is not valid, and
+// a list that holds one must not open the server to every client.
+func TestTrustsProxyRefusesAnEmptyPrefix(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{TrustedProxies: []netip.Prefix{{}}}
+	if srv.trustsProxy(tcp("203.0.113.7")) {
+		t.Fatal("a zero prefix matched an address")
+	}
+}
+
+// TestServeRefusesAnInvalidPrefix verifies that a prefix that does not read
+// stops the server at Serve. Such a prefix matches no address, so the server
+// would otherwise start and refuse every proxy.
+func TestServeRefusesAnInvalidPrefix(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{TrustedProxies: []netip.Prefix{
+		netip.MustParsePrefix("10.0.0.0/8"),
+		{},
+	}}
+
+	err := srv.Serve(nil)
+	if err == nil {
+		t.Fatal("Serve took a prefix that does not read")
+	}
+	if !strings.Contains(err.Error(), "TrustedProxies[1]") {
+		t.Fatalf("Serve() = %v, want an error that names the prefix", err)
+	}
+}

--- a/xclient.go
+++ b/xclient.go
@@ -34,6 +34,17 @@ func (s *session) handleXCLIENT(ctx context.Context, cmd *command) context.Conte
 		return s.replyEnhanced(ctx, 550, EnhancedCode{5, 7, 0}, "XCLIENT is not accepted from this address")
 	}
 
+	// A PROXY header stood for a client behind the proxy, and the proxy passes
+	// on what that client sends. The address of the connection is still that
+	// of the proxy, so it says nothing about who wrote this command, and the
+	// client would take an identity of its own with it.
+	if s.proxied {
+		LoggerFromContext(ctx).WarnContext(ctx, "refused an XCLIENT command that followed a PROXY header",
+			slog.String("address", s.rawConn.RemoteAddr().String()),
+		)
+		return s.replyEnhanced(ctx, 550, EnhancedCode{5, 7, 0}, "XCLIENT is not accepted after a PROXY header")
+	}
+
 	var (
 		newHeloName, newUsername string
 		newProto                 Protocol

--- a/xclient.go
+++ b/xclient.go
@@ -2,6 +2,7 @@ package smtpd
 
 import (
 	"context"
+	"log/slog"
 	"net"
 	"strconv"
 	"strings"
@@ -17,6 +18,20 @@ func (s *session) handleXCLIENT(ctx context.Context, cmd *command) context.Conte
 
 	if !s.server.EnableXCLIENT {
 		return s.replyEnhanced(ctx, 550, EnhancedCode{5, 7, 0}, "XCLIENT not enabled")
+	}
+
+	// The command writes Peer.Addr, Peer.HeloName, Peer.Username and
+	// Peer.Protocol, so only a proxy that the server trusts may send one.
+	//
+	// The address of the connection decides, and never Peer.Addr: a PROXY
+	// header that arrived first already wrote that one, and a client could
+	// otherwise name an address of its own and then act on it.
+	if !s.server.trustsProxy(s.rawConn.RemoteAddr()) {
+		LoggerFromContext(ctx).WarnContext(ctx, "refused an XCLIENT command from an address that is not a trusted proxy",
+			slog.String("address", s.rawConn.RemoteAddr().String()),
+			slog.String("remedy", "add the address to Server.TrustedProxies"),
+		)
+		return s.replyEnhanced(ctx, 550, EnhancedCode{5, 7, 0}, "XCLIENT is not accepted from this address")
 	}
 
 	var (

--- a/xclient_test.go
+++ b/xclient_test.go
@@ -434,3 +434,50 @@ func TestXCLIENTFromATrustedAddress(t *testing.T) {
 		t.Fatalf("Peer.Addr = %v, want 9.9.9.9:999", got)
 	}
 }
+
+// TestXCLIENTAfterAnAcceptedPROXYHeader verifies that a session which took a
+// PROXY header refuses an XCLIENT command.
+//
+// A proxy writes its header and then passes on what the client sends, so
+// every octet after the header comes from the client behind the proxy. The
+// address of the connection stays that of the proxy, and it therefore says
+// nothing about who sent the command.
+func TestXCLIENTAfterAnAcceptedPROXYHeader(t *testing.T) {
+	t.Parallel()
+
+	cap := &capturedPeer{}
+	srv := runserver(t, &smtpd.Server{
+		EnableXCLIENT:       true,
+		EnableProxyProtocol: true,
+		Logger:              testLogger(t),
+	}, capturePeer(cap))
+
+	tp, conn := dialRawProxy(t, srv.Addr)
+	defer func() { _ = conn.Close() }()
+
+	// The loopback address of the connection is trusted, so the header is
+	// taken and the greeting follows it.
+	if err := smtptest.Cmd(tp, 220, "PROXY TCP4 42.42.42.42 5.6.7.8 4242 25"); err != nil {
+		t.Fatalf("the PROXY command was not accepted: %v", err)
+	}
+
+	// The client behind the proxy sends this one.
+	if err := smtptest.Cmd(tp, 550, "XCLIENT ADDR=9.9.9.9 LOGIN=someone"); err != nil {
+		t.Fatalf("the XCLIENT command after a PROXY header did not get 550: %v", err)
+	}
+
+	if err := smtptest.Cmd(tp, 250, "EHLO client.example"); err != nil {
+		t.Fatalf("EHLO failed: %v", err)
+	}
+	if err := smtptest.Cmd(tp, 250, "MAIL FROM:<sender@example.org>"); err != nil {
+		t.Fatalf("MAIL FROM failed: %v", err)
+	}
+
+	// The address of the header stands, and the one of the command does not.
+	if host, _, _ := net.SplitHostPort(cap.got.Addr.String()); host != "42.42.42.42" {
+		t.Fatalf("Peer.Addr = %v, want the address of the PROXY header", cap.got.Addr)
+	}
+	if cap.got.Username == "someone" {
+		t.Error("the refused command wrote Peer.Username")
+	}
+}

--- a/xclient_test.go
+++ b/xclient_test.go
@@ -2,8 +2,11 @@ package smtpd_test
 
 import (
 	"context"
+	"net"
+	"net/netip"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/chrj/smtpd/v2"
 	"github.com/chrj/smtpd/v2/smtptest"
@@ -323,5 +326,111 @@ func TestXCLIENTUnavailableAddressKeepsThePeer(t *testing.T) {
 	}
 	if !strings.HasPrefix(cap.got.Addr.String(), "127.0.0.1:") {
 		t.Errorf("Addr = %v, want the address of the connection", cap.got.Addr)
+	}
+}
+
+// TestXCLIENTFromAnUntrustedAddress verifies that an XCLIENT command from an
+// address outside Server.TrustedProxies is refused. The command writes
+// Peer.Addr, Peer.HeloName, Peer.Username and Peer.Protocol.
+//
+// The session goes on, because a server that takes XCLIENT sends its greeting
+// as any other server does, and the client has an ordinary session to run.
+func TestXCLIENTFromAnUntrustedAddress(t *testing.T) {
+	t.Parallel()
+
+	cap := &capturedPeer{}
+	srv := runserver(t, &smtpd.Server{
+		EnableXCLIENT:  true,
+		TrustedProxies: []netip.Prefix{netip.MustParsePrefix("203.0.113.0/24")},
+		Logger:         testLogger(t),
+	}, capturePeer(cap))
+
+	c := srv.Dial()
+
+	if err := smtptest.Cmd(c.Text, 550, "XCLIENT ADDR=9.9.9.9 PORT=999 LOGIN=someone"); err != nil {
+		t.Fatalf("the XCLIENT command from an untrusted address did not get 550: %v", err)
+	}
+
+	if err := c.Mail("sender@example.org"); err != nil {
+		t.Fatalf("MAIL FROM after the refusal failed: %v", err)
+	}
+
+	if cap.got.Username == "someone" {
+		t.Error("the refused command wrote Peer.Username")
+	}
+	if host, _, _ := net.SplitHostPort(cap.got.Addr.String()); host == "9.9.9.9" {
+		t.Fatalf("Peer.Addr = %v, want the address of the connection", cap.got.Addr)
+	}
+	_ = c.Quit()
+}
+
+// TestXCLIENTAfterPROXYReadsTheConnection verifies that the trust of an
+// XCLIENT command is read from the address of the connection, and never from
+// Peer.Addr.
+//
+// A PROXY header writes Peer.Addr before any XCLIENT command arrives. A client
+// that named a trusted address in the header would otherwise authorize itself
+// for the command that follows it.
+func TestXCLIENTAfterPROXYReadsTheConnection(t *testing.T) {
+	t.Parallel()
+
+	cap := &capturedPeer{}
+	srv := runserver(t, &smtpd.Server{
+		EnableXCLIENT:       true,
+		EnableProxyProtocol: true,
+		// The loopback address of the connection is left out, and the address
+		// that the PROXY command below names is in.
+		TrustedProxies: []netip.Prefix{netip.MustParsePrefix("42.42.42.42/32")},
+		Logger:         testLogger(t),
+	}, capturePeer(cap))
+
+	tp, conn := dialRawProxy(t, srv.Addr)
+	defer func() { _ = conn.Close() }()
+
+	// The PROXY command is refused for the same reason, so the client never
+	// reaches the state it was after.
+	if err := smtptest.Cmd(tp, 550, "PROXY TCP4 42.42.42.42 5.6.7.8 4242 25"); err != nil {
+		t.Fatalf("the PROXY command from an untrusted address did not get 550: %v", err)
+	}
+
+	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	if err := smtptest.Cmd(tp, 250, "XCLIENT ADDR=9.9.9.9"); err == nil {
+		t.Fatal("the session took an XCLIENT command after the refusal")
+	}
+
+	if cap.got.Addr != nil {
+		t.Fatalf("a hook saw Peer.Addr = %v, want no hook to run", cap.got.Addr)
+	}
+}
+
+// TestXCLIENTFromATrustedAddress verifies that the command still works for an
+// address that the list names.
+func TestXCLIENTFromATrustedAddress(t *testing.T) {
+	t.Parallel()
+
+	cap := &capturedPeer{}
+	srv := runserver(t, &smtpd.Server{
+		EnableXCLIENT: true,
+		TrustedProxies: []netip.Prefix{
+			netip.MustParsePrefix("127.0.0.0/8"),
+			netip.MustParsePrefix("::1/128"),
+		},
+		Logger: testLogger(t),
+	}, capturePeer(cap))
+
+	c := srv.Dial()
+
+	if err := smtptest.Cmd(c.Text, 220, "XCLIENT ADDR=9.9.9.9 PORT=999"); err != nil {
+		t.Fatalf("the XCLIENT command from a trusted address failed: %v", err)
+	}
+	if err := smtptest.Cmd(c.Text, 250, "EHLO client.example"); err != nil {
+		t.Fatalf("EHLO failed: %v", err)
+	}
+	if err := smtptest.Cmd(c.Text, 250, "MAIL FROM:<sender@example.org>"); err != nil {
+		t.Fatalf("MAIL FROM failed: %v", err)
+	}
+
+	if got := cap.got.Addr.String(); got != "9.9.9.9:999" {
+		t.Fatalf("Peer.Addr = %v, want 9.9.9.9:999", got)
 	}
 }


### PR DESCRIPTION
A PROXY protocol header and an `XCLIENT` command both restate who the client
is. `Peer.Addr` is what the greylist, the RBL check, the rate limit and the
SPF check all read, so a client that reached either one took the identity of
any client it named. A boolean turned the features on, and the address of the
sender was never read.

This is the finding that the `PROXY` fix in #64 sat next to: that one stopped
a client behind the proxy from sending a second header, and this one stops a
client that is not behind the proxy from sending the first.

## `Server.TrustedProxies`

One list for both features, because both answer the same question: who may
speak for another client.

```go
srv.TrustedProxies = []netip.Prefix{
    netip.MustParsePrefix("203.0.113.7/32"),
}
```

**This changes behavior.** An empty list trusts the addresses that the public
internet does not reach: the loopback addresses, the private ranges of RFC
1918 and RFC 4193, and the link-local addresses. That covers a proxy beside
the server or on the network of the server, which is the common deployment
and needs no configuration.

A proxy that reaches the server from any other address, such as a load
balancer with a public one, has to be named. That deployment breaks on
upgrade until the address is in the list. It breaks loudly: the refusal
carries a log line with the address and the field to add it to.

The list replaces the default rule rather than adding to it, so a server that
names its proxies and still takes connections over the loopback interface
names that range too. Adding to the default would make the field unable to
express "these addresses and no others", which is the point of it.

## The address that decides

The server reads the address of the connection, and never `Peer.Addr`.

A header writes `Peer.Addr` before any `XCLIENT` command arrives, so reading
that field would let a client name a trusted address in the header and pass
the check for the command after it. `TestXCLIENTAfterPROXYReadsTheConnection`
covers that sequence.

## What a refused client gets

| Sender | Reply |
| --- | --- |
| `XCLIENT` from an untrusted address | `550`, and the session goes on |
| `PROXY` command from an untrusted address | `550`, and the session ends |
| PROXY header of version 2 from an untrusted address | no reply, the session ends, `ProxyError` to the `Disconnect` hooks |

The `PROXY` command ends the session because a server that reads the protocol
holds the greeting back until a header arrives. Such a client never had a
greeting and has no session to go on with, so a `550` that left it connected
would leave it waiting on a banner that never comes.

`XCLIENT` is different: that server greets every client, so the session is an
ordinary one and it continues with the address of the connection.

## A prefix that does not read

`Serve` refuses one. `netip.ParsePrefix` returns an error next to the value,
and a caller that passes over it gets the zero prefix, which matches no
address. Without the check the server would start and refuse every proxy,
with nothing but a log line to say why.

## Tests

`trust_test.go` covers the matching: each private range, the edges of a
prefix, the address just past RFC 1918, carrier NAT, IPv6, a unix socket, and
the 4-in-6 form that a dual-stack listener gives. That last one matters
because `netip.Prefix.Contains` matches neither prefix for a mapped address,
so the reader takes the mapping off.

The session tests reach the refusal by naming a range that holds no loopback
address, so a client on the loopback interface is the untrusted one.
