### PR TITLE
ci: add a daily security scan

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.11.3
+          version: v2.13.1
 
   test:
     name: "Go: Test"

--- a/.github/workflows/security-daily.yml
+++ b/.github/workflows/security-daily.yml
@@ -1,0 +1,78 @@
+name: Security (Daily)
+
+on:
+  schedule:
+    - cron: "0 23 * * *" # 11pm UTC (6pm EST / 7pm EDT)
+  workflow_dispatch:
+
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+
+jobs:
+  govulncheck:
+    name: "Go: Vulnerability Check"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Run govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
+          govulncheck -show verbose ./...
+
+  semgrep:
+    name: "Semgrep: Full Scan"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+
+      - name: Install Semgrep
+        run: python -m pip install semgrep==1.171.0
+
+      - name: Run Semgrep
+        run: |
+          semgrep scan \
+            --config p/golang \
+            --config p/security-audit \
+            --error \
+            --sarif --output semgrep.sarif
+
+      - name: Upload SARIF
+        if: always() && hashFiles('semgrep.sarif') != ''
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          sarif_file: semgrep.sarif
+
+  gosec:
+    name: "gosec: Full Scan"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Run gosec
+        run: |
+          go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0
+          gosec -exclude-generated ./...

--- a/_examples/gmail-relay/main.go
+++ b/_examples/gmail-relay/main.go
@@ -54,7 +54,7 @@ func forwardToGmail(user, pass string) smtpd.Handler {
 		if err := c.Hello("localhost"); err != nil {
 			return ctx, relayErr(err)
 		}
-		if err := c.StartTLS(&tls.Config{ServerName: gmailHost}); err != nil {
+		if err := c.StartTLS(&tls.Config{ServerName: gmailHost, MinVersion: tls.VersionTLS12}); err != nil {
 			return ctx, relayErr(err)
 		}
 		if err := c.Auth(auth); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/chrj/smtpd/v2
 
 go 1.25.0
 
+toolchain go1.27.1
+
 require (
 	blitiri.com.ar/go/spf v1.6.0
 	github.com/chrj/keyrate v0.2.5


### PR DESCRIPTION
smtpd had no security scan. The other Go repositories run one every day, and
this workflow is the same one.

## What runs

Three jobs, at 23:00 UTC and on a manual start:

- **govulncheck** `v1.6.0`, for the vulnerabilities of the dependencies and of
  the standard library that this code calls.
- **Semgrep** `1.171.0`, with the `p/golang` and `p/security-audit` rules. The
  job sends a SARIF report to code scanning, which fills the Security tab.
- **gosec** `v2.28.0`.

Each action is pinned to a commit. The workflow of the tests names a tag, and
the other repositories draw the same line between the two files.

## The toolchain line

govulncheck does not pass on the `go` directive alone. It reported 12
vulnerabilities of the standard library that this code calls, and `crypto/tls`
and `crypto/x509` carry most of them:

```
GO-2026-4870  Unauthenticated TLS 1.3 KeyUpdate record can cause persistent
              connection retention and DoS in crypto/tls
GO-2026-4866  Case-sensitive excludedSubtrees name constraints cause Auth
              Bypass in crypto/x509
```

Every session that takes STARTTLS runs that code, so the trace is real and not
a report of something the package holds but never calls.

`toolchain go1.27.1` corrects it. The `go` directive stays at **1.25.0**: it is
the lowest version which can build this module, the README names it, and a
consumer on Go 1.25 reads that line alone. The toolchain line of a dependency
does not reach the module that requires it.

1.27 is the current line. Go keeps the two most recent major versions, so 1.26
leaves that set when 1.28 arrives. `conduit`, `tools`, `zerodrop` and
`prometheus-dnssec-exporter` build with 1.27 as well.

golangci-lint v2.11.3 cannot read a module that targets 1.27, because Go 1.26
built it:

```
can't load config: the Go language version (go1.26) used to build
golangci-lint is lower than the targeted Go version (1.27.1)
```

v2.13.1 is built with Go 1.27, and `tools` and `zerodrop` name that version.
The bump comes first, so every commit of this branch passes the linter.

## The Semgrep finding

The first scan found one thing, in `_examples/gmail-relay/main.go`: the TLS
configuration of the `StartTLS` call named the server and no minimum version.

Go takes TLS 1.2 when the field is empty, so the example already connected
with that version, and the commit writes the field. A reader who copies the
example gets a floor that the code states.

`_examples` starts with an underscore, so `go build` and gosec both pass it
by. Semgrep reads the file.

## Checks

govulncheck, Semgrep and gosec all run clean on this branch, and the tests,
`go vet`, `golangci-lint` and `go mod tidy` do as well.