### PR TITLE
ci: audit the security of a pull request

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -68,3 +68,52 @@ jobs:
 
       - name: Run tests
         run: go test -v -race -count=1 ./...
+  security:
+    name: "Go: Security Audit"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+
+      - name: Install Semgrep
+        run: python -m pip install semgrep==1.171.0
+
+      - name: Run Semgrep
+        run: |
+          semgrep scan \
+            --config p/golang \
+            --config p/security-audit \
+            --error
+
+      - name: Get changed Go packages
+        id: changed-packages
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+            BASE="origin/${{ github.base_ref }}"
+          else
+            BASE="HEAD~1"
+          fi
+          PKGS=$(git diff --name-only "${BASE}...HEAD" | grep '\.go$' | xargs -r -I{} dirname {} | sort -u | grep -vE '(^|/)_' | sed 's|^|./|' | tr '\n' ' ')
+          echo "packages=${PKGS}" >> "$GITHUB_OUTPUT"
+
+      - name: Run gosec on changed packages
+        if: steps.changed-packages.outputs.packages != ''
+        run: |
+          go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0
+          gosec -exclude-generated ${{ steps.changed-packages.outputs.packages }}


### PR DESCRIPTION
The ruleset of the repository asks for the `Go: Security Audit` check on `v1`
as well as on `main`. The job did not exist on this branch, so a pull request
against v1 waited for a check that nothing reported, and nothing could merge.

The job is the one that main carries, with the same steps and the same pinned
versions.

## What runs

- **Semgrep** `1.171.0`, `p/golang` and `p/security-audit`, over the whole
  tree. It reads 13 files here and reports nothing.
- **gosec** `v2.28.0`, over the packages of the changed Go files alone.

## The Go version

`go 1.25` in go.mod selects the newest patch of that line, which is 1.25.14.
gosec v2.28.0 asks for 1.25.8 and govulncheck v1.6.0 asks for 1.25.0, so both
build. This branch keeps its go.mod and its version of golangci-lint.

## The dead example

`_examples/dkim-proxy` imports `github.com/eaigner/dkim`. GitHub answers that
path with a 404 and the module proxy holds nothing for it, so the package
cannot load:

```
loading files from package "_examples/dkim-proxy": err: exit status 1:
go: github.com/eaigner/dkim@v0.0.0-20150301120808-6fe4a7ee9cfb:
invalid version
```

`gosec ./...` ends with status 1 for that reason alone. `go vet`, `go test`
and `go mod tidy` all pass, because Go passes over a directory whose name
starts with an underscore.

The job reads changed packages, so it meets the directory only when a pull
request touches that file. The list drops the underscore directories, which
keeps such a pull request from stopping against a check it cannot pass. The
same filter is on main.

Two things stay open, and neither belongs to this change:

- The example cannot build for a reader either. It names a repository that is
  gone.
- A daily scan on this branch needs `-exclude-dir` for gosec, for the same
  reason. govulncheck is clean here.