### PR TITLE
ci: audit the security of a pull request

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -68,3 +68,53 @@ jobs:
 
       - name: Run tests
         run: go test -v -race -count=1 ./...
+  security:
+    name: "Go: Security Audit"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+
+      # Keep the pinned version in sync with .github/workflows/security-daily.yml.
+      - name: Install Semgrep
+        run: python -m pip install semgrep==1.171.0
+
+      - name: Run Semgrep
+        run: |
+          semgrep scan \
+            --config p/golang \
+            --config p/security-audit \
+            --error
+
+      - name: Get changed Go packages
+        id: changed-packages
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+            BASE="origin/${{ github.base_ref }}"
+          else
+            BASE="HEAD~1"
+          fi
+          PKGS=$(git diff --name-only "${BASE}...HEAD" | grep '\.go$' | xargs -r -I{} dirname {} | sort -u | sed 's|^|./|' | tr '\n' ' ')
+          echo "packages=${PKGS}" >> "$GITHUB_OUTPUT"
+
+      - name: Run gosec on changed packages
+        if: steps.changed-packages.outputs.packages != ''
+        run: |
+          go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0
+          gosec -exclude-generated ${{ steps.changed-packages.outputs.packages }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -110,7 +110,7 @@ jobs:
           else
             BASE="HEAD~1"
           fi
-          PKGS=$(git diff --name-only "${BASE}...HEAD" | grep '\.go$' | xargs -r -I{} dirname {} | sort -u | sed 's|^|./|' | tr '\n' ' ')
+          PKGS=$(git diff --name-only "${BASE}...HEAD" | grep '\.go$' | xargs -r -I{} dirname {} | sort -u | grep -vE '(^|/)_' | sed 's|^|./|' | tr '\n' ' ')
           echo "packages=${PKGS}" >> "$GITHUB_OUTPUT"
 
       - name: Run gosec on changed packages

--- a/.github/workflows/security-daily.yml
+++ b/.github/workflows/security-daily.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           python-version: "3.13"
 
+      # Keep the pinned version in sync with .github/workflows/go.yml.
       - name: Install Semgrep
         run: python -m pip install semgrep==1.171.0
 


### PR DESCRIPTION
The daily scan finds a fault as much as a day after the merge. This job runs on
a pull request and on a push to main, so a fault stops at the gate.

## What runs

- **Semgrep** `1.171.0`, `p/golang` and `p/security-audit`, over the whole
  tree. The daily run takes 26 seconds, so a full read costs little. It writes
  no SARIF here: the daily job owns the report to code scanning.
- **gosec** `v2.28.0`, over the packages of the changed Go files alone. The
  step compares against the base branch of the pull request, and against
  `HEAD~1` for a push.

`vanguard` runs the same pair, and the script that reads the changed packages
is the one from that repository.

## What does not run

govulncheck stays in the daily workflow.

It reports the vulnerabilities of the standard library that the code calls, and
one arrives on the day the Go team publishes it, under no change here. Such a
report would stop every open pull request for a reason that belongs to none of
them, which is what happened to `prometheus-dnssec-exporter` last week: a
dependency bump sat red for two days behind three advisories that the branch
did not cause.

The daily job catches the same thing within a day and stops nobody.

## Checks of the script

The step passes the packages to gosec as a list. Three inputs of this
repository could go wrong, and gosec takes all of them:

| Input | Where it comes from | Result |
|---|---|---|
| `./.` | a change to a file of the root package | scans the root package |
| `./_examples/gmail-relay` | a change to the example | 0 files, exit 0 |
| a path that is gone | a pull request that deletes a file | exit 0 |

Go passes over a directory whose name starts with an underscore, so gosec
reads no file of `_examples`. Semgrep reads that directory, and it found the
TLS version of the example last week.

A run against `v2.4.0...HEAD` gives `./. ./_examples/gmail-relay ./middleware`,
and gosec reads 32 files of the 36 in the tree. A run against `main` gives an
empty list, because this branch changes YAML alone, and the `if` of the step
holds gosec back.